### PR TITLE
Fix recursive calls in Logger WriteLine object functions

### DIFF
--- a/Classes/Logger.cs
+++ b/Classes/Logger.cs
@@ -40,7 +40,7 @@ namespace PSXPrev.Classes
 
         public void WriteLine(object text)
         {
-            WriteLine(new[] { text });
+            WriteLine("{0}", new[] { text });
         }
 
         public void WriteErrorLine(string format, params object[] args)
@@ -50,7 +50,7 @@ namespace PSXPrev.Classes
         }
         public void WriteErrorLine(object text)
         {
-            WriteErrorLine(new[] { text });
+            WriteErrorLine("{0}", new[] { text });
         }
 
 


### PR DESCRIPTION
* `WriteLine(object text)` and `WriteErrorLine(object text)` were missing the format string before the object array, so instead the functions would endlessly call themselves because the array was treated as `object text`.
* This might also fix issue #39, since calling these functions would cause a stack overflow. It wouldn't solve the underlying problem of an error occurring while loading, but it won't stack overflow anymore.