### PR TITLE
Add HMD animation coordinate linear interpolation support

### DIFF
--- a/Classes/Animation.cs
+++ b/Classes/Animation.cs
@@ -9,7 +9,8 @@ namespace PSXPrev.Classes
         NormalDiff,
         RPYDiff,
         MatrixDiff,
-        AxisDiff
+        AxisDiff,
+        HMD, // Multiple methods of interpolation that can change between frames.
     }
 
     public class Animation

--- a/Classes/AnimationFrame.cs
+++ b/Classes/AnimationFrame.cs
@@ -16,15 +16,49 @@ namespace PSXPrev.Classes
 
         [Browsable(false)]
         public Vector3? EulerRotation { get; set; }
+        // HMD: 
+        [Browsable(false)]
+        public Vector3? FinalEulerRotation { get; set; }
+        // HMD: Used for Bezier Curve and B-Spline.
+        //[Browsable(false)]
+        //public Vector3[] CurveEulerRotations { get; set; }
+
+        [Browsable(false)]
+        public InterpolationType RotationType { get; set; }
+
+        [Browsable(false)]
+        public RotationOrder RotationOrder { get; set; }
 
         [Browsable(false)]
         public Vector3? Scale { get; set; }
+        // HMD: 
+        [Browsable(false)]
+        public Vector3? FinalScale { get; set; }
+        // HMD: Used for Bezier Curve and B-Spline.
+        //[Browsable(false)]
+        //public Vector3[] CurveScales { get; set; }
+
+        [Browsable(false)]
+        public InterpolationType ScaleType { get; set; }
 
         [Browsable(false)]
         public Vector3? Translation { get; set; }
+        // HMD: 
+        [Browsable(false)]
+        public Vector3? FinalTranslation { get; set; }
+        // HMD: Used for Bezier Curve and B-Spline.
+        //[Browsable(false)]
+        //public Vector3[] CurveTranslations { get; set; }
+
+        [Browsable(false)]
+        public InterpolationType TranslationType { get; set; }
         
         [ReadOnly(true)]
         public uint FrameTime { get; set; }
+
+        // HMD: Not incorporated into any other animation types.
+        [ReadOnly(true)]
+        public uint FrameDuration { get; set; }
 
         [ReadOnly(true)]
         public int VertexCount

--- a/Classes/CoordUnit.cs
+++ b/Classes/CoordUnit.cs
@@ -1,0 +1,106 @@
+﻿using OpenTK;
+
+namespace PSXPrev.Classes
+{
+    // Hierarchical coordinates for use with HMD models.
+    // This is needed so that models can be treated as nested,
+    // even when they're stored in a flat list of the root entity.
+    public class CoordUnit
+    {
+        public const uint NoID = uint.MaxValue;
+
+        private Matrix4 _originalLocalMatrix;
+        private Vector3 _originalTranslation;
+        private Vector3 _originalRotation;
+        
+        public Matrix4 LocalMatrix { get; set; }
+        public Matrix4 OriginalLocalMatrix
+        {
+            get => _originalLocalMatrix;
+            set => LocalMatrix = _originalLocalMatrix = value;
+        }
+
+        public Vector3 Translation { get; set; }
+        public Vector3 OriginalTranslation
+        {
+            get => _originalTranslation;
+            set => Translation = _originalTranslation = value;
+        }
+
+        public Vector3 Rotation { get; set; }
+        public Vector3 OriginalRotation
+        {
+            get => _originalRotation;
+            set => Rotation = _originalRotation = value;
+        }
+
+        public RotationOrder RotationOrder { get; set; }
+        public RotationOrder OriginalRotationOrder => RotationOrder.YXZ; // Observed in Gods98 (PSX) source.
+        
+        public uint ID { get; set; } = NoID;
+        public uint ParentID { get; set; } = NoID;
+
+        public CoordUnit[] Coords { get; set; }
+
+        public uint TMDID => ID + 1;
+
+        public bool HasParent => ParentID != NoID && ParentID != ID;
+        public CoordUnit Parent => (HasParent ? Coords?[ParentID] : null);
+        
+        public Matrix4 WorldMatrix
+        {
+            get
+            {
+                var matrix = Matrix4.Identity;
+                var coord = this;
+                do
+                {
+                    matrix *= coord.LocalMatrix;
+                    coord = coord.Parent;
+                } while (coord != null);
+                return matrix;
+            }
+        }
+
+        public CoordUnit()
+        {
+            OriginalLocalMatrix = Matrix4.Identity;
+            // Everything below is unused at the moment:
+            OriginalTranslation = Vector3.Zero;
+            OriginalRotation = Vector3.Zero;
+            RotationOrder = OriginalRotationOrder;
+        }
+
+        public void ResetTransform()
+        {
+            LocalMatrix = OriginalLocalMatrix;
+            // Everything below is unused at the moment:
+            Translation = OriginalTranslation;
+            Rotation = OriginalRotation;
+            RotationOrder = OriginalRotationOrder;
+        }
+
+        // Check to see if the coord unit has parents that eventually reference themselves.
+        public bool HasCircularReference()
+        {
+            if (ParentID == ID)
+            {
+                return true; // Parent is self. We can check this even without the coords table.
+            }
+            else if (Coords != null)
+            {
+                var coord = this;
+                for (var depth = 0; depth < Coords.Length; depth++)
+                {
+                    coord = coord.Parent;
+                    if (coord == null)
+                    {
+                        return false; // End of parents.
+                    }
+                }
+                return true; // More parents than number of coords means infinite recursion.
+            }
+            return false; // Can't test because there's no coords table.
+        }
+    }
+}

--- a/Classes/EntityBase.cs
+++ b/Classes/EntityBase.cs
@@ -72,7 +72,23 @@ namespace PSXPrev.Classes
                 var entity = this;
                 do
                 {
-                    matrix = matrix * entity.LocalMatrix;
+                    matrix *= entity.LocalMatrix;
+                    entity = entity.ParentEntity;
+                } while (entity != null);
+                return matrix;
+            }
+        }
+
+        [Browsable(false)]
+        public Matrix4 OriginalWorldMatrix
+        {
+            get
+            {
+                var matrix = Matrix4.Identity;
+                var entity = this;
+                do
+                {
+                    matrix *= entity.OriginalLocalMatrix;
                     entity = entity.ParentEntity;
                 } while (entity != null);
                 return matrix;
@@ -125,6 +141,9 @@ namespace PSXPrev.Classes
 
         [Browsable(false)]
         public Matrix4 TempMatrix { get; set; } = Matrix4.Identity;
+
+        [Browsable(false)]
+        public Matrix4 TempWorldMatrix => TempMatrix * WorldMatrix;
 
         protected EntityBase()
         {
@@ -229,6 +248,16 @@ namespace PSXPrev.Classes
                 modelEntity.FinalVertices = null;
                 modelEntity.InitialNormals = null;
                 modelEntity.FinalNormals = null;
+            }
+            if (this is RootEntity rootEntity)
+            {
+                if (rootEntity.Coords != null)
+                {
+                    foreach (var coord in rootEntity.Coords)
+                    {
+                        coord.ResetTransform();
+                    }
+                }
             }
             TempMatrix = Matrix4.Identity;
             if (ChildEntities != null)

--- a/Classes/GeomUtils.cs
+++ b/Classes/GeomUtils.cs
@@ -63,10 +63,25 @@ namespace PSXPrev.Classes
 
         public static Matrix4 CreateR(Vector3 rotation)
         {
+            // todo: Should this actually be RotationOrder.XYZ (zRot * yRot * xRot)?
+            return CreateR(rotation, RotationOrder.ZYX); // RotationOrder.XYZ);
+        }
+
+        public static Matrix4 CreateR(Vector3 rotation, RotationOrder order)
+        {
             var xRot = Matrix4.CreateRotationX(rotation.X);
             var yRot = Matrix4.CreateRotationY(rotation.Y);
             var zRot = Matrix4.CreateRotationZ(rotation.Z);
-            return xRot * yRot * zRot;
+            switch (order)
+            {
+                case RotationOrder.XYZ: return zRot * yRot * xRot;
+                case RotationOrder.XZY: return yRot * zRot * xRot;
+                case RotationOrder.YXZ: return zRot * xRot * yRot;
+                case RotationOrder.YZX: return xRot * zRot * yRot;
+                case RotationOrder.ZXY: return yRot * xRot * zRot;
+                case RotationOrder.ZYX: return xRot * yRot * zRot;
+            }
+            return Matrix4.Identity; // Invalid rotation order
         }
 
         public static Vector3 UnProject(this Vector3 position, Matrix4 projection, Matrix4 view, float width, float height)
@@ -150,6 +165,22 @@ namespace PSXPrev.Classes
                 outMin = min;
                 outMax = max;
             }
+        }
+
+        public static float InterpolateValue(float src, float dst, float delta)
+        {
+            // Uncomment if we want clamping. Or add bool clamp as an optional parameter.
+            //if (delta <= 0f) return src;
+            //if (delta >= 1f) return dst;
+            return (src * (1f - delta)) + (dst * (delta));
+        }
+
+        public static Vector3 InterpolateVector(Vector3 src, Vector3 dst, float delta)
+        {
+            // Uncomment if we want clamping. Or add bool clamp as an optional parameter.
+            //if (delta <= 0f) return src;
+            //if (delta >= 1f) return dst;
+            return (src * (1f - delta)) + (dst * (delta));
         }
     }
 }

--- a/Classes/HMDHelper.cs
+++ b/Classes/HMDHelper.cs
@@ -1,0 +1,466 @@
+﻿using OpenTK;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PSXPrev.Classes
+{
+    public static class HMDHelper
+    {
+        public static bool TryGetAnimInterpolationType(uint interpAlgo, out InterpolationType interpType)
+        {
+            switch (interpAlgo)
+            {
+                case  0: // None
+                    interpType = InterpolationType.None;
+                    return true;
+                case  1: // Linear
+                case  9: // Linear(*)
+                    interpType = InterpolationType.Linear;
+                    return true;
+                case  2: // Bezier Curve
+                case 10: // Bezier Curve(*)
+                    //interpType = InterpolationType.Bezier;
+                    //return true;
+                    break; // Not supported yet
+                case  3: // B-Spline
+                case 11: // B-Spline(*)
+                    //interpType = InterpolationType.BSpline;
+                    //return true;
+                    break; // Not supported yet
+                case  4: // Beta-Spline
+                    //interpType = InterpolationType.BetaSpline;
+                    //return true;
+                    break; // Not supported yet
+            }
+            interpType = InterpolationType.None;
+            return false;
+        }
+
+        public static bool TryGetAnimRotationOrder(uint rotOrder, out RotationOrder rotOrderType)
+        {
+            switch (rotOrder)
+            {
+                case 0: // XYZ
+                    rotOrderType = RotationOrder.XYZ;
+                    return true;
+                case 1: // XYZ
+                    rotOrderType = RotationOrder.XZY;
+                    return true;
+                case 2: // YXZ
+                    rotOrderType = RotationOrder.YXZ;
+                    return true;
+                case 3: // YZX
+                    rotOrderType = RotationOrder.YZX;
+                    return true;
+                case 4: // ZXY
+                    rotOrderType = RotationOrder.ZXY;
+                    return true;
+                case 5: // ZYX
+                    rotOrderType = RotationOrder.ZYX;
+                    return true;
+            }
+            rotOrderType = RotationOrder.None;
+            return false;
+        }
+
+        private static Vector3[] AppendToCurve(Vector3[] curve, Vector3 v)
+        {
+            if (curve == null)
+            {
+                return new Vector3[1] { v }; // First element in curve.
+            }
+            Array.Resize(ref curve, curve.Length + 1);
+            curve[curve.Length - 1] = v;
+            return curve;
+        }
+
+        public static bool ReadAnimPacket(BinaryReader reader, uint animationType, AnimationFrame animationFrame, AnimationFrame lastAnimationFrame)
+        {
+            var tgt = ((animationType >> 16) & 0xf); // Update: 0-Coordinate, 1-General
+            var cat = ((animationType >> 20) & 0x7); // Category: 0-Standard update driver
+            var ini = ((animationType >> 23) & 0x1) == 1; // Scan: 0-Off, 1-On
+
+            if (tgt == 0) // Coordinate update
+            {
+                // Interpolation: 0-None, 1-Linear, 2-Bezier, 3-BSpline, 4-BetaSpline[*], 9-Linear(*), 10-Bezier(*), 11-BSpline(*)
+                // Scale: No packet information available for anything other than linear.
+                // [*] Scale only, no packet information available. Assumed to be same as B-Spline.
+                // (*) Scale: single value for xyz, Translation: int16 values, Rotation: not supported.
+                var transAlgo = (animationType >>  0) & 0xf;
+                var rotAlgo   = (animationType >>  4) & 0xf;
+                var scaleAlgo = (animationType >>  8) & 0xf;
+                var rotOrder  = (animationType >> 12) & 0xf; // 0-XYZ, 1-XZY, 2-YXZ, 3-YZX, 4-ZXY, 5-ZYX
+
+                var transShort  = (transAlgo >= 9 && transAlgo <= 11);
+                var scaleSingle = (scaleAlgo >= 9 && scaleAlgo <= 11);
+                // Bezier curve packets store 3 vectors for each algorithm.
+                var transCount = (transAlgo == 2 || transAlgo == 10 ? 3 : 1);
+                var rotCount   = (rotAlgo   == 2                    ? 3 : 1);
+                var scaleCount = (scaleAlgo == 2 || scaleAlgo == 10 ? 3 : 1);
+                Vector3[] t = (transAlgo != 0 ? new Vector3[transCount] : null);
+                Vector3[] r = (rotAlgo   != 0 ? new Vector3[rotCount]   : null);
+                Vector3[] s = (scaleAlgo != 0 ? new Vector3[scaleCount] : null);
+                if (transAlgo != 0)
+                {
+                    for (var i = 0; i < transCount; i++)
+                    {
+                        t[i].X = (transShort ? reader.ReadInt16() : reader.ReadInt32());
+                        t[i].Y = (transShort ? reader.ReadInt16() : reader.ReadInt32());
+                        t[i].Z = (transShort ? reader.ReadInt16() : reader.ReadInt32());
+                    }
+                }
+                if (rotAlgo != 0)
+                {
+                    for (var i = 0; i < rotCount; i++)
+                    {
+                        // 4096 == 360 degrees
+                        r[i].X = (float)(reader.ReadInt16() / 4096.0 * (Math.PI * 2.0));
+                        r[i].Y = (float)(reader.ReadInt16() / 4096.0 * (Math.PI * 2.0));
+                        r[i].Z = (float)(reader.ReadInt16() / 4096.0 * (Math.PI * 2.0));
+                    }
+                }
+                if (scaleAlgo != 0)
+                {
+                    for (var i = 0; i < scaleCount; i++)
+                    {
+                        s[i].X = reader.ReadInt16() / 4096f;
+                        if (!scaleSingle)
+                        {
+                            s[i].Y = reader.ReadInt16() / 4096f;
+                            s[i].Z = reader.ReadInt16() / 4096f;
+                        }
+                        else
+                        {
+                            s[i].Y = s[i].X;
+                            s[i].Z = s[i].X;
+                        }
+                    }
+                }
+                // Note: Packets may end in 2-byte padding, but we don't need to read that.
+
+
+                if (TryGetAnimInterpolationType(transAlgo, out var transType))
+                {
+                    animationFrame.TranslationType = transType;
+
+                    switch (transType)
+                    {
+                        case InterpolationType.Linear:
+                            animationFrame.Translation = t[0];
+                            break;
+                        case InterpolationType.Bezier:
+                            //animationFrame.CurveTranslations = t;
+                            //break;
+                            return false; // Only linear is currently supported.
+                        case InterpolationType.BSpline:
+                            //animationFrame.CurveTranslations = AppendToCurve(animationFrame.CurveTranslations, t[0]);
+                            //break;
+                            return false; // Only linear is currently supported.
+                        case InterpolationType.BetaSpline:
+                            return false; // Invalid translation type.
+                    }
+
+                    if (transType != InterpolationType.None && lastAnimationFrame != null)
+                    {
+                        lastAnimationFrame.FinalTranslation = t[0];
+                    }
+                }
+                else
+                {
+                    return false; // Invalid translation interpolation type.
+                }
+
+                if (TryGetAnimInterpolationType(scaleAlgo, out var scaleType))
+                {
+                    animationFrame.ScaleType = scaleType;
+
+                    switch (scaleType)
+                    {
+                        case InterpolationType.Linear:
+                            animationFrame.Scale = s[0];
+                            break;
+                        case InterpolationType.Bezier:
+                            //animationFrame.CurveScales = s;
+                            //break;
+                            return false; // Only linear is currently supported.
+                        case InterpolationType.BSpline:
+                        case InterpolationType.BetaSpline:
+                            //animationFrame.CurveScales = AppendToCurve(animationFrame.CurveScales, s[0]);
+                            //break;
+                            return false; // Only linear is currently supported.
+                    }
+
+                    if (scaleType != InterpolationType.None && lastAnimationFrame != null)
+                    {
+                        lastAnimationFrame.FinalScale = s[0];
+                    }
+                }
+                else
+                {
+                    return false; // Invalid scale interpolation type.
+                }
+
+                if (TryGetAnimInterpolationType(rotAlgo, out var rotType))
+                {
+                    animationFrame.RotationType = rotType;
+
+                    switch (rotType)
+                    {
+                        case InterpolationType.Linear:
+                            animationFrame.EulerRotation = r[0];
+                            break;
+                        case InterpolationType.Bezier:
+                            //animationFrame.CurveEulerRotations = r;
+                            //break;
+                            return false; // Only linear is currently supported.
+                        case InterpolationType.BSpline:
+                            //animationFrame.CurveEulerRotations = AppendToCurve(animationFrame.CurveEulerRotations, r[0]);
+                            //break;
+                            return false; // Only linear is currently supported.
+                        case InterpolationType.BetaSpline:
+                            return false; // Invalid rotation type.
+                    }
+
+                    if (rotType != InterpolationType.None && lastAnimationFrame != null)
+                    {
+                        lastAnimationFrame.FinalEulerRotation = r[0];
+                    }
+
+                    if (rotType == InterpolationType.None)
+                    {
+                        animationFrame.RotationOrder = RotationOrder.None;
+                    }
+                    else if (TryGetAnimRotationOrder(rotOrder, out var rotOrderType))
+                    {
+                        animationFrame.RotationOrder = rotOrderType;
+                    }
+                    else
+                    {
+                        return false; // Invalid rotation order.
+                    }
+                }
+                else
+                {
+                    return false; // Invalid rotation interpolation type.
+                }
+
+                return true;
+            }
+            else if (tgt == 1) // General update (vertices or normals)
+            {
+                var length = (animationType >> 0) & 0xf; // Length: 0-32bit, 1-16bit, 2-8bit
+                var write  = (animationType >> 4) & 0xf; // Write area: bits represent each unit to write to.
+                var algo   = (animationType >> 8) & 0xf; // Interpolation: 1-Linear, 2-Bezier, 3-BSpline
+                // Length: 16bit, Write: 0b1010 - Would write to 0x2 and 0x6
+                // Not supported. In the future we can add support for updating vertices and normals.
+
+                return false;
+            }
+            else
+            {
+                return false; // Invalid TGT
+            }
+        }
+
+        public static Vector3 Interpolate(InterpolationType interpType, Vector3? src, Vector3[] curve, Vector3? dst, float delta)
+        {
+            switch (interpType)
+            {
+                case InterpolationType.Linear:
+                    return GeomUtils.InterpolateVector(src.Value, dst ?? src.Value, delta);
+                case InterpolationType.Bezier:
+                case InterpolationType.BSpline:
+                case InterpolationType.BetaSpline:
+                    if (curve == null || curve.Length < 3)
+                    {
+                        break; // Invalid curve array
+                    }
+                    // todo: Using curve[2] instead of dst isn't really a solution...
+                    //curve[0], curve[1], curve[2], dst ?? curve[2], delta
+                    break; // Not supported yet
+            }
+            return Vector3.Zero;
+        }
+
+        public static void PrintAnimInstructions(BinaryReader reader, uint ctrlTop, uint paramTop, long offset, Dictionary<uint, List<Tuple<uint, uint>>> tmdidStarts = null)
+        {
+            // Read instructions.
+            var position = reader.BaseStream.Position;
+            reader.BaseStream.Seek(offset + ctrlTop, SeekOrigin.Begin);
+
+            var instructionCount = (paramTop - ctrlTop) / 4;
+            var instructions = new uint[instructionCount];
+            for (var i = 0; i < instructionCount; i++)
+            {
+                instructions[i] = reader.ReadUInt32();
+            }
+            reader.BaseStream.Seek(position, SeekOrigin.Begin);
+
+            // Find instructions that are referenced by jumps.
+            var xrefs = new Dictionary<uint, List<uint>>();
+            for (uint i = 0; i < instructionCount; i++)
+            {
+                var descriptor = instructions[i];
+                var descriptorType = (descriptor >> 30) & 0x3;
+                if (descriptorType == 0x2)
+                {
+                    var seqIndex = (descriptor) & 0xffff; // Next control descriptor to jump to.
+                    if (!xrefs.TryGetValue(seqIndex, out var xrefList))
+                    {
+                        xrefList = new List<uint>();
+                        xrefs.Add(seqIndex, xrefList);
+                    }
+                    xrefList.Add(i);
+                }
+            }
+
+            // Print starting Indices#StreamIDs for each TMDID object.
+            if (tmdidStarts != null)
+            {
+                Console.ForegroundColor = ConsoleColor.White;
+                foreach (var pair in tmdidStarts.OrderBy(p => p.Key))
+                {
+                    var arrayStr = string.Join(", ", pair.Value.Select(t => $"{t.Item1}#{t.Item2}"));
+                    Console.WriteLine($"TMDID {pair.Key,2}: [{arrayStr}]");
+                }
+                Console.ResetColor();
+            }
+
+            // Format padding information.
+            var digits = instructionCount.ToString().Length;
+            var addrLen = digits + 2;
+            var opLen = 7;
+            var argLen = 20;
+            var xrefStart = addrLen + opLen + argLen;
+
+            // Print instructions.
+            for (uint i = 0; i < instructionCount; i++)
+            {
+                // Writer to track line length for padding purposes.
+                var lineLength = 0;
+                void Write(ConsoleColor color, string text, int pad = 0, bool padLeft = false)
+                {
+                    if (pad > 0)
+                    {
+                        text = (padLeft ? text.PadLeft(pad) : text.PadRight(pad));
+                    }
+                    Console.ForegroundColor = color;
+                    Console.Write(text);
+                    Console.ResetColor();
+                    lineLength += text.Length;
+                }
+
+                var descriptor = instructions[i];
+                var descriptorType = (descriptor >> 30) & 0x3;
+
+                // Format: " N: "
+                var addrColor = (xrefs.ContainsKey(i) ? ConsoleColor.DarkCyan : ConsoleColor.DarkGray);
+                Write(addrColor, $"{i}: ", addrLen, true);
+
+                if ((descriptorType & 0x2) == 0x0) // Normal
+                {
+                    var paramIndex  = (descriptor >>  0) & 0xffff; // Index to parameter data for key frame referred to by sequence descriptor.
+                    var nextTFrame  = (descriptor >> 16) & 0xff; // Frame number of next sequence descriptor (int).
+                    var interpIndex = (descriptor >> 24) & 0x7f; // Index into interpolation table. Specifies function to be used.
+                    
+                    // TFrame==0 has special meaning
+                    var tfColor = (nextTFrame == 0 ? ConsoleColor.Red : ConsoleColor.Green);
+                    //var tfColor = (nextTFrame == 0 ? ConsoleColor.DarkYellow : ConsoleColor.Green);
+                    //var tfColor = ConsoleColor.Gray;
+
+                    // Format: "norm    p:N     t:N   f:N"
+                    Write(ConsoleColor.White, "norm", opLen);
+                    Write(ConsoleColor.Gray, $" p:{paramIndex,-5}"); // +8
+                    Write(tfColor, $" t:{nextTFrame,-3}"); // +6
+                    Write(ConsoleColor.Gray, $" f:{interpIndex,-2}"); // +5
+                }
+                else if (descriptorType == 0x2) // Jump
+                {
+                    var seqIndex = (descriptor >>  0) & 0xffff; // Next control descriptor to jump to.
+                    var cnd      = (descriptor >> 16) & 0x7f; // Stream ID conditional jump.
+                    var dst      = (descriptor >> 23) & 0x7f; // Stream ID destination of jump.
+
+                    // Format: "cnd     @N     #N   >#N"
+                    // Format: "jmpd    @N          >#N"
+                    // Format: "jmp     @N"
+                    if (cnd != 0)
+                    {
+                        Write(ConsoleColor.Blue, "cnd", opLen); // Jump if condition and set SID.
+                    }
+                    else if (dst != 0)
+                    {
+                        Write(ConsoleColor.Blue, "jmpd", opLen); // Jump and set SID.
+                    }
+                    else if (dst == 0)
+                    {
+                        Write(ConsoleColor.Blue, "jmp", opLen); // Jump without setting SID.
+                    }
+
+                    Write(ConsoleColor.Cyan, $" @{seqIndex,-5}"); // +7
+                    if (cnd != 0)
+                    {
+                        var cnd_sid = (cnd == 127 ? 0 : cnd);
+                        Write(ConsoleColor.Yellow, $" #{cnd_sid,-3}"); // +5
+                    }
+                    if (cnd != 0 || dst != 0)
+                    {
+                        Write(ConsoleColor.Yellow, $" >#{dst,-3}"); // +6
+                    }
+                }
+                else if (descriptorType == 0x3) // Control
+                {
+                    var code = (descriptor >> 23) & 0x7f;
+                    var p1   = (descriptor >> 16) & 0x7f;
+                    var p2   = (descriptor >>  0) & 0xffff;
+                    if (code == 1) // End
+                    {
+                        // Format: "end"
+                        // Format: "endif         #N"
+                        if (p1 == 0)
+                        {
+                            Write(ConsoleColor.Magenta, "end", opLen);
+                        }
+                        else if (p1 != 0)
+                        {
+                            Write(ConsoleColor.Magenta, "endif", opLen);
+                            var cnd_sid = (p1 == 127 ? 0 : p1);
+                            Write(ConsoleColor.Yellow, "", 6); // +6 (align with cnd instructions by skipping jump target)
+                            Write(ConsoleColor.Yellow, $" #{cnd_sid,-3}"); // +5
+                        }
+                    }
+                    else if (code == 2) // Work
+                    {
+                        // Format: "work    p:N"
+                        // Format: "work    p:N     p1:N"
+                        Write(ConsoleColor.Magenta, "work", opLen);
+                        Write(ConsoleColor.Gray, $" p:{p2,-5}"); // +8
+                        if (p1 != 127) // Should always be 127
+                        {
+                            Write(ConsoleColor.DarkGray, $" p1:{p1,-3}"); // +7
+                        }
+                    }
+                    else // Unknown code
+                    {
+                        // Format: "code.XX p1:0xXX p2:0xXXXX"
+                        Write(ConsoleColor.Red, $"code.{code:x02}", opLen);
+                        Write(ConsoleColor.Gray, $" p1:0x{p1:x02}"); // +8
+                        Write(ConsoleColor.Gray, $" p2:0x{p2:x04}"); // +10
+                    }
+                }
+                
+                if (xrefs.TryGetValue(i, out var xrefList))
+                {
+                    // Format: " [N] [N]"
+                    Write(ConsoleColor.DarkCyan, "", (xrefStart - lineLength)); // Pad
+                    foreach (var xref in xrefList)
+                    {
+                        Write(ConsoleColor.DarkCyan, $" [{xref}]");
+                    }
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/Classes/HMDHelper.cs
+++ b/Classes/HMDHelper.cs
@@ -291,6 +291,10 @@ namespace PSXPrev.Classes
             reader.BaseStream.Seek(offset + ctrlTop, SeekOrigin.Begin);
 
             var instructionCount = (paramTop - ctrlTop) / 4;
+            if (instructionCount > Program.MaxHMDAnimInstructions)
+            {
+                return;
+            }
             var instructions = new uint[instructionCount];
             for (var i = 0; i < instructionCount; i++)
             {
@@ -316,7 +320,7 @@ namespace PSXPrev.Classes
                 }
             }
 
-            // Print starting Indices#StreamIDs for each TMDID object.
+            // Print starting Index#StreamID's for each TMDID object.
             if (tmdidStarts != null)
             {
                 Console.ForegroundColor = ConsoleColor.White;

--- a/Classes/InterpolationType.cs
+++ b/Classes/InterpolationType.cs
@@ -1,0 +1,12 @@
+﻿namespace PSXPrev.Classes
+{
+    // Interpolation types for HMD animations.
+    public enum InterpolationType
+    {
+        None,
+        Linear,
+        Bezier,
+        BSpline,
+        BetaSpline, // Not supported
+    }
+}

--- a/Classes/MeshBatch.cs
+++ b/Classes/MeshBatch.cs
@@ -81,7 +81,7 @@ namespace PSXPrev
                     }
                     foreach (ModelEntity modelEntity in entity.ChildEntities)
                     {
-                        BindMesh(modelEntity, modelEntity.TempMatrix * modelEntity.WorldMatrix, textureBinder, updateMeshData, modelEntity.InitialVertices, modelEntity.InitialNormals, modelEntity.FinalVertices, modelEntity.FinalNormals, modelEntity.Interpolator);
+                        BindMesh(modelEntity, modelEntity.TempWorldMatrix, textureBinder, updateMeshData, modelEntity.InitialVertices, modelEntity.InitialNormals, modelEntity.FinalVertices, modelEntity.FinalNormals, modelEntity.Interpolator);
                     }
                 }
             }
@@ -93,7 +93,7 @@ namespace PSXPrev
             {
                 foreach (ModelEntity modelEntity in selectedRootEntity.ChildEntities)
                 {
-                    BindMesh(modelEntity, selectedRootEntity.TempMatrix * modelEntity.TempMatrix * modelEntity.WorldMatrix, textureBinder, updateMeshData, modelEntity.InitialVertices, modelEntity.InitialNormals, modelEntity.FinalVertices, modelEntity.FinalNormals, modelEntity.Interpolator);
+                    BindMesh(modelEntity, selectedRootEntity.TempMatrix * modelEntity.TempWorldMatrix, textureBinder, updateMeshData, modelEntity.InitialVertices, modelEntity.InitialNormals, modelEntity.FinalVertices, modelEntity.FinalNormals, modelEntity.Interpolator);
                 }
             }
             //}

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -108,8 +108,8 @@ namespace PSXPrev.Classes
                                     {
                                         if (subTriangle.AttachableIndices[j] == attachedIndex)
                                         {
-                                            var newVertex = Vector3.TransformPosition(subTriangle.Vertices[j], subModel.WorldMatrix);
-                                            newVertex = Vector3.TransformPosition(newVertex, WorldMatrix.Inverted());
+                                            var newVertex = Vector3.TransformPosition(subTriangle.Vertices[j], subModel.TempWorldMatrix);
+                                            newVertex = Vector3.TransformPosition(newVertex, TempWorldMatrix.Inverted());
                                             triangle.Vertices[i] = newVertex;
                                             break;
                                         }
@@ -119,11 +119,11 @@ namespace PSXPrev.Classes
                                 // HMD: Check for attachable vertices and normals that aren't associated with an existing triangle.
                                 if (subModel.AttachableVertices != null && subModel.AttachableVertices.TryGetValue(attachedIndex, out var attachedVertex))
                                 {
-                                    var newVertex = Vector3.TransformPosition(attachedVertex, subModel.WorldMatrix);
+                                    var newVertex = Vector3.TransformPosition(attachedVertex, subModel.TempWorldMatrix);
                                     // WorldMatrix.Inverted() here prevents transforms for this model from being
                                     // applied, which they shouldn't be since attached vertices should only transform
                                     // based on their attached model.
-                                    newVertex = Vector3.TransformPosition(newVertex, WorldMatrix.Inverted());
+                                    newVertex = Vector3.TransformPosition(newVertex, TempWorldMatrix.Inverted());
                                     triangle.Vertices[i] = newVertex;
                                 }
                                 if (subModel.AttachableNormals != null && subModel.AttachableNormals.TryGetValue(attachedNormalIndex, out var attachedNormal))

--- a/Classes/RootEntity.cs
+++ b/Classes/RootEntity.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using OpenTK;
 
 namespace PSXPrev.Classes
@@ -6,6 +7,9 @@ namespace PSXPrev.Classes
     public class RootEntity : EntityBase
     {
         private readonly List<ModelEntity> _groupedModels = new List<ModelEntity>();
+
+        [Browsable(false)]
+        public CoordUnit[] Coords { get; set; }
 
         public override void ComputeBounds()
         {

--- a/Classes/RotationOrder.cs
+++ b/Classes/RotationOrder.cs
@@ -1,0 +1,14 @@
+﻿namespace PSXPrev.Classes
+{
+    // Rotation order for Euler angles.
+    public enum RotationOrder
+    {
+        None,
+        XYZ, // zRot * yRot * xRot
+        XZY, // yRot * zRot * xRot
+        YXZ, // zRot * xRot * yRot
+        YZX, // xRot * zRot * yRot
+        ZXY, // yRot * xRot * zRot
+        ZYX, // xRot * yRot * zRot
+    }
+}

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -244,6 +244,11 @@ namespace PSXPrev
                     _curAnimationFrame = 0f;
                     _curAnimationTime = 0f;
                 }
+                else
+                {
+                    // Update attached limbs while animating.
+                    (_selectedRootEntity ?? _selectedModelEntity?.GetRootEntity())?.FixConnections();
+                }
             }
             _scene.Draw();
             _openTkControl.SwapBuffers();

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -78,10 +78,13 @@
     <Compile Include="Classes\BoundingBox.cs" />
     <Compile Include="Classes\BRenderHelper.cs" />
     <Compile Include="Classes\collada_schema_1_4.cs" />
+    <Compile Include="Classes\CoordUnit.cs" />
     <Compile Include="Classes\DaeExporter.cs" />
     <Compile Include="Classes\EntityBase.cs" />
     <Compile Include="Classes\FInt.cs" />
+    <Compile Include="Classes\HMDHelper.cs" />
     <Compile Include="Classes\HMDParser.cs" />
+    <Compile Include="Classes\InterpolationType.cs" />
     <Compile Include="Classes\Line.cs" />
     <Compile Include="Classes\LineMesh.cs" />
     <Compile Include="Classes\LineBatch.cs" />
@@ -92,6 +95,7 @@
     <Compile Include="Classes\PrimitiveDataType.cs" />
     <Compile Include="Classes\CrocModelReader.cs" />
     <Compile Include="Classes\PSXParser.cs" />
+    <Compile Include="Classes\RotationOrder.cs" />
     <Compile Include="Classes\Texture.cs" />
     <Compile Include="Classes\Color.cs" />
     <Compile Include="Classes\FileReader.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -77,6 +77,7 @@ namespace PSXPrev
 
         public const string DefaultFilter = "*.*";
 
+        // Sanity check values
         public static ulong MaxTODPackets = 10000;
         public static ulong MaxTODFrames = 10000;
         public static ulong MaxTMDPrimitives = 10000;
@@ -88,8 +89,14 @@ namespace PSXPrev
         public static ulong MaxVDFObjects = 512;
         public static ulong MaxPSXObjectCount = 1024;
         public static ulong MaxHMDBlockCount = 1024;
+        public static ulong MaxHMDCoordCount = 1024; // Same as BlockCount, because they're related
         public static ulong MaxHMDTypeCount = 1024;
-        public static ulong MaxHMDDataSize = 5000;
+        public static ulong MaxHMDDataSize = 20000;
+        public static ulong MaxHMDDataCount = 5000;
+        public static ulong MaxHMDPrimitiveChainLength = 512;
+        public static ulong MaxHMDAnimSequenceSize = 20000;
+        public static ulong MaxHMDAnimSequenceCount = 1024;
+        public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
         public static ulong MaxHMDMimeDiffs = 100;
         public static ulong MaxHMDVertCount = 5000;
         public static uint MaxANJoints = 512;


### PR DESCRIPTION
This adds support for a subset of HMD animation types. Specifically only coordinate update drivers (TGT==0) that use linear interpolation.
* Bezier curve, B-Spline, and Beta-Spline interpolation is not supported yet.
* General update drivers (TGT==1) is not supported yet. This would update individual vertices or normals.

## Animation format

Animation is defined as a list of `dataCount` sequence pointers (just a data structure. "pointer" is just the name). Each sequence pointer defines what data will be changed for that part of the animation (like a coordinate that transforms models).

Each sequence pointer defines a count for the number of individual sequences (4-byte structures that appear after the sequence pointer structure). Consider each individual sequence a *separate* animation, while each sequence pointer in `dataCount` of the same individual sequence index is part of the *same* animation.

**Example:**
Each sequence pointer defines what data that part of the animation updates. Each sequence of each sequence pointer defines what instruction to start on, and what Stream ID (variable state) to start execution with.

* SP 0: Updates coords\[4\] (TMDID 5)
    * Sequence 0: Part of animation 0
    * Sequence 1: Part of animation 1
    * Sequence 2: Part of animation 2
* SP 1: Updates coords\[3\] (TMDID 4)
    * Sequence 0: Part of animation 0
    * Sequence 1: Part of animation 1
    * Sequence 2: Part of animation 2

Animations work by interpolating between coordinates (TGT==0) or individual data values (TGT==1). Values are changed using either Linear, Bezier Curve, B-Spline, or Beta-Spline interpolation. The type of interpolation can change during the animation sequence, though it's not clear if TGT can change...

Animations use a bytecode instruction set (each instruction is 4-bytes) that can perform Interpolation (normal instruction), Jumps, End the sequence (control instruction), or setup the work area for interpolation (control instruction).

**A stream has 3 variables of note:**
* The current instruction index (`idx`).
* The current Stream ID (`sid`). Consider this the one and only variable that can be used for conditional logic flow.
* The current time. Time is incremented by the TFrame value of each Normal instruction.

Normal (interpolation) instructions always come in pairs. The first instruction must define TFRAME==0. A tframe of 0 means the instruction isn't ready to perform interpolation. Once an instruction where TFRAME!=0 is reached, interpolation is defined using this instruction as the destination values, and the last instruction as the source values.

The B-Spline interpolation type is special, in that it requires 3 source instructions before interpolation can start. In this case, 3 instructions must define TFRAME==0.

When the type of interpolation changes, instructions need to define a STOP (a normal instruction where TFRAME==0 using the current interpolation type). After that, instructions are added as the source for the new interpolation type (with TFRAME==0 until the source data is ready).

```
instruction / parameterIndex(or @jump) / tframe / interpolationType

 0: jmp    @1              // Commonly seen in animations, even if @1 is the start index.
 1: norm   p:0   t:0   f:0 // Pretend f:0 is linear interpolation type
 2: norm   p:1   t:3   f:0 // Linear using p:0 as source parameter
 3: norm   p:2   t:1   f:0 // Linear using p:1 as source parameter
 4: norm   p:3   t:1   f:0 // Linear using p:2 as source parameter
 5: norm   p:3   t:0   f:0 // Transition away from f:0 before B-Spline

 6: norm   p:10  t:0   f:1 // Pretend f:1 is B-Spline interpolation type
 7: norm   p:11  t:0   f:1
 8: norm   p:12  t:0   f:1
 9: norm   p:13  t:10  f:1 // B-Spline using p:10,11,12 as source parameters
10: norm   p:14  t:7   f:1 // B-Spline using p:11,12,13 as source parameters
11: norm   p:14  t:0   f:1 // Transition away from f:1 before looping
12: jmp    @1              // Looping animations commonly start at the beginning
```

<details>
<summary>Preview of real animation instructions</summary>

![image](https://github.com/rickomax/psxprev/assets/9752430/3f7617ea-c1f8-4c80-a441-44f4fa84c161)

</details>

***

## Animation support changes

* Added OriginalWorldMatrix property for only using OriginalLocalMatrix.
* Added TempWorldMatrix shortcut property for use in-place of TempMatrix * WorldMatrix.
* Fixed FixConnections not accounting for TempMatrix.
* FixConnections is now called while animating.
* Changed how coords are parsed in HMD. There's no more need for a hacky nested check.
* HMD coords are now parsed as CoordUnit classes.
* Added support for parsing HMD animations using coordinate update drivers and linear interpolation.
* HMD animations have a try catch around parsing so that failure will still allow reading the rest of the model.
* Added disabled-by-default helper function to print the instructions used for HMD animation sequences. *(WITH COLOR~)*
* RootEntity now stores a table of CoordUnits which are used solely for updating HMD animations.
* Added HMD AnimationType.

## Sanity check changes

* Changed storage of dataSize and sequenceSize to be in byte units instead of 4-byte units. Because of this, MaxHMDDataSize has been multiplied by 4.
* Coords can no longer be assinged to post-process primitives (if coord.ID > blockCount - 2).
* Added MaxHMDCoordCount sanity check (only checked if coordCount > blockCount - 2).
* Added MaxHMDPrimitiveChainLength sanity check.
* Added dataSize == 0 sanity check.
* Added MaxHMDDataCount constant (replaces use of MaxHMDDataSize for dataCount).
* Added (primitiveSetTop == nextPrimitivePointer * 4) sanity check to catch infinite chains earlier.
* Added sequenceSize == 0 and MaxHMDAnimSequenceSize sanity checks.
* Added MaxHMDAnimSequenceCount sanity check.
* Added MaxHMDAnimInstructions sanity check (this is the hard cap for instruction counts).