### PR TITLE
Fix empty Croc models polluting model list

### DIFF
--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -105,6 +105,10 @@ namespace PSXPrev.Classes
                     normals[j] = new Vector3(x, y, z);
                 }
                 var countFaces = BRenderHelper.ReadU32BE(reader.BaseStream);
+                if (countFaces == 0)
+                {
+                    return null;
+                }
                 var triangles = new List<Triangle>();
                 //var header = Encoding.ASCII.GetString(reader.ReadBytes(64));
                 for (var j = 0; j < countFaces; j++)


### PR DESCRIPTION
When reading from a folder or even a single file with all model formats being scanned for, Croc models will end up polluting the results, often with multiple models in the same file at different offsets. This is because the `countFaces` number can be zero and reading the model will still succeed (resulting in a model with no triangles). Other checks already exist to make sure the model isn't empty, such as comparing `countVerts`.

When `countFaces` is 0, `null` will be returned, like with other checks.