### PR TITLE
Fix memory leak

### DIFF
--- a/Classes/MeshBatch.cs
+++ b/Classes/MeshBatch.cs
@@ -343,6 +343,7 @@ namespace PSXPrev
                 }
             }
             _meshes = new Mesh[nMeshes];
+            if (_ids != null) GL.DeleteVertexArrays(_ids.Length, _ids);
             _ids = new uint[nMeshes];
             ResetModelIndex();
             GL.GenVertexArrays(nMeshes, _ids);


### PR DESCRIPTION
Memory usage just piles up endlessly as long as you have the animation tab open until it crashes. This patch fixes that.