### PR TITLE
Add FileOffsetScanner base class and -nooffset command line argument

### DIFF
--- a/Classes/ANParser.cs
+++ b/Classes/ANParser.cs
@@ -5,58 +5,28 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class ANParser
+    public class ANParser : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<Animation, long> _animationAddedAction;
-
-        public ANParser(Action<Animation, long> animationAdded)
+        public ANParser(AnimationAddedAction animationAdded)
+            : base(animationAdded: animationAdded)
         {
-            _animationAddedAction = animationAdded;
         }
 
-        public void LookForAN(BinaryReader reader, string fileTitle)
+        public override string FormatName => "AN";
+
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
         {
-            if (reader == null)
+            entities = null;
+            animations = null;
+            textures = null;
+
+            var magic = reader.ReadUInt16();
+            if (magic == 0xAAAA)
             {
-                throw (new Exception("File must be opened"));
-            }
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            while (reader.BaseStream.CanRead)
-            {
-                var passed = false;
-                try
+                var animation = ParseAN(reader);
+                if (animation != null)
                 {
-                    _offset = reader.BaseStream.Position;
-                    var magic = reader.ReadUInt16();
-                    if (magic == 0xAAAA)
-                    {
-                        var animation = ParseAN(reader);
-                        if (animation != null)
-                        {
-                            animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _animationAddedAction(animation, _offset);
-                            Program.Logger.WritePositiveLine("Found AN Animation at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
-                            passed = true;
-                        }
-                    }
-                }
-                catch (Exception exp)
-                {
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"AN - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
+                    animations = new List<Animation> { animation };
                 }
             }
         }

--- a/Classes/BFFModelReader.cs
+++ b/Classes/BFFModelReader.cs
@@ -9,65 +9,32 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class BFFModelReader
+    public class BFFModelReader : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<RootEntity, long> _entityAddedAction;
-
-        public BFFModelReader(Action<RootEntity, long> entityAdded)
+        public BFFModelReader(EntityAddedAction entityAdded)
+            : base(entityAdded: entityAdded)
         {
-            _entityAddedAction = entityAdded;
         }
 
-        public void LookForBFF(BinaryReader reader, string fileTitle)
+        public override string FormatName => "BFF";
+
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
         {
-            if (reader == null)
+            entities = null;
+            animations = null;
+            textures = null;
+
+            var model = ReadModels(reader);
+            if (model != null)
             {
-                throw (new Exception("File must be opened"));
-            }
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            while (reader.BaseStream.CanRead)
-            {
-                var passed = false;
-                try
-                {
-                    var groupedTriangles = new Dictionary<uint, List<Triangle>>();
-                    var model = ReadModels(reader, groupedTriangles);
-                    if (model != null)
-                    {
-                        model.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(model, _offset);
-                        Program.Logger.WritePositiveLine("Found BFF Model at offset {0:X}", _offset);
-                        _offset = reader.BaseStream.Position;
-                        passed = true;
-                    }
-                    //else
-                    //{
-                    //    return;
-                    //}
-                }
-                catch (Exception exp)
-                {
-                    var x = 1;
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"BFF - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
-                }
+                entities = new List<RootEntity> { model };
             }
         }
 
-        private RootEntity ReadModels(BinaryReader reader, Dictionary<uint, List<Triangle>> groupedTriangles)
+        private RootEntity ReadModels(BinaryReader reader)
         {
+            var groupedTriangles = new Dictionary<uint, List<Triangle>>();
+
             void AddTriangle(Triangle triangle, uint tPage)
             {
                 List<Triangle> triangles;

--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -5,59 +5,25 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class CrocModelReader
+    public class CrocModelReader : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<RootEntity, long> _entityAddedAction;
-
-        public CrocModelReader(Action<RootEntity, long> entityAdded)
+        public CrocModelReader(EntityAddedAction entityAdded)
+            : base(entityAdded: entityAdded)
         {
-            _entityAddedAction = entityAdded;
         }
 
-        public void LookForCrocModel(BinaryReader reader, string fileTitle)
-        {
-            if (reader == null)
-            {
-                throw (new Exception("File must be opened"));
-            }
+        public override string FormatName => "Croc";
 
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            while (reader.BaseStream.CanRead)
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        {
+            entities = null;
+            animations = null;
+            textures = null;
+
+            var model = ReadModels(reader);
+            if (model != null)
             {
-                var passed = false;
-                try
-                {
-                    var model = ReadModels(reader);
-                    if (model != null)
-                    {
-                        model.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _entityAddedAction(model, _offset);
-                        Program.Logger.WritePositiveLine("Found Croc Model at offset {0:X}", _offset);
-                        _offset = reader.BaseStream.Position;
-                        passed = true;
-                    }
-                    //else
-                    //{
-                    //    return;
-                    //}
-                }
-                catch (Exception exp)
-                {
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"Croc - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
-                }
+                entities = new List<RootEntity> { model };
             }
         }
 

--- a/Classes/FileOffsetScanner.cs
+++ b/Classes/FileOffsetScanner.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PSXPrev.Classes
+{
+    public delegate void EntityAddedAction(RootEntity rootEntity, long offset);
+    public delegate void AnimationAddedAction(Animation animation, long offset);
+    public delegate void TextureAddedAction(Texture texture, long offset);
+
+    public abstract class FileOffsetScanner
+    {
+        protected long _offset;
+        private readonly EntityAddedAction _entityAddedAction;
+        private readonly AnimationAddedAction _animationAddedAction;
+        private readonly TextureAddedAction _textureAddedAction;
+
+        public FileOffsetScanner(EntityAddedAction entityAdded = null, AnimationAddedAction animationAdded = null, TextureAddedAction textureAdded = null)
+        {
+            _entityAddedAction = entityAdded;
+            _animationAddedAction = animationAdded;
+            _textureAddedAction = textureAdded;
+        }
+
+        public void ScanFile(BinaryReader reader, string fileTitle)
+        {
+            if (reader == null)
+            {
+                throw new Exception("File must be opened");
+            }
+
+            Program.Logger.WriteLine($"Scanning for {FormatName} at file {fileTitle}");
+
+
+            reader.BaseStream.Seek(0, SeekOrigin.Begin);
+            
+            while (reader.BaseStream.CanRead)
+            {
+                var passed = false;
+                try
+                {
+                    _offset = reader.BaseStream.Position;
+
+                    Parse(reader, fileTitle, out var entities, out var animations, out var textures);
+
+                    var offsetPostfix = (_offset > 0 ? $"_{_offset:X}" : string.Empty);
+                    var name = $"{fileTitle}{offsetPostfix}";
+                        
+                    if (entities != null)
+                    {
+                        foreach (var entity in entities)
+                        {
+                            if (entity == null)
+                            {
+                                continue;
+                            }
+                            passed = true;
+                            entity.EntityName = name;
+                            _entityAddedAction(entity, _offset);
+
+                            Program.Logger.WritePositiveLine($"Found {FormatName} Model at offset {_offset:X}");
+                        }
+                    }
+                    if (animations != null)
+                    {
+                        foreach (var animation in animations)
+                        {
+                            if (animation == null)
+                            {
+                                continue;
+                            }
+                            passed = true;
+                            animation.AnimationName = name;
+                            _animationAddedAction(animation, _offset);
+
+                            Program.Logger.WritePositiveLine($"Found {FormatName} Animation at offset {_offset:X}");
+                        }
+                    }
+                    if (textures != null)
+                    {
+                        foreach (var texture in textures)
+                        {
+                            if (texture == null)
+                            {
+                                continue;
+                            }
+                            passed = true;
+                            texture.TextureName = name;
+                            _textureAddedAction(texture, _offset);
+
+                            Program.Logger.WritePositiveLine($"Found {FormatName} Image at offset {_offset:X}");
+                        }
+                    }
+                }
+                catch (Exception exp)
+                {
+                    //if (Program.Debug)
+                    //{
+                    //    Program.Logger.WriteLine(exp);
+                    //}
+                }
+
+                if (!passed)
+                {
+                    if (Program.NoOffset || ++_offset > reader.BaseStream.Length)
+                    {
+                        Program.Logger.WriteLine($"{FormatName} - Reached file end: {fileTitle}");
+                        return;
+                    }
+                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
+                }
+            }
+        }
+
+        public abstract string FormatName { get; }
+
+        protected abstract void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures);
+    }
+}

--- a/Classes/Logger.cs
+++ b/Classes/Logger.cs
@@ -60,10 +60,9 @@ namespace PSXPrev.Classes
             Write(format, args);
         }
 
-        public void WritePositiveLine(string format, object value)
+        public void WritePositiveLine(object text)
         {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Write(format, new[] { value });
+            WritePositiveLine("{0}", new[] { text });
         }
 
         public void Dispose()

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -7,59 +7,28 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class TMDParser
+    public class TMDParser : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<RootEntity, long> _entityAddedAction;
-
-        public TMDParser(Action<RootEntity, long> entityAddedAction)
+        public TMDParser(EntityAddedAction entityAdded)
+            : base(entityAdded: entityAdded)
         {
-            _entityAddedAction = entityAddedAction;
         }
 
-        public void LookForTmd(BinaryReader reader, string fileTitle)
+        public override string FormatName => "TMD";
+
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
         {
-            if (reader == null)
-            {
-                throw new Exception("File must be opened");
-            }
+            entities = null;
+            animations = null;
+            textures = null;
 
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-
-            while (reader.BaseStream.CanRead)
+            var version = reader.ReadUInt32();
+            if (Program.IgnoreTmdVersion || version == 0x00000041)
             {
-                var passed = false;
-                try
+                var entity = ParseTmd(reader, fileTitle);
+                if (entity != null)
                 {
-                    var version = reader.ReadUInt32();
-                    if (Program.IgnoreTmdVersion || version == 0x00000041)
-                    {
-                        var entity = ParseTmd(reader, fileTitle);
-                        if (entity != null)
-                        {
-                            entity.EntityName = string.Format("{0}{1:X}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _entityAddedAction(entity, _offset);
-                            Program.Logger.WritePositiveLine("Found TMD Model at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
-                            passed = true;
-                        }
-                    }
-                }
-                catch (Exception exp)
-                {
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"TMD - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
+                    entities = new List<RootEntity> { entity };
                 }
             }
         }

--- a/Classes/TODParser.cs
+++ b/Classes/TODParser.cs
@@ -5,58 +5,28 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class TODParser
+    public class TODParser : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<Animation, long> _animationAddedAction;
-
-        public TODParser(Action<Animation, long> animationAdded)
+        public TODParser(AnimationAddedAction animationAdded)
+            : base(animationAdded: animationAdded)
         {
-            _animationAddedAction = animationAdded;
         }
 
-        public void LookForTOD(BinaryReader reader, string fileTitle)
+        public override string FormatName => "TOD";
+
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
         {
-            if (reader == null)
+            entities = null;
+            animations = null;
+            textures = null;
+
+            var fileID = reader.ReadByte();
+            if (fileID == 0x50)
             {
-                throw (new Exception("File must be opened"));
-            }
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            while (reader.BaseStream.CanRead)
-            {
-                var passed = false;
-                try
+                var animation = ParseTOD(reader);
+                if (animation != null)
                 {
-                    _offset = reader.BaseStream.Position;
-                    var fileID = reader.ReadByte();
-                    if (fileID == 0x50)
-                    {
-                        var animation = ParseTOD(reader);
-                        if (animation != null)
-                        {
-                            animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                            _animationAddedAction(animation, _offset);
-                            Program.Logger.WritePositiveLine("Found TOD Animation at offset {0:X}", _offset);
-                            _offset = reader.BaseStream.Position;
-                            passed = true;
-                        }
-                    }
-                }
-                catch (Exception exp)
-                {
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"TOD - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
+                    animations = new List<Animation> { animation };
                 }
             }
         }

--- a/Classes/VDFParser.cs
+++ b/Classes/VDFParser.cs
@@ -5,55 +5,25 @@ using OpenTK;
 
 namespace PSXPrev.Classes
 {
-    public class VDFParser
+    public class VDFParser : FileOffsetScanner
     {
-        private long _offset;
-        private readonly Action<Animation, long> _animationAddedAction;
-
-        public VDFParser(Action<Animation, long> animationAdded)
+        public VDFParser(AnimationAddedAction animationAdded)
+            : base(animationAdded: animationAdded)
         {
-            _animationAddedAction = animationAdded;
         }
 
-        public void LookForVDF(BinaryReader reader, string fileTitle)
+        public override string FormatName => "VDF";
+
+        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
         {
-            if (reader == null)
+            entities = null;
+            animations = null;
+            textures = null;
+            
+            var animation = ParseVDF(reader);
+            if (animation != null)
             {
-                throw (new Exception("File must be opened"));
-            }
-            reader.BaseStream.Seek(0, SeekOrigin.Begin);
-            while (reader.BaseStream.CanRead)
-            {
-                var passed = false;
-                try
-                {
-                    _offset = reader.BaseStream.Position;
-                    var animation = ParseVDF(reader);
-                    if (animation != null)
-                    {
-                        animation.AnimationName = string.Format("{0}{1:x}", fileTitle, _offset > 0 ? "_" + _offset : string.Empty);
-                        _animationAddedAction(animation, _offset);
-                        Program.Logger.WritePositiveLine("Found VDF Animation at offset {0:X}", _offset);
-                        _offset = reader.BaseStream.Position;
-                        passed = true;
-                    }
-                }
-                catch (Exception exp)
-                {
-                    //if (Program.Debug)
-                    //{
-                    //    Program.Logger.WriteLine(exp);
-                    //}
-                }
-                if (!passed)
-                {
-                    if (++_offset > reader.BaseStream.Length)
-                    {
-                        Program.Logger.WriteLine($"VDF - Reached file end: {fileTitle}");
-                        return;
-                    }
-                    reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
-                }
+                animations = new List<Animation> { animation };
             }
         }
 

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Classes\LineBatch.cs" />
     <Compile Include="Classes\MtlExporter.cs" />
     <Compile Include="Classes\ObjBlock.cs" />
+    <Compile Include="Classes\FileOffsetScanner.cs" />
     <Compile Include="Classes\PlyExporter.cs" />
     <Compile Include="Classes\PMDParser.cs" />
     <Compile Include="Classes\PrimitiveDataType.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -42,6 +42,7 @@ namespace PSXPrev
             public bool SelectFirstModel { get; set; }
             public bool DrawAllToVRAM { get; set; }
             public bool AutoAttachLimbs { get; set; }
+            public bool NoOffset { get; set; }
 
             public ScanOptions Clone()
             {
@@ -73,6 +74,7 @@ namespace PSXPrev
         public static bool Debug => _options.Debug;
         public static bool LogToFile => _options.LogToFile;
         public static bool NoVerbose => _options.NoVerbose;
+        public static bool NoOffset => _options.NoOffset;
 
 
         public const string DefaultFilter = "*.*";
@@ -115,7 +117,7 @@ namespace PSXPrev
                 + " [-an] [-bff] [-croc] [-hmd] [-pmd] [-psx] [-tim] [-tmd] [-tod] [-vdf]" // scanner formats (alphabetical)
                 + " [-ignoretmdversion]" // scanner options
                 + " [-log] [-noverbose] [-debug]" // log options
-                + " [-selectmodel] [-drawvram] [-attachlimbs]" // program options
+                + " [-selectmodel] [-drawvram] [-attachlimbs] [-nooffset]" // program options
                 );
 
             Console.ResetColor();
@@ -136,7 +138,7 @@ namespace PSXPrev
             Console.WriteLine("scanner options: (default: all formats)");
             Console.WriteLine("  -an    : scan for AN animations");
             Console.WriteLine("  -bff   : scan for BFF models");
-            Console.WriteLine("  -croc  : scan for CROC models");
+            Console.WriteLine("  -croc  : scan for Croc models");
             Console.WriteLine("  -hmd   : scan for HMD models, textures, and animations");
             Console.WriteLine("  -pmd   : scan for PMD models");
             Console.WriteLine("  -psx   : scan for PSX models");
@@ -156,6 +158,7 @@ namespace PSXPrev
             Console.WriteLine("  -selectmodel : select and display the first-loaded model");
             Console.WriteLine("  -drawvram    : draw all loaded textures to VRAM (not advised when scanning a lot of files)");
             Console.WriteLine("  -attachlimbs : enable Auto Attach Limbs by default");
+            Console.WriteLine("  -nooffset    : only scan files at offset 0");
 
             Console.ResetColor();
         }
@@ -240,6 +243,9 @@ namespace PSXPrev
                     break;
                 case "-attachlimbs":
                     options.AutoAttachLimbs = true;
+                    break;
+                case "-nooffset":
+                    options.NoOffset = true;
                     break;
 
                 default:
@@ -474,8 +480,7 @@ namespace PSXPrev
                 {
                     var timParser = new TIMParser(AddTexture);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for TIM at file {0}", fileTitle);
-                    timParser.LookForTim(binaryReader, fileTitle);
+                    timParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -485,8 +490,7 @@ namespace PSXPrev
                 {
                     var crocModelReader = new CrocModelReader(AddEntity);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for Croc at file {0}", fileTitle);
-                    crocModelReader.LookForCrocModel(binaryReader, fileTitle);
+                    crocModelReader.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -496,8 +500,7 @@ namespace PSXPrev
                 {
                     var bffModelReader = new BFFModelReader(AddEntity);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for BFF at file {0}", fileTitle);
-                    bffModelReader.LookForBFF(binaryReader, fileTitle);
+                    bffModelReader.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -507,8 +510,7 @@ namespace PSXPrev
                 {
                     var psxParser = new PSXParser(AddEntity);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for PSX at file {0}", fileTitle);
-                    psxParser.LookForPSX(binaryReader, fileTitle);
+                    psxParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -518,8 +520,7 @@ namespace PSXPrev
                 {
                     var tmdParser = new TMDParser(AddEntity);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for TMD at file {0}", fileTitle);
-                    tmdParser.LookForTmd(binaryReader, fileTitle);
+                    tmdParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -529,8 +530,7 @@ namespace PSXPrev
                 {
                     var vdfParser = new VDFParser(AddAnimation);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for VDF at file {0}", fileTitle);
-                    vdfParser.LookForVDF(binaryReader, fileTitle);
+                    vdfParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -540,8 +540,7 @@ namespace PSXPrev
                 {
                     var anParser = new ANParser(AddAnimation);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for AN at file {0}", fileTitle);
-                    anParser.LookForAN(binaryReader, fileTitle);
+                    anParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -551,8 +550,7 @@ namespace PSXPrev
                 {
                     var pmdParser = new PMDParser(AddEntity);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for PMD at file {0}", fileTitle);
-                    pmdParser.LookForPMD(binaryReader, fileTitle);
+                    pmdParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -562,8 +560,7 @@ namespace PSXPrev
                 {
                     var todParser = new TODParser(AddAnimation);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for TOD at file {0}", fileTitle);
-                    todParser.LookForTOD(binaryReader, fileTitle);
+                    todParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 
@@ -573,8 +570,7 @@ namespace PSXPrev
                 {
                     var hmdParser = new HMDParser(AddEntity, AddAnimation, AddTexture);
                     //Program.Logger.WriteLine("");
-                    Program.Logger.WriteLine("Scanning for HMD at file {0}", fileTitle);
-                    hmdParser.LookForHMDEntities(binaryReader, fileTitle);
+                    hmdParser.ScanFile(binaryReader, fileTitle);
                 });
             }
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Command line usage:
 usage: PSXPrev <PATH> [FILTER="*.*"] [-help] [-an] [-bff] [-croc]
                [-hmd] [-pmd] [-psx] [-tim] [-tmd] [-tod] [-vdf]
                [-ignoretmdversion] [-log] [-noverbose] [-debug]
-               [-selectmodel] [-drawvram] [-attachlimbs]
+               [-selectmodel] [-drawvram] [-attachlimbs] [-nooffset]
 
 arguments:
   PATH   : folder or file path to scan
@@ -50,7 +50,7 @@ arguments:
 scanner options: (default: all formats)
   -an    : scan for AN animations
   -bff   : scan for BFF models
-  -croc  : scan for CROC models
+  -croc  : scan for Croc models
   -hmd   : scan for HMD models, textures, and animations
   -pmd   : scan for PMD models
   -psx   : scan for PSX models
@@ -69,4 +69,5 @@ program options:
   -selectmodel : select and display the first-loaded model
   -drawvram    : draw all loaded textures to VRAM (not advised when scanning a lot of files)
   -attachlimbs : enable Auto Attach Limbs by default
+  -nooffset    : only scan files at offset 0
 ```


### PR DESCRIPTION
### FileOffsetScanner base class
The `FileOffsetScanner` base class is intended for use with all offset-scanning readers. It wraps around all functionality that's duplicated between each reader.
* `ScanFile` is the replacement for `LookFor*` functions.
* `FormatName` is an abstract property where the reader defines the format name to attach to log messages.
* `Parse` is the abstract function that takes a reader and file title and outputs optional lists of entities, animations, and textures that were found.

### -nooffset command line argument
Added `-nooffset` command line argument (no GUI checkbox yet). This tells the `FileOffsetScanner` to stop after offset 0.
* Updated README usage and command line usage to include `-nooffset`.

### Other changes
* Fixed offset of entity/animation/texture names not being in hex, like what was intended.
* Changed `Logger.WritePositiveLine(string format, object arg0)` to `Logger.WritePositiveLine(string text)`. We already had a function for format + arguments.
* Changed casing of "Croc" model in usage from "CROC" to "Croc".