### PR TITLE
Use correct _offset for file titles

### DIFF
--- a/Classes/ANParser.cs
+++ b/Classes/ANParser.cs
@@ -8,11 +8,11 @@ namespace PSXPrev.Classes
     public class ANParser
     {
         private long _offset;
-        private readonly Action<Animation, long> _entityAddedAction;
+        private readonly Action<Animation, long> _animationAddedAction;
 
-        public ANParser(Action<Animation, long> entityAdded)
+        public ANParser(Action<Animation, long> animationAdded)
         {
-            _entityAddedAction = entityAdded;
+            _animationAddedAction = animationAdded;
         }
 
         public void LookForAN(BinaryReader reader, string fileTitle)
@@ -35,7 +35,7 @@ namespace PSXPrev.Classes
                         if (animation != null)
                         {
                             animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _entityAddedAction(animation, reader.BaseStream.Position);
+                            _animationAddedAction(animation, _offset);
                             Program.Logger.WritePositiveLine("Found AN Animation at offset {0:X}", _offset);
                             _offset = reader.BaseStream.Position;
                             passed = true;

--- a/Classes/BFFModelReader.cs
+++ b/Classes/BFFModelReader.cs
@@ -36,7 +36,7 @@ namespace PSXPrev.Classes
                     if (model != null)
                     {
                         model.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(model, reader.BaseStream.Position);
+                        _entityAddedAction(model, _offset);
                         Program.Logger.WritePositiveLine("Found BFF Model at offset {0:X}", _offset);
                         _offset = reader.BaseStream.Position;
                         passed = true;

--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -32,7 +32,7 @@ namespace PSXPrev.Classes
                     if (model != null)
                     {
                         model.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(model, reader.BaseStream.Position);
+                        _entityAddedAction(model, _offset);
                         Program.Logger.WritePositiveLine("Found Croc Model at offset {0:X}", _offset);
                         _offset = reader.BaseStream.Position;
                         passed = true;

--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -11,16 +11,15 @@ namespace PSXPrev.Classes
     public class HMDParser
     {
         private long _offset;
-
         private readonly Action<RootEntity, long> _entityAddedAction;
         private readonly Action<Animation, long> _animationAddedAction;
         private readonly Action<Texture, long> _textureAddedAction;
 
-        public HMDParser(Action<RootEntity, long> entityAddedAction, Action<Animation, long> animationAddedAction, Action<Texture, long> textureAddedAction)
+        public HMDParser(Action<RootEntity, long> entityAdded, Action<Animation, long> animationAdded, Action<Texture, long> textureAdded)
         {
-            _entityAddedAction = entityAddedAction;
-            _animationAddedAction = animationAddedAction;
-            _textureAddedAction = textureAddedAction;
+            _entityAddedAction = entityAdded;
+            _animationAddedAction = animationAdded;
+            _textureAddedAction = textureAdded;
         }
 
         public void LookForHMDEntities(BinaryReader reader, string fileTitle)
@@ -44,26 +43,23 @@ namespace PSXPrev.Classes
                         if (rootEntity != null)
                         {
                             rootEntity.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _entityAddedAction(rootEntity, reader.BaseStream.Position);
+                            _entityAddedAction(rootEntity, _offset);
                             Program.Logger.WritePositiveLine("Found HMD Model at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
                             passed = true;
                         }
                         foreach (var animation in animations)
                         {
                             animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _animationAddedAction(animation, reader.BaseStream.Position);
+                            _animationAddedAction(animation, _offset);
                             Program.Logger.WritePositiveLine("Found HMD Animation at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
                             passed = true;
                         }
 
                         foreach (var texture in textures)
                         {
                             texture.TextureName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _textureAddedAction(texture, reader.BaseStream.Position);
+                            _textureAddedAction(texture, _offset);
                             Program.Logger.WritePositiveLine("Found HMD Image at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
                             passed = true;
                         }
                     }
@@ -74,6 +70,12 @@ namespace PSXPrev.Classes
                     //{
                     //    Program.Logger.WriteLine(exp);
                     //}
+                }
+
+                // Handle passed here, and not inside try/catch in-case something unexpected happens with the added callbacks.
+                if (passed)
+                {
+                    _offset = reader.BaseStream.Position;
                 }
 
                 if (!passed)

--- a/Classes/PMDParser.cs
+++ b/Classes/PMDParser.cs
@@ -8,12 +8,11 @@ namespace PSXPrev.Classes
     public class PMDParser
     {
         private long _offset;
+        private readonly Action<RootEntity, long> _entityAddedAction;
 
-        private Action<RootEntity, long> entityAddedAction;
-
-        public PMDParser(Action<RootEntity, long> entityAddedAction)
+        public PMDParser(Action<RootEntity, long> entityAdded)
         {
-            this.entityAddedAction = entityAddedAction;
+            _entityAddedAction = entityAdded;
         }
 
         public void LookForPMD(BinaryReader reader, string fileTitle)
@@ -40,7 +39,7 @@ namespace PSXPrev.Classes
                         {
                             entity.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
                             //entities.Add(entity);
-                            entityAddedAction(entity, reader.BaseStream.Position);
+                            _entityAddedAction(entity, _offset);
                             Program.Logger.WritePositiveLine("Found PMD Model at offset {0:X}", _offset);
                             passed = true;
                         }

--- a/Classes/PSXParser.cs
+++ b/Classes/PSXParser.cs
@@ -38,7 +38,7 @@ namespace PSXPrev.Classes
                     if (model != null)
                     {
                         model.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(model, reader.BaseStream.Position);
+                        _entityAddedAction(model, _offset);
                         Program.Logger.WritePositiveLine("Found PSX Model at offset {0:X}", _offset);
                         _offset = reader.BaseStream.Position;
                         passed = true;

--- a/Classes/TIMParser.cs
+++ b/Classes/TIMParser.cs
@@ -7,11 +7,11 @@ namespace PSXPrev.Classes
     public class TIMParser
     {
         private long _offset;
-        private readonly Action<Texture, long> _entityAddedAction;
+        private readonly Action<Texture, long> _textureAddedAction;
 
-        public TIMParser(Action<Texture, long> entityAdded)
+        public TIMParser(Action<Texture, long> textureAdded)
         {
-            _entityAddedAction = entityAdded;
+            _textureAddedAction = textureAdded;
         }
 
         public void LookForTim(BinaryReader reader, string fileTitle)
@@ -41,7 +41,7 @@ namespace PSXPrev.Classes
                             {
                                 texture.TextureName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
                                 //textures.Add(texture);
-                                _entityAddedAction(texture, reader.BaseStream.Position);
+                                _textureAddedAction(texture, _offset);
                                 Program.Logger.WritePositiveLine("Found TIM Image at offset {0:X}", _offset);
                                 _offset = reader.BaseStream.Position;
                                 passed = true;

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -10,7 +10,6 @@ namespace PSXPrev.Classes
     public class TMDParser
     {
         private long _offset;
-
         private readonly Action<RootEntity, long> _entityAddedAction;
 
         public TMDParser(Action<RootEntity, long> entityAddedAction)
@@ -39,7 +38,7 @@ namespace PSXPrev.Classes
                         if (entity != null)
                         {
                             entity.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _entityAddedAction(entity, reader.BaseStream.Position);
+                            _entityAddedAction(entity, _offset);
                             Program.Logger.WritePositiveLine("Found TMD Model at offset {0:X}", _offset);
                             _offset = reader.BaseStream.Position;
                             passed = true;

--- a/Classes/TODParser.cs
+++ b/Classes/TODParser.cs
@@ -8,11 +8,11 @@ namespace PSXPrev.Classes
     public class TODParser
     {
         private long _offset;
-        private Action<Animation, long> entityAddedAction;
+        private readonly Action<Animation, long> _animationAddedAction;
 
-        public TODParser(Action<Animation, long> entityAdded)
+        public TODParser(Action<Animation, long> animationAdded)
         {
-            entityAddedAction = entityAdded;
+            _animationAddedAction = animationAdded;
         }
 
         public void LookForTOD(BinaryReader reader, string fileTitle)
@@ -35,7 +35,7 @@ namespace PSXPrev.Classes
                         if (animation != null)
                         {
                             animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            entityAddedAction(animation, reader.BaseStream.Position);
+                            _animationAddedAction(animation, _offset);
                             Program.Logger.WritePositiveLine("Found TOD Animation at offset {0:X}", _offset);
                             _offset = reader.BaseStream.Position;
                             passed = true;

--- a/Classes/VDFParser.cs
+++ b/Classes/VDFParser.cs
@@ -8,11 +8,11 @@ namespace PSXPrev.Classes
     public class VDFParser
     {
         private long _offset;
-        private readonly Action<Animation, long> _entityAddedAction;
+        private readonly Action<Animation, long> _animationAddedAction;
 
-        public VDFParser(Action<Animation, long> entityAdded)
+        public VDFParser(Action<Animation, long> animationAdded)
         {
-            _entityAddedAction = entityAdded;
+            _animationAddedAction = animationAdded;
         }
 
         public void LookForVDF(BinaryReader reader, string fileTitle)
@@ -32,7 +32,7 @@ namespace PSXPrev.Classes
                     if (animation != null)
                     {
                         animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(animation, reader.BaseStream.Position);
+                        _animationAddedAction(animation, _offset);
                         Program.Logger.WritePositiveLine("Found VDF Animation at offset {0:X}", _offset);
                         _offset = reader.BaseStream.Position;
                         passed = true;


### PR DESCRIPTION
* Correctly pass `_offset` to added callbacks instead of `reader.BaseStream.Position`. This is especially helpful for identifying resources tied to a specific HMD model.
* Changed HMD model `_offset` assignment until after all resources are added. And put it outside of the try/catch in-case an error happens inside an added callback.
* Some minor refactoring with the added callbacks so that they are all consistent.
    * Use readonly.
    * No empty line between this and `_offset` field.
    * Correct "_entity"/"_animation"/"_texture" name prefix.
    * Removed "Action" postfix from constructor argument names.