### PR TITLE
Read texture page in TMD as 5-bit instead of 4

### DIFF
--- a/Classes/TMDHelper.cs
+++ b/Classes/TMDHelper.cs
@@ -293,7 +293,7 @@ namespace PSXPrev.Classes
 
         public static void AddTrianglesToGroup(Dictionary<uint, List<Triangle>> groupedTriangles, Dictionary<PrimitiveDataType, uint> primitiveData, Func<uint, Vector3> vertexCallback, Func<uint, Vector3> normalCallback)
         {
-            var tPage = primitiveData.TryGetValue(PrimitiveDataType.TSB, out var tsbValue) ? tsbValue & 0xF : 0;
+            var tPage = primitiveData.TryGetValue(PrimitiveDataType.TSB, out var tsbValue) ? tsbValue & 0x1F : 0;
             void AddTriangle(Triangle triangle)
             {
                 List<Triangle> triangles;


### PR DESCRIPTION
I came across some models that have textures in the second half of VRAM, and those weren't being read correctly. Turns out this was why.