### PR TITLE
Revamp command line handling and add new options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 # User-specific files
 *.rsuser
 *.suo
-#*.user
+*.user
 *.userosscache
 *.sln.docstates
 

--- a/Classes/TMDHelper.cs
+++ b/Classes/TMDHelper.cs
@@ -432,7 +432,7 @@ namespace PSXPrev.Classes
 
             if (Program.Debug)
             {
-                Console.WriteLine($"Primitive data: {PrintPrimitiveData(primitiveData)}");
+                Program.Logger.WriteLine($"Primitive data: {PrintPrimitiveData(primitiveData)}");
             }
 
             var vertex0 = vertexCallback(vertexIndex0);

--- a/Forms/LauncherForm.Designer.cs
+++ b/Forms/LauncherForm.Designer.cs
@@ -53,6 +53,9 @@
             this.LogCheckBox = new System.Windows.Forms.CheckBox();
             this.ScanButton = new System.Windows.Forms.Button();
             this.scanForBffCheckBox = new System.Windows.Forms.CheckBox();
+            this.selectFirstModelCheckBox = new System.Windows.Forms.CheckBox();
+            this.drawAllToVRAMCheckBox = new System.Windows.Forms.CheckBox();
+            this.autoAttachLimbsCheckBox = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -241,6 +244,9 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.autoAttachLimbsCheckBox);
+            this.groupBox4.Controls.Add(this.drawAllToVRAMCheckBox);
+            this.groupBox4.Controls.Add(this.selectFirstModelCheckBox);
             this.groupBox4.Controls.Add(this.ignoreVersionCheckBox);
             this.groupBox4.Controls.Add(this.DebugCheckBox);
             this.groupBox4.Controls.Add(this.NoVerboseCheckBox);
@@ -248,7 +254,7 @@
             this.groupBox4.Dock = System.Windows.Forms.DockStyle.Top;
             this.groupBox4.Location = new System.Drawing.Point(0, 228);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(384, 46);
+            this.groupBox4.Size = new System.Drawing.Size(384, 69);
             this.groupBox4.TabIndex = 3;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Options";
@@ -296,7 +302,7 @@
             // ScanButton
             // 
             this.ScanButton.Enabled = false;
-            this.ScanButton.Location = new System.Drawing.Point(297, 280);
+            this.ScanButton.Location = new System.Drawing.Point(297, 303);
             this.ScanButton.Name = "ScanButton";
             this.ScanButton.Size = new System.Drawing.Size(75, 23);
             this.ScanButton.TabIndex = 4;
@@ -314,11 +320,41 @@
             this.scanForBffCheckBox.Text = "BFF";
             this.scanForBffCheckBox.UseVisualStyleBackColor = true;
             // 
+            // selectFirstModelCheckBox
+            // 
+            this.selectFirstModelCheckBox.AutoSize = true;
+            this.selectFirstModelCheckBox.Location = new System.Drawing.Point(12, 42);
+            this.selectFirstModelCheckBox.Name = "selectFirstModelCheckBox";
+            this.selectFirstModelCheckBox.Size = new System.Drawing.Size(110, 17);
+            this.selectFirstModelCheckBox.TabIndex = 5;
+            this.selectFirstModelCheckBox.Text = "Select First Model";
+            this.selectFirstModelCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // drawAllToVRAMCheckBox
+            // 
+            this.drawAllToVRAMCheckBox.AutoSize = true;
+            this.drawAllToVRAMCheckBox.Location = new System.Drawing.Point(128, 42);
+            this.drawAllToVRAMCheckBox.Name = "drawAllToVRAMCheckBox";
+            this.drawAllToVRAMCheckBox.Size = new System.Drawing.Size(111, 17);
+            this.drawAllToVRAMCheckBox.TabIndex = 6;
+            this.drawAllToVRAMCheckBox.Text = "Draw All to VRAM";
+            this.drawAllToVRAMCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // autoAttachLimbsCheckBox
+            // 
+            this.autoAttachLimbsCheckBox.AutoSize = true;
+            this.autoAttachLimbsCheckBox.Location = new System.Drawing.Point(245, 42);
+            this.autoAttachLimbsCheckBox.Name = "autoAttachLimbsCheckBox";
+            this.autoAttachLimbsCheckBox.Size = new System.Drawing.Size(112, 17);
+            this.autoAttachLimbsCheckBox.TabIndex = 7;
+            this.autoAttachLimbsCheckBox.Text = "Auto Attach Limbs";
+            this.autoAttachLimbsCheckBox.UseVisualStyleBackColor = true;
+            // 
             // LauncherForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(384, 310);
+            this.ClientSize = new System.Drawing.Size(384, 333);
             this.Controls.Add(this.ScanButton);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.groupBox3);
@@ -368,5 +404,8 @@
         private System.Windows.Forms.CheckBox scanForAnCheckBox;
         private System.Windows.Forms.CheckBox ignoreVersionCheckBox;
         private System.Windows.Forms.CheckBox scanForBffCheckBox;
+        private System.Windows.Forms.CheckBox autoAttachLimbsCheckBox;
+        private System.Windows.Forms.CheckBox drawAllToVRAMCheckBox;
+        private System.Windows.Forms.CheckBox selectFirstModelCheckBox;
     }
 }

--- a/Forms/LauncherForm.cs
+++ b/Forms/LauncherForm.cs
@@ -54,7 +54,30 @@ namespace PSXPrev.Forms
 
         private void ScanButton_Click(object sender, EventArgs e)
         {
-            Program.DoScan(FilenameText.Text, FilterText.Text, TMDCheckBox.Checked, VDFCheckBox.Checked, TIMCheckBox.Checked, PMDCheckBox.Checked, TODCheckBox.Checked, hmdCheckBox.Checked, LogCheckBox.Checked, NoVerboseCheckBox.Checked, DebugCheckBox.Checked, crocCheckBox.Checked, psxCheckBox.Checked, scanForAnCheckBox.Checked, ignoreVersionCheckBox.Checked, scanForBffCheckBox.Checked);
+            Program.DoScan(FilenameText.Text, FilterText.Text, new Program.ScanOptions
+            {
+                CheckAN = scanForAnCheckBox.Checked,
+                CheckBFF = scanForBffCheckBox.Checked,
+                CheckCROC = crocCheckBox.Checked,
+                CheckHMD = hmdCheckBox.Checked,
+                CheckPMD = PMDCheckBox.Checked,
+                CheckPSX = psxCheckBox.Checked,
+                CheckTIM = TIMCheckBox.Checked,
+                CheckTMD = TMDCheckBox.Checked,
+                CheckTOD = TODCheckBox.Checked,
+                CheckVDF = VDFCheckBox.Checked,
+
+                IgnoreTMDVersion = ignoreVersionCheckBox.Checked,
+
+                LogToFile = LogCheckBox.Checked,
+                NoVerbose = NoVerboseCheckBox.Checked,
+                Debug = DebugCheckBox.Checked,
+                
+                SelectFirstModel = selectFirstModelCheckBox.Checked,
+                DrawAllToVRAM = drawAllToVRAMCheckBox.Checked,
+                AutoAttachLimbs = autoAttachLimbsCheckBox.Checked,
+            });
+
             Close();
         }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -170,6 +170,53 @@ namespace PSXPrev
             }
         }
 
+        public void SetAutoAttachLimbs(bool attachLimbs)
+        {
+            if (InvokeRequired)
+            {
+                var invokeAction = new Action<bool>(SetAutoAttachLimbs);
+                Invoke(invokeAction, attachLimbs);
+            }
+            else
+            {
+                autoAttachLimbsToolStripMenuItem.Checked = attachLimbs;
+                _scene.AutoAttach = attachLimbs;
+                UpdateSelectedEntity(true);
+            }
+        }
+
+        public void SelectFirstEntity()
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new Action(SelectFirstEntity));
+            }
+            else
+            {
+                if (entitiesTreeView.Nodes.Count > 0)
+                {
+                    // I don't think the user will necessarily want the entity checked too.
+                    //entitiesTreeView.Nodes[0].Checked = true;
+                    entitiesTreeView.SelectedNode = entitiesTreeView.Nodes[0];
+                }
+            }
+        }
+
+        public void DrawAllTexturesToVRAM()
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new Action(DrawAllTexturesToVRAM));
+            }
+            else
+            {
+                foreach (var texture in _textures)
+                {
+                    DrawTextureToVRAM(texture);
+                }
+            }
+        }
+
         private void SetupControls()
         {
             _openTkControl = new GLControl
@@ -625,7 +672,7 @@ namespace PSXPrev
 
         private Texture GetSelectedTexture(int? index = null)
         {
-            if (texturesListView.SelectedIndices.Count == 0)
+            if (!index.HasValue && texturesListView.SelectedIndices.Count == 0)
             {
                 return null;
             }
@@ -635,6 +682,20 @@ namespace PSXPrev
                 return null;
             }
             return _textures[textureIndex];
+        }
+
+        private void DrawTextureToVRAM(Texture texture)
+        {
+            var texturePage = texture.TexturePage;
+            var textureX = texture.X;
+            var textureY = texture.Y;
+            var textureBitmap = texture.Bitmap;
+            var textureWidth = textureBitmap.Width;
+            var textureHeight = textureBitmap.Height;
+            var vramPageBitmap = _vramPage[texturePage].Bitmap;
+            var vramPageGraphics = Graphics.FromImage(vramPageBitmap);
+            vramPageGraphics.DrawImage(textureBitmap, textureX, textureY, textureWidth, textureHeight);
+            _scene.UpdateTexture(vramPageBitmap, texturePage);
         }
 
         private void drawToVRAMButton_Click(object sender, EventArgs e)
@@ -647,17 +708,7 @@ namespace PSXPrev
             }
             foreach (int index in texturesListView.SelectedIndices)
             {
-                var texture = GetSelectedTexture(index);
-                var texturePage = texture.TexturePage;
-                var textureX = texture.X;
-                var textureY = texture.Y;
-                var textureBitmap = texture.Bitmap;
-                var textureWidth = textureBitmap.Width;
-                var textureHeight = textureBitmap.Height;
-                var vramPageBitmap = _vramPage[texturePage].Bitmap;
-                var vramPageGraphics = Graphics.FromImage(vramPageBitmap);
-                vramPageGraphics.DrawImage(textureBitmap, textureX, textureY, textureWidth, textureHeight);
-                _scene.UpdateTexture(vramPageBitmap, texturePage);
+                DrawTextureToVRAM(GetSelectedTexture(index));
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,38 @@ Compatibility list:
 
 Known issues/limitations:
 PSXPrev only find files conformant to the file formats it's looking for. PSXPrev can't scan any compressed or proprietary format.
+
+Command line usage:
+```
+usage: PSXPrev <PATH> [FILTER="*.*"] [-help] [-an] [-bff] [-croc]
+               [-hmd] [-pmd] [-psx] [-tim] [-tmd] [-tod] [-vdf]
+               [-ignoretmdversion] [-log] [-noverbose] [-debug]
+               [-selectmodel] [-drawvram] [-attachlimbs]
+
+arguments:
+  PATH   : folder or file path to scan
+  FILTER : wildcard filter for files to include (default: "*.*")
+
+scanner options: (default: all formats)
+  -an    : scan for AN animations
+  -bff   : scan for BFF models
+  -croc  : scan for CROC models
+  -hmd   : scan for HMD models, textures, and animations
+  -pmd   : scan for PMD models
+  -psx   : scan for PSX models
+  -tim   : scan for TIM textures
+  -tmd   : scan for TMD models
+  -tod   : scan for TOD animations
+  -vdf   : scan for VDF animations
+  -ignoretmdversion : reduce strictness when scanning TMD models
+
+log options:
+  -log       : write output to log file
+  -noverbose : reduce output to console and file
+  -debug     : output file format details and other information
+
+program options:
+  -selectmodel : select and display the first-loaded model
+  -drawvram    : draw all loaded textures to VRAM (not advised when scanning a lot of files)
+  -attachlimbs : enable Auto Attach Limbs by default
+```


### PR DESCRIPTION
# Short explanation

Command line arguments and command line help has been completely redone. Usage is now displayed in a more compact manner (`<required> [optional]`). A help message can now be displayed that shows the usage of all command line arguments. This same message has also been added to the README. `DoScan` now takes an argument of the class `ScanOptions` instead of all of its boolean arguments.

Added a few new command line options. The last three have also been added as checkboxes to the Launcher form. This implements issue #53.

* `-help` - Shows a detailed help message and exits the program. This command can be detected in-place of the `PATH` and `FILTER` positional arguments.
* `-selectmodel` - After the scan is finished, the first-loaded model will be selected.
* `-drawvram` - After the scan is finished, all loaded textures will be drawn to VRAM.
* `-attachlimbs` - Sets the default **Auto Attach Limbs** setting to true.

**Some issues have also been fixed:**

The last change to handle threading with `Application.Run` would set the auto event before `Application.Run` was called, meaning the form may not have been ready, even if it was already assigned. This could cause issues where `InvokeRequired` would return false when it should have returned true. To fix this, the auto events are now set in a `HandleCreated` event. Unfortunately this will add a slight delay to the start of scanning, since it needs to wait for the Preview form to show. :(

`Logger` is now correctly assigned before Program attempts to use it when complaining that the path is not a file or directory.

Preview form's `GetSelectedTexture` would return null when passing a non-null `index` if the selected count was zero. Now it will only check the selected count if `index` is null.

`*.user` was mistakenly left commented out when `.gitignore` was added. This has been uncommented.

<details>
<summary>Preview of launcher window with new checkboxes</summary>

![image](https://github.com/rickomax/psxprev/assets/9752430/17be4b65-8792-4492-9291-ebce34acb7a1)

</details>

***

# Detailed explanation

## Program

* Program has been refactored to more cleanly handle command line arguments.
* Added `ScanOptions` nested class that contains all boolean command line options. This class is passed as an argument to `DoScan` instead of passing a wall of booleans.
* Boolean command line options are now stored under the `ScanOptions _options` field.
* Added a `DefaultFilter` constant, that is now used in-place of all `"*.*"` strings.
* Added `PrintUsage` to automatically print the usage information of PSXPrev.
* Added `PrintHelp` to print the full help message detailing the usage of each argument.
* Added `TryParseHelp` to parse the special `-help` command, which is allowed to be used in-place of positional arguments `PATH` and `FILTER`. Returns true on success.
* Added `TryParseOption` to parse all other boolean command line options. Returns true on success.

### Initialize

* Refactored to work around using `ScanOptions` and the new `-help` command.
* `-help` is now checked for in both positional arguments before trying to parse them.
* Changed `_waitForLauncherForm.Set()` to be called inside the `HandleCreated` event. Doing this is imporant if the form is going to do anything involving `InvokeRequired`.

### DoScan

* Now takes 3 arguments, `string path`, `string filter`, and `ScanOptions options`.
* Fixed `Logger` not being assigned before using it to print an error if the path was not found.
* `CheckAll` is now handled by the `ScanOptions` class instead of manually handling this during `DoScan`. Technically this is slightly less performant, but it's only called 10 times.
* Changed `_waitForPreviewForm.Set()` to be called inside the `HandleCreated` event. Doing this is imporant if the form is going to do anything involving `InvokeRequired`. Unfortunately this will also delay the scan from starting until the Preview Form is ready, I'm not sure of a better way of handling this.
* Added handling for setting the default Auto Attach Limbs setting before beginning the scan.
* Added handling for selecting the first model and drawing all textures to VRAM after the scan is complete.

***

## LauncherForm

* Added checkboxes for **Select First Model**, **Draw All to VRAM**, and **Auto Attach Limbs** below the other **Options** checkboxes.

***

## PreviewForm

### 

* Added `SetAutoAttachLimbs` function to set default setting for Auto Attached Limbs checkbox.
* Added `SelectFirstEntity` function to select the first node in the `entitiesTreeView` tree view.
* Added `DrawAllTexturesToVRAM` function to draw all textures in `_textures` to VRAM.
* Added `DrawTextureToVRAM` helper function for drawing a single texture to VRAM to avoid code duplication.
    * `drawToVRAMButton_Click` and `DrawAllTexturesToVRAM` both use this function.

### GetSelectedTexture

* Fixed issue where function wouldn't return the texture (due to no selection) even if a non-null `index` was passed.