### PR TITLE
Fix Gizmo Translation and add Reset Transform

### DIFF
--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -133,7 +133,7 @@ namespace PSXPrev.Classes
                 {
                     if (modelEntity.TMDID == c + 1)
                     {
-                        modelEntity.LocalMatrix = localMatrix;
+                        modelEntity.OriginalLocalMatrix = localMatrix;
                     }
                 }
             }

--- a/Classes/PSXParser.cs
+++ b/Classes/PSXParser.cs
@@ -425,7 +425,7 @@ namespace PSXPrev.Classes
                             Triangles = triangles.ToArray(),
                             TexturePage = kvp.Key.Item2,
                             TMDID = 1, //todo
-                            LocalMatrix = Matrix4.CreateTranslation(psxModel.X, psxModel.Y, psxModel.Z)
+                            OriginalLocalMatrix = Matrix4.CreateTranslation(psxModel.X, psxModel.Y, psxModel.Z)
                         };
                         modelEntities.Add(model);
                     }

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -107,6 +107,10 @@
             this.animationFrameLabel = new System.Windows.Forms.Label();
             this.lightIntensityNumericUpDown = new System.Windows.Forms.NumericUpDown();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetTransformToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cmsResetTransform = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.resetWholeModelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetSelectedModelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.entitiesTabPage.SuspendLayout();
             this.menusTabControl.SuspendLayout();
             this.bitmapsTabPage.SuspendLayout();
@@ -124,6 +128,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.lightYawNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.lightRollNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.lightIntensityNumericUpDown)).BeginInit();
+            this.cmsResetTransform.SuspendLayout();
             this.SuspendLayout();
             // 
             // entitiesTabPage
@@ -503,6 +508,7 @@
             // 
             this.modelsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportSelectedToolStripMenuItem,
+            this.resetTransformToolStripMenuItem,
             this.toolStripSeparator2,
             this.wireframeToolStripMenuItem,
             this.showGizmosToolStripMenuItem,
@@ -876,6 +882,37 @@
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
+            // resetTransformToolStripMenuItem
+            // 
+            this.resetTransformToolStripMenuItem.DropDown = this.cmsResetTransform;
+            this.resetTransformToolStripMenuItem.Name = "resetTransformToolStripMenuItem";
+            this.resetTransformToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.resetTransformToolStripMenuItem.Text = "Reset Transform";
+            // 
+            // cmsResetTransform
+            // 
+            this.cmsResetTransform.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.resetWholeModelToolStripMenuItem,
+            this.resetSelectedModelToolStripMenuItem});
+            this.cmsResetTransform.Name = "cmsResetTransform";
+            this.cmsResetTransform.OwnerItem = this.resetTransformToolStripMenuItem;
+            this.cmsResetTransform.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.cmsResetTransform.Size = new System.Drawing.Size(181, 70);
+            // 
+            // resetWholeModelToolStripMenuItem
+            // 
+            this.resetWholeModelToolStripMenuItem.Name = "resetWholeModelToolStripMenuItem";
+            this.resetWholeModelToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.resetWholeModelToolStripMenuItem.Text = "Reset Whole Model";
+            this.resetWholeModelToolStripMenuItem.Click += new System.EventHandler(this.resetWholeModelToolStripMenuItem_Click);
+            // 
+            // resetSelectedModelToolStripMenuItem
+            // 
+            this.resetSelectedModelToolStripMenuItem.Name = "resetSelectedModelToolStripMenuItem";
+            this.resetSelectedModelToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.resetSelectedModelToolStripMenuItem.Text = "Reset Selected Model";
+            this.resetSelectedModelToolStripMenuItem.Click += new System.EventHandler(this.resetSelectedModelToolStripMenuItem_Click);
+            // 
             // PreviewForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -922,6 +959,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.lightYawNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.lightRollNumericUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.lightIntensityNumericUpDown)).EndInit();
+            this.cmsResetTransform.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1005,5 +1043,9 @@
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
         private System.Windows.Forms.ToolStripMenuItem lineRendererToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetTransformToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip cmsResetTransform;
+        private System.Windows.Forms.ToolStripMenuItem resetWholeModelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetSelectedModelToolStripMenuItem;
     }
 }

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -573,7 +573,7 @@ namespace PSXPrev
             _scene.BoundsBatch.Reset();
             _scene.SkeletonBatch.Reset();
             var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
-            var rootEntity = selectedEntityBase != null ? selectedEntityBase as RootEntity ?? selectedEntityBase.GetRootEntity() : null;
+            var rootEntity = selectedEntityBase?.GetRootEntity();
             if (rootEntity != null)
             {
                 rootEntity.ResetAnimationData();
@@ -1199,6 +1199,28 @@ namespace PSXPrev
         private void lineRendererToolStripMenuItem_CheckedChanged(object sender, EventArgs e)
         {
             _scene.VibRibbonWireframe = lineRendererToolStripMenuItem.Checked;
+        }
+
+        private void resetWholeModelToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
+            if (selectedEntityBase != null)
+            {
+                // This could be changed to only reset the selected model and its children.
+                // But that's only necessary if sub-sub-model support is ever added.
+                selectedEntityBase.GetRootEntity()?.ResetTransform(true);
+                UpdateSelectedEntity(true);
+            }
+        }
+
+        private void resetSelectedModelToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
+            if (selectedEntityBase != null)
+            {
+                selectedEntityBase.ResetTransform(false);
+                UpdateSelectedEntity(true);
+            }
         }
     }
 }

--- a/Forms/PreviewForm.resx
+++ b/Forms/PreviewForm.resx
@@ -126,6 +126,9 @@
   <metadata name="mainMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>160, 17</value>
   </metadata>
+  <metadata name="cmsResetTransform.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>556, 17</value>
+  </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>440, 17</value>
   </metadata>


### PR DESCRIPTION
# Short explanation

This PR aims to fix the Translation Gizmo (issue #50), and a handful of other transform issues generally stemming from matrix multiplication.

An additional feature has been added to store a model's original `LocalMatrix` transform, and allow users to reset the model's transform from the **Model** menu.

Lastly, a UI thread issue has been fixed with `PreviewForm` and `LauncherForm`, where these classes were constructed outside the UI thread, but run by the application inside the thread. I have no idea how this didn't cause problems sooner, since I only encountered an issue after adding a submenu under the **Model** menu.

<details>
<summary>Preview: UI thread error</summary>

![image](https://github.com/rickomax/psxprev/assets/9752430/b115170b-b38d-44d8-b0f4-e1950bcdae29)

</details>

***

# Detailed explanation

## EntityBase

* Added properties `Translation`, `Rotation`, and `Scale` to store the entity's transform components so that translation with the Gizmo wouldn't slowly rotate the entity (if it had any rotation). Assigning to `LocalMatrix` will now update the 3 components, and changing any of the 3 components will update `LocalMatrix`.
* Added `OriginalLocalMatrix` property (which should now be assigned instead of `LocalMatrix` when first setting the transform). This property exists so that the user can reset any transform applied to the model back to the default.
    * `HMDParser` and `PSXParser` now assign to this property instead of `LocalMatrix`.

### WorldMatrix

* Fixed matrix multiplication order (`matrix * entity.LocalMatrix`). This was causing issues where sub-models with rotation were being translated in their orientation's direction when trying to move the root entity with the translation Gizmo.

### ResetTransform

* Added function to automatically handle assigning `OriginalLocalMatrix` to `LocalMatrix` for the calling entity, and optionally all children.

### ApplyTranslation &rarr; ApplyTransform

* This function now multiplies the transform components in the right order (`scale * rotation * translation`), thus fixing the issue with Gizmo translation that would often throw the model all over the place.
* This function has been renamed and changed to a more general `ApplyTransform`, where optional arguments are present for all three transform components. Any arguments not specified will use the stored component properties.

### GetRootEntity

* Changed function to start `entity` on `this` instead of `ParentEntity`. This way `GetRootEntity` can be called by the `RootEntity` class without returning `null`.
    * One instance where this behavior was worked around in `PreviewForm.UpdateSelectedEntity` has been simplified, since there's no longer any worry of `GetRootEntity` returning `null`.

***

## PreviewForm

* Under the **Model** menu, the following submenu structure has been added (below **Export Selected**). These two options allow the user to reset any translation applied to either the whole model and its children of the selected root or sub-model, or just the selected root or sub-model.
* In the future when sub-sub-model support is added, the **Reset Whole Model** menu item could be changed to instead only reset the selected model and its children, but not the whole model, since you could just select the root to do this instead.

<pre>
Export Selected &rtri;
Reset Transform &rtri;
    Reset Whole Model
    Reset Selected Model
----------
Wireframe
...
</pre>

***

## Program

* Fixed UI thread error by making sure `LauncherForm` and `PreviewForm` are constructed in their own thread, rather than the main thread.
* To ensure thread safety, both Forms have been marked as volatile, and an event wait handle has been added for each form to ensure the field is assigned before continuing execution.