### PR TITLE
Add render flags, semi-transparency, and renderer refactoring

### DIFF
--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -208,7 +208,7 @@ namespace PSXPrev.Classes
 
         private void ProccessPrimitive(BinaryReader reader, List<ModelEntity> modelEntities, List<Animation> animations, List<Texture> textures, uint primitiveIndex, uint primitiveSetTop, uint primitiveHeaderTop)
         {
-            var groupedTriangles = new Dictionary<uint, List<Triangle>>();
+            var groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
             var sharedVertices = new Dictionary<uint, Vector3>();
             var sharedNormals = new Dictionary<uint, Vector3>();
             uint chainLength = 0;
@@ -393,13 +393,16 @@ namespace PSXPrev.Classes
                 }
                 break;
             }
-            foreach (var key in groupedTriangles.Keys)
+            foreach (var kvp in groupedTriangles)
             {
-                var triangles = groupedTriangles[key];
+                var renderInfo = kvp.Key;
+                var triangles = kvp.Value;
                 var model = new ModelEntity
                 {
                     Triangles = triangles.ToArray(),
-                    TexturePage = key,
+                    TexturePage = renderInfo.TexturePage,
+                    RenderFlags = renderInfo.RenderFlags,
+                    MixtureRate = renderInfo.MixtureRate,
                     TMDID = primitiveIndex, //todo
                     //PrimitiveIndex = primitiveIndex
                 };
@@ -421,6 +424,7 @@ namespace PSXPrev.Classes
                 var sharedModel = new ModelEntity
                 {
                     Triangles = new Triangle[0], // No triangles. Is it possible this could break exporters?
+                    RenderFlags = RenderFlags.None,
                     TMDID = primitiveIndex, //todo
                     //PrimitiveIndex = primitiveIndex
                     Visible = false,
@@ -449,6 +453,7 @@ namespace PSXPrev.Classes
             var imageIndex = reader.ReadUInt32() * 4;
             uint pmode;
             System.Drawing.Color[] palette;
+            bool[] semiTransparentPalette;
             if (hasClut)
             {
                 var clutX = reader.ReadUInt16();
@@ -466,16 +471,17 @@ namespace PSXPrev.Classes
                 
                 reader.BaseStream.Seek(_offset + clutTop + clutIndex, SeekOrigin.Begin);
                 // Allow out of bounds to support HMDs with invalid image data, but valid model data.
-                palette = TIMParser.ReadPalette(reader, pmode, clutWidth, clutHeight, true);
+                palette = TIMParser.ReadPalette(reader, pmode, clutWidth, clutHeight, out semiTransparentPalette, true);
             }
             else
             {
                 pmode = 3u; // 24bpp
                 palette = null;
+                semiTransparentPalette = null;
             }
             reader.BaseStream.Seek(_offset + imageTop + imageIndex, SeekOrigin.Begin);
             // Allow out of bounds to support HMDs with invalid image data, but valid model data.
-            var texture = TIMParser.ReadTexture(reader, width, height, x, y, pmode, palette, true);
+            var texture = TIMParser.ReadTexture(reader, width, height, x, y, pmode, palette, semiTransparentPalette, true);
 
             reader.BaseStream.Seek(position, SeekOrigin.Begin);
             return texture;
@@ -521,7 +527,7 @@ namespace PSXPrev.Classes
             return normal;
         }
 
-        private void ProcessNonSharedGeometryData(Dictionary<uint, List<Triangle>> groupedTriangles, BinaryReader reader, bool shared, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint polygonIndex, uint dataCount)
+        private void ProcessNonSharedGeometryData(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, BinaryReader reader, bool shared, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint polygonIndex, uint dataCount)
         {
             var primitivePosition = reader.BaseStream.Position;
             uint dataTop, vertTop, normTop, coordTop;
@@ -535,13 +541,13 @@ namespace PSXPrev.Classes
                 ProcessSharedGeometryPrimitiveHeader(reader, primitiveHeaderPointer, out dataTop, out vertTop, out var calcVertTop, out normTop, out var calcNormTop, out coordTop);
             }
             reader.BaseStream.Seek(_offset + dataTop + polygonIndex, SeekOrigin.Begin);
+
             for (var j = 0; j < dataCount; j++)
             {
-                var packetStructure = TMDHelper.CreateHMDPacketStructure(driver, primitiveType, reader);
-                //var offset = reader.BaseStream.Position;
+                var packetStructure = TMDHelper.CreateHMDPacketStructure(driver, primitiveType, reader, out var renderFlags);
                 if (packetStructure != null)
                 {
-                    TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, shared,
+                    TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, renderFlags, shared,
                         index =>
                         {
                             if (shared)
@@ -594,7 +600,7 @@ namespace PSXPrev.Classes
             reader.BaseStream.Seek(primitivePosition, SeekOrigin.Begin);
         }
 
-        private List<Animation> ProcessAnimationData(Dictionary<uint, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint dataCount)
+        private List<Animation> ProcessAnimationData(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint dataCount)
         {
             var primitivePosition = reader.BaseStream.Position;
             ProcessAnimationPrimitiveHeader(reader, primitiveHeaderPointer, out var interpTop, out var ctrlTop, out var paramTop, out var coordTop, out var sectionList);
@@ -948,7 +954,7 @@ namespace PSXPrev.Classes
             return animationList;
         }
 
-        private Animation ProcessMimeVertexData(Dictionary<uint, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint diffTop, uint dataCount, bool rst)
+        private Animation ProcessMimeVertexData(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint diffTop, uint dataCount, bool rst)
         {
             Animation animation;
             Dictionary<uint, AnimationObject> animationObjects;
@@ -1042,19 +1048,15 @@ namespace PSXPrev.Classes
             return animation;
         }
 
-        private void ProcessGroundData(Dictionary<uint, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint polygonIndex, uint dataCount, uint gridIndex, uint vertexIndex)
+        private void ProcessGroundData(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint nextPrimitivePointer, uint polygonIndex, uint dataCount, uint gridIndex, uint vertexIndex)
         {
-            void AddTriangle(Triangle triangle, uint tPageNum)
+            void AddTriangle(Triangle triangle, uint tPageNum, RenderFlags renderFlags, MixtureRate mixtureRate)
             {
-                List<Triangle> triangles;
-                if (groupedTriangles.ContainsKey(tPageNum))
-                {
-                    triangles = groupedTriangles[tPageNum];
-                }
-                else
+                var renderInfo = new RenderInfo(tPageNum, renderFlags, mixtureRate);
+                if (!groupedTriangles.TryGetValue(renderInfo, out var triangles))
                 {
                     triangles = new List<Triangle>();
-                    groupedTriangles.Add(tPageNum, triangles);
+                    groupedTriangles.Add(renderInfo, triangles);
                 }
                 triangles.Add(triangle);
             }
@@ -1088,6 +1090,9 @@ namespace PSXPrev.Classes
                         Color color;
                         Vector3 n0, n1, n2, n3;
                         Vector3 uv0, uv1, uv2, uv3;
+
+                        var renderFlags = RenderFlags.None; // todo
+                        var mixtureRate = MixtureRate.None;
 
                         if (primitiveType == 0)
                         {
@@ -1141,7 +1146,7 @@ namespace PSXPrev.Classes
                             Colors = new[] { color, color, color },
                             Uv = new[] { uv0, uv1, uv2 },
                             AttachableIndices = new[] { uint.MaxValue, uint.MaxValue, uint.MaxValue }
-                        }, tPage);
+                        }, tPage, renderFlags, mixtureRate);
 
                         AddTriangle(new Triangle
                         {
@@ -1150,7 +1155,7 @@ namespace PSXPrev.Classes
                             Colors = new[] { color, color, color },
                             Uv = new[] { uv2, uv3, uv0 },
                             AttachableIndices = new[] { uint.MaxValue, uint.MaxValue, uint.MaxValue }
-                        }, tPage);
+                        }, tPage, renderFlags, mixtureRate);
                     }
                     reader.BaseStream.Seek(rowPosition, SeekOrigin.Begin);
 

--- a/Classes/ManifestResourceLoader.cs
+++ b/Classes/ManifestResourceLoader.cs
@@ -1,19 +1,43 @@
-﻿using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
+using System.Reflection;
 
 namespace PSXPrev.Classes
 {
     public static class ManifestResourceLoader
     {
-        public static string LoadTextFile(string textFileName)
+        public static string BaseNamespace = "PSXPrev";
+
+        private static string ConvertPath(string fileName)
         {
-            using (var stream = File.OpenRead(textFileName))
+            // Replace path slashes with dots.
+            var resourceName = fileName.Replace('\\', '.').Replace('/', '.');
+            // Prefix path with base namespace.
+            return $"{BaseNamespace}.{resourceName}";
+        }
+
+        public static Stream Open(string fileName, bool checkFileSystem = true)
+        {
+            if (checkFileSystem && File.Exists(fileName))
             {
-                Debug.Assert(stream != null, "stream != null");
-                using (var reader = new StreamReader(stream))
+                return File.OpenRead(fileName);
+            }
+            else
+            {
+                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ConvertPath(fileName));
+                if (stream == null)
                 {
-                    return reader.ReadToEnd();
+                    throw new FileNotFoundException("Could not open resource file", fileName);
                 }
+                return stream;
+            }
+        }
+
+        public static string LoadTextFile(string fileName, bool checkFileSystem = true)
+        {
+            using (var stream = Open(fileName, checkFileSystem))
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
             }
         }
     }

--- a/Classes/Mesh.cs
+++ b/Classes/Mesh.cs
@@ -10,6 +10,8 @@ namespace PSXPrev.Classes
 
         public Matrix4 WorldMatrix { get; set; }
         public uint Texture { get; set; }
+        public RenderFlags RenderFlags { get; set; }
+        public MixtureRate MixtureRate { get; set; }
 
         private readonly uint _meshId;
         private int _numElements;

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -6,9 +6,18 @@ namespace PSXPrev.Classes
 {
     public class ModelEntity : EntityBase
     {
+        // Default flags for when a reader doesn't assign any.
+        public const RenderFlags DefaultRenderFlags = RenderFlags.DoubleSided;
+
         [DisplayName("VRAM Page")]
         public uint TexturePage { get; set; }
         
+        [DisplayName("Render Flags")]
+        public RenderFlags RenderFlags { get; set; } = DefaultRenderFlags;
+        
+        [DisplayName("Mixture Rate")]
+        public MixtureRate MixtureRate { get; set; }
+
         [ReadOnly(true), DisplayName("Total Triangles")]
         public int TrianglesCount => Triangles.Length;
 

--- a/Classes/PMDParser.cs
+++ b/Classes/PMDParser.cs
@@ -61,13 +61,22 @@ namespace PSXPrev.Classes
                         return null;
                     }
                     var primType = reader.ReadUInt16();
-                    if (primType > 15)
+
+                    var lgtCalcBit = ((primType >> 4) & 0x1) == 1; // Light source calc: 0-Off, 1-On
+                    var botBit     = ((primType >> 5) & 0x1) == 1; // Both sides: 0-Single sided, 1-Double sided
+
+                    var renderFlags = RenderFlags.None;
+                    if (botBit) renderFlags |= RenderFlags.DoubleSided;
+
+                    var primTypeSwitch = primType & ~0x30; // These two bits don't effect packet structure
+                    if (primTypeSwitch > 15)
                     {
                         return null;
                     }
+
                     for (var pk = 0; pk < nPacket; pk++)
                     {
-                        switch (primType)
+                        switch (primTypeSwitch)
                         {
                             case 0x00:
                                 triangles.Add(ReadPolyFT3(reader));

--- a/Classes/RenderInfo.cs
+++ b/Classes/RenderInfo.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+namespace PSXPrev.Classes
+{
+    [Flags]
+    public enum RenderFlags
+    {
+        None = 0,
+
+        DoubleSided       = (1 << 0),
+        Unlit             = (1 << 1),
+        SemiTransparent   = (1 << 3),
+        Fog               = (1 << 4),
+        // Are these even render-related?
+        Subdivision       = (1 << 5),
+        AutomaticDivision = (1 << 6),
+
+        // Use this mask when separating meshes by render info.
+        SupportedFlags = DoubleSided | Unlit | SemiTransparent,
+
+        // Bits 30 and 31 are reserved for MixtureRate.
+    }
+
+    // Blending when RenderFlags.SemiTransparent is set.
+    public enum MixtureRate
+    {
+        None,
+        Back50_Poly50,    //  50% back +  50% poly
+        Back100_Poly100,  // 100% back + 100% poly
+        Back100_PolyM100, // 100% back - 100% poly
+        Back100_Poly25,   // 100% back +  25% poly
+    }
+    
+    // A named Tuple<uint, RenderFlags, MixtureRate> for render information used to separate models/meshes.
+    public struct RenderInfo : IEquatable<RenderInfo>
+    {
+        public uint TexturePage { get; }
+        public RenderFlags RenderFlags { get; }
+        public MixtureRate MixtureRate { get; }
+        
+        // Helper property for getting hash codes and checking for equality.
+        private ulong RawValue
+        {
+            get
+            {
+                return (((ulong)TexturePage <<  0) |
+                        ((ulong)RenderFlags << 32) |
+                        ((ulong)MixtureRate << 62));
+            }
+        }
+
+        public RenderInfo(uint texturePage, RenderFlags renderFlags, MixtureRate mixtureRate = MixtureRate.None)
+        {
+            TexturePage = texturePage;
+            RenderFlags = renderFlags & RenderFlags.SupportedFlags; // Ignore flags that we can't use for now
+            MixtureRate = mixtureRate;
+        }
+
+        public override int GetHashCode() => RawValue.GetHashCode();
+
+        public override bool Equals(object obj)
+        {
+            if (obj is RenderInfo other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        public bool Equals(RenderInfo other)
+        {
+            return RawValue.Equals(other.RawValue);
+        }
+    }
+}

--- a/Classes/Scene.cs
+++ b/Classes/Scene.cs
@@ -35,6 +35,7 @@ namespace PSXPrev.Classes
         public static int UniformMaskColor;
         public static int UniformAmbientColor;
         public static int UniformRenderMode;
+        public static int UniformSemiTransparentMode;
         public static int UniformLightIntensity;
 
         public const string AttributeNamePosition = "in_Position";
@@ -48,6 +49,7 @@ namespace PSXPrev.Classes
         public const string UniformMaskColorName = "maskColor";
         public const string UniformAmbientColorName = "ambientColor";
         public const string UniformRenderModeName = "renderMode";
+        public const string UniformSemiTransparentModeName = "semiTransparentMode";
         public const string UniformLightIntensityName = "lightIntensity";
 
         public enum GizmoId
@@ -101,6 +103,10 @@ namespace PSXPrev.Classes
         public bool ShowBounds { get; set; } = true;
 
         public bool ShowSkeleton { get; set; }
+
+        public bool SemiTransparencyEnabled { get; set; } = true;
+
+        public bool ForceDoubleSided { get; set; }
 
         public float CameraDistanceIncrement => CameraDistanceToOrigin * CameraDistanceIncrementFactor;
 
@@ -229,6 +235,7 @@ namespace PSXPrev.Classes
             UniformMaskColor = GL.GetUniformLocation(_shaderProgram, UniformMaskColorName);
             UniformAmbientColor = GL.GetUniformLocation(_shaderProgram, UniformAmbientColorName);
             UniformRenderMode = GL.GetUniformLocation(_shaderProgram, UniformRenderModeName);
+            UniformSemiTransparentMode = GL.GetUniformLocation(_shaderProgram, UniformSemiTransparentModeName);
             UniformLightIntensity = GL.GetUniformLocation(_shaderProgram, UniformLightIntensityName);
         }
 
@@ -280,7 +287,8 @@ namespace PSXPrev.Classes
             GL.Uniform3(UniformAmbientColor, AmbientColor.R / 255f, AmbientColor.G / 255f, AmbientColor.B / 255f);
             GL.Uniform1(UniformLightIntensity, LightIntensity);
             GL.Uniform1(UniformRenderMode, LightEnabled ? 0 : 1);
-            MeshBatch.Draw(_viewMatrix, _projectionMatrix, TextureBinder, Wireframe);
+            GL.Uniform1(UniformSemiTransparentMode, 0);
+            MeshBatch.Draw(_viewMatrix, _projectionMatrix, TextureBinder, Wireframe, standard: true);
             GL.Uniform1(UniformRenderMode, 2);
             if (ShowBounds)
             {
@@ -289,7 +297,7 @@ namespace PSXPrev.Classes
             GL.Clear(ClearBufferMask.DepthBufferBit);
             if (ShowGizmos)
             {
-                GizmosMeshBatch.Draw(_viewMatrix, _projectionMatrix);
+                GizmosMeshBatch.Draw(_viewMatrix, _projectionMatrix, standard: false);
             }
             GL.Disable(EnableCap.DepthTest);
             GL.Disable(EnableCap.Texture2D);

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -147,7 +147,7 @@ namespace PSXPrev.Classes
                     normals[n] = normal.Normalized();
                 }
 
-                var groupedTriangles = new Dictionary<uint, List<Triangle>>();
+                var groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
 
                 reader.BaseStream.Seek(objBlock.PrimitiveTop, SeekOrigin.Begin);
                 if (Program.IgnoreTmdVersion && objBlock.PrimitiveTop < _offset)
@@ -166,10 +166,10 @@ namespace PSXPrev.Classes
                     var flag = reader.ReadByte();
                     var mode = reader.ReadByte();
                     var offset = reader.BaseStream.Position;
-                    var packetStructure = TMDHelper.CreateTMDPacketStructure(flag, mode, reader, p);
+                    var packetStructure = TMDHelper.CreateTMDPacketStructure(flag, mode, reader, p, out var renderFlags);
                     if (packetStructure != null)
                     {
-                        TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, false, delegate (uint index)
+                        TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, renderFlags, false, delegate (uint index)
                         {
                             if (index >= vertices.Length)
                             {
@@ -205,13 +205,16 @@ namespace PSXPrev.Classes
 
                 foreach (var kvp in groupedTriangles)
                 {
+                    var renderInfo = kvp.Key;
                     var triangles = kvp.Value;
                     if (triangles.Count > 0)
                     {
                         var model = new ModelEntity
                         {
                             Triangles = triangles.ToArray(),
-                            TexturePage = kvp.Key,
+                            TexturePage = renderInfo.TexturePage,
+                            RenderFlags = renderInfo.RenderFlags,
+                            MixtureRate = renderInfo.MixtureRate,
                             TMDID = o
                         };
                         models.Add(model);

--- a/Classes/Texture.cs
+++ b/Classes/Texture.cs
@@ -1,10 +1,14 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Drawing;
 
 namespace PSXPrev.Classes
 {
-    public class Texture
+    public class Texture : IDisposable
     {
+        public static readonly System.Drawing.Color NoSemiTransparentFlag = System.Drawing.Color.FromArgb(255, 0, 0, 0);
+        public static readonly System.Drawing.Color SemiTransparentFlag = System.Drawing.Color.FromArgb(255, 255, 255, 255);
+
         public Texture(int width, int height, int x, int y, int bpp, int texturePage)
         {
             Bitmap = new Bitmap(width, height);
@@ -37,5 +41,27 @@ namespace PSXPrev.Classes
 
         [Browsable(false)]
         public Bitmap Bitmap { get; set; }
+
+        [Browsable(false)]
+        public Bitmap SemiTransparentMap { get; set; }
+
+        public Bitmap SetupSemiTransparentMap()
+        {
+            if (SemiTransparentMap == null)
+            {
+                SemiTransparentMap = new Bitmap(Width, Height);
+                using (var graphics = Graphics.FromImage(SemiTransparentMap))
+                {
+                    graphics.Clear(Texture.NoSemiTransparentFlag);
+                }
+            }
+            return SemiTransparentMap;
+        }
+
+        public void Dispose()
+        {
+            Bitmap?.Dispose();
+            SemiTransparentMap?.Dispose();
+        }
     }
 }

--- a/Classes/VRAMPages.cs
+++ b/Classes/VRAMPages.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace PSXPrev.Classes
+{
+    public class VRAMPages : IReadOnlyList<Texture>, IDisposable
+    {
+        public const int PageCount = 32;
+        public const int PageSize = 256;
+        private const int PageSemiTransparencyX = PageSize;
+
+
+        private readonly Scene _scene;
+        private readonly Texture[] _vramPage;
+        private readonly bool[] _modifiedPage;
+
+        public System.Drawing.Color BackgroundColor { get; set; } = System.Drawing.Color.White;
+
+        public VRAMPages(Scene scene)
+        {
+            _scene = scene;
+            _vramPage = new Texture[PageCount];
+            _modifiedPage = new bool[PageCount];
+        }
+
+        public Texture this[uint index] => _vramPage[index];
+        public Texture this[int index] => _vramPage[index];
+
+        public int Count => PageCount;
+
+        public IEnumerator<Texture> GetEnumerator()
+        {
+            return ((IReadOnlyList<Texture>)_vramPage).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Dispose()
+        {
+            for (var i = 0; i < PageCount; i++)
+            {
+                _vramPage[i]?.Dispose();
+                //_vramPage[i] = null;
+            }
+        }
+
+        public void Setup(bool suppressUpdate = false)
+        {
+            for (var i = 0; i < PageCount; i++)
+            {
+                if (_vramPage[i] == null)
+                {
+                    // X coordinates [0,256) store texture data.
+                    // X coordinates [256,512) store semi-transparency information for textures.
+                    _vramPage[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i);
+                    ClearPage(i, suppressUpdate);
+                }
+            }
+        }
+        
+        // Update page textures in the scene.
+        public void UpdatePage(uint index, bool force = false) => UpdatePage((int)index, force);
+
+        public void UpdatePage(int index, bool force = false)
+        {
+            if (force || _modifiedPage[index])
+            {
+                _scene.UpdateTexture(_vramPage[index].Bitmap, index);
+                _modifiedPage[index] = false;
+            }
+        }
+
+        public void UpdateAllPages()
+        {
+            for (var i = 0; i < PageCount; i++)
+            {
+                UpdatePage(i, false); // Only update page if modified.
+            }
+        }
+
+        // Clear page textures to background color.
+        public void ClearPage(uint index, bool suppressUpdate = false) => ClearPage((int)index, suppressUpdate);
+
+        public void ClearPage(int index, bool suppressUpdate = false)
+        {
+            using (var graphics = Graphics.FromImage(_vramPage[index].Bitmap))
+            {
+                graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+
+                // Clear texture data to background color.
+                graphics.Clear(BackgroundColor);
+
+                // Clear semi-transparent information to its default.
+                using (var brush = new SolidBrush(Texture.NoSemiTransparentFlag))
+                {
+                    graphics.FillRectangle(brush, PageSemiTransparencyX, 0, PageSize, PageSize);
+                }
+            }
+
+            if (suppressUpdate)
+            {
+                _modifiedPage[index] = true;
+            }
+            else
+            {
+                UpdatePage(index, true);
+            }
+        }
+
+        public void ClearAllPages()
+        {
+            for (var i = 0; i < PageCount; i++)
+            {
+                ClearPage(i);
+            }
+        }
+
+        // Draw texture onto page.
+        public void DrawTexture(Texture texture, bool suppressUpdate = false)
+        {
+            var index = texture.TexturePage;
+            var textureX = texture.X;
+            var textureY = texture.Y;
+            var textureWidth = texture.Width;
+            var textureHeight = texture.Height;
+            var textureBitmap = texture.Bitmap;
+            var textureSemiTransparentMap = texture.SemiTransparentMap;
+            using (var graphics = Graphics.FromImage(_vramPage[index].Bitmap))
+            {
+                // Use SourceCopy to overwrite image alpha with alpha stored in textures.
+                graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
+                graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+
+                // Draw the actual texture to VRAM.
+                // Clip drawing region so we don't draw over semi-transparent information.
+                graphics.SetClip(new Rectangle(0, 0, PageSize, PageSize));
+                graphics.DrawImage(textureBitmap, textureX, textureY, textureWidth, textureHeight);
+
+                // Draw semi-transparent information to VRAM in X coordinates [256,512).
+                graphics.SetClip(new Rectangle(PageSemiTransparencyX, 0, PageSize, PageSize));
+                if (textureSemiTransparentMap != null)
+                {
+                    graphics.DrawImage(textureSemiTransparentMap, PageSemiTransparencyX + textureX, textureY, textureWidth, textureHeight);
+                }
+                else
+                {
+                    using (var brush = new SolidBrush(Texture.NoSemiTransparentFlag))
+                    {
+                        graphics.FillRectangle(brush, PageSemiTransparencyX + textureX, textureY, textureWidth, textureHeight);
+                    }
+                }
+                graphics.ResetClip();
+            }
+
+            if (suppressUpdate)
+            {
+                _modifiedPage[index] = true;
+            }
+            else
+            {
+                UpdatePage(index, true);
+            }
+        }
+
+
+        public static uint ClampTexturePage(uint index) => (uint)ClampTexturePage((int)index);
+
+        public static int ClampTexturePage(int index)
+        {
+            return Math.Max(0, Math.Min(PageCount - 1, index));
+        }
+
+        public static int ClampTextureX(int x)
+        {
+            return Math.Max(0, Math.Min(PageSize - 1, x));
+        }
+
+        public static int ClampTextureY(int y)
+        {
+            return Math.Max(0, Math.Min(PageSize - 1, y));
+        }
+    }
+}

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -82,6 +82,8 @@
             this.showGizmosToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showBoundsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.enableLightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.enableTransparencyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.forceDoubleSidedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.autoAttachLimbsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.setAmbientColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -705,6 +707,8 @@
             this.showGizmosToolStripMenuItem,
             this.showBoundsToolStripMenuItem,
             this.enableLightToolStripMenuItem,
+            this.enableTransparencyToolStripMenuItem,
+            this.forceDoubleSidedToolStripMenuItem,
             this.autoAttachLimbsToolStripMenuItem,
             this.toolStripSeparator7,
             this.setAmbientColorToolStripMenuItem,
@@ -789,6 +793,24 @@
             this.enableLightToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
             this.enableLightToolStripMenuItem.Text = "Enable Light";
             this.enableLightToolStripMenuItem.Click += new System.EventHandler(this.enableLightToolStripMenuItem_Click);
+            // 
+            // enableTransparencyToolStripMenuItem
+            // 
+            this.enableTransparencyToolStripMenuItem.Checked = true;
+            this.enableTransparencyToolStripMenuItem.CheckOnClick = true;
+            this.enableTransparencyToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.enableTransparencyToolStripMenuItem.Name = "enableTransparencyToolStripMenuItem";
+            this.enableTransparencyToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.enableTransparencyToolStripMenuItem.Text = "Enable Transparency";
+            this.enableTransparencyToolStripMenuItem.Click += new System.EventHandler(this.enableTransparencyToolStripMenuItem_Click);
+            // 
+            // forceDoubleSidedToolStripMenuItem
+            // 
+            this.forceDoubleSidedToolStripMenuItem.CheckOnClick = true;
+            this.forceDoubleSidedToolStripMenuItem.Name = "forceDoubleSidedToolStripMenuItem";
+            this.forceDoubleSidedToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.forceDoubleSidedToolStripMenuItem.Text = "Force Double-Sided";
+            this.forceDoubleSidedToolStripMenuItem.Click += new System.EventHandler(this.forceDoubleSidedToolStripMenuItem_Click);
             // 
             // autoAttachLimbsToolStripMenuItem
             // 
@@ -1414,5 +1436,7 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel4;
         private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.ToolStripMenuItem enableTransparencyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem forceDoubleSidedToolStripMenuItem;
     }
 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Classes\PrimitiveDataType.cs" />
     <Compile Include="Classes\CrocModelReader.cs" />
     <Compile Include="Classes\PSXParser.cs" />
+    <Compile Include="Classes\RenderInfo.cs" />
     <Compile Include="Classes\RotationOrder.cs" />
     <Compile Include="Classes\Texture.cs" />
     <Compile Include="Classes\Color.cs" />
@@ -119,6 +120,7 @@
     <Compile Include="Classes\Triangle.cs" />
     <Compile Include="Classes\Utils.cs" />
     <Compile Include="Classes\VDFParser.cs" />
+    <Compile Include="Classes\VRAMPages.cs" />
     <Compile Include="Forms\DialogForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -16,6 +16,7 @@ uniform vec3 lightDirection;
 uniform vec3 maskColor;
 uniform vec3 ambientColor;
 uniform int renderMode;
+uniform int semiTransparentMode;
 uniform float lightIntensity;
 uniform sampler2D mainTex;
 


### PR DESCRIPTION
# Short explanation


## Rendering

This PR aims to support a variety of flags that effect how each mesh is rendered. This includes Unlit, Double-Sided, and Semi-transparent.

Semi-transparency required the most work to implement since it required storing the stp bit (MSB) found in all 16-bit colors. This was done by adding a second Bitmap to Texture that stores false as black, and true as white (This could not be stored in the alpha because textures may be used by both opaque and semi-transparent meshes. Additionally this would mess with texture exporting). To make sure this information is available to the shader, VRAM pages now create 512x256 textures, where x coordinates [256,512) hold the semi-transparent information drawn by textures. Lastly, the fragment shader has been updated to handle reading the stp bits by dividing the uv.x by 2 and adding 0.5 to the second lookup.

Mask color is now ignored when stp bit is SET. This fixes issues where portions of models would be invisible when they should be black.

The MeshBatch now performs drawing in 3 passes.
1. Opaque meshes
2. Semi-transparent meshes for pixels with stp bit UNSET (opaque pixels)
3. Semi-transparent meshes for pixels with stp bit SET (semi-transparent pixels)

The Preview form now has two new checkbox menu items under **Models**:
* **Enable Transparency:** Can be used to turn off semi-transparency behavior.
* **Force Double-Sided:** Can be used to use the old behavior of PSXPrev and double-side all polygons. Useful for viewing models from unintended angles.

## Refactoring

* VRAM page management has now been moved to a new `VRAMPages` class.
* `ManifestResourceLoader` can now load files from resources, but will default to the file system if the file exists.
* Improved cleanup handling of GDI objects. This still doesn't fix all cases though, like with textures that are lost when a parser fails.

***

# Detailed explanation

* Implemented RenderFlags, MixtureRate (ABR), and RenderInfo for separating meshes.
    * RenderInfo is a struct that stores TexturePage, RenderFlags, and MixtureRate.
    * Most instances where groupedTriangles are looked up via uint (TexturePage) are now looked up via RenderInfo.
* Added support for Unlit, DoubleSided, and SemiTransparency RenderFlags, along with support for all 4 MixtureRates.
    * For readers that don't support RenderFlags, DoubleSided is treated as the default flags (for now). This is because double-sided was already the default behavior for PSXPrev.
    * PMDParser supports DoubleSided.
    * TMDParser supports DoubleSided, Unlit, SemiTransparent (and MixtureRates).
    * HMDParser supports DoubleSided, Unlit, SemiTransparent (and MixtureRates).
* MeshBatch now draws meshes in 3 passes. The passes make things a bit more complex, and results in a lot of GL settings (that were originally handled by Scene) needing to be changed on a per-pass or per-mesh basis. This can be optimized in the future by grouping meshes of the same settings together.
    * Pass 1: Opaque meshes
    * Pass 2: Semi-transparent meshes for pixels with stp bit UNSET. (opaque pixels)
    * Pass 3: Semi-transparent meshes for pixels with stp bit SET. (semi-transparent pixels)
* Fixed PMDParser bailing on primitiveTypes with bits 0x30, because it treated those as an unknown structure, when in reality, these bits don't affect packet structure (as stated by the docs).
* Changed TIMParser allowOutOfBounds handling to check if there's enough room at the start of the function, rather than checking at each pixel. This fixes issues where loading all LRR data at once would produce some partially-invalid texture data. Now null is returned if there's not enough room, so invalid textures never make it to the party.
* Textures now store an additional Bitmap that contains semi-transparent data. This is simply a boolean flag (stored as black (false) and white (true)). TIMParser also handles reading in this semi-transparent data.
* Texture now implements IDisposable (although this isn't made us of yet).
* ManifestResourceLoader now fulfills its intended purpose of loading files from resources. By default, it will attempt to load from a filepath, and fallback to resources if the file isn't found.
* Added VRAMPages class to manage VRAM, and move management away from PreviewForm.
    * This class handles adding Semi-transparency data to pages by storing this data from X coordinates [256,512), so page textures are now 512x256 in size.
    * Includes static helper functions for clamping TexturePage, TextureX, and TextureY.
    * Includes functions for supressing updates to the scene textures, allowing for mass-drawing of textures and then updating each page afterwards.
    * Implements IDisposable (but this isn't made use of yet).
* Added uniform semiTransparentMode variable to fragment shader. This variable is used to detect which of the 3 drawing passes the mesh batch is on, and determines when to discard pixels.
* Fragment shader now only discards black (mask) pixels when stp bit is UNSET. This fixes a lot of models having gaps in the mesh where black should be.
* Added more instances of using and proper cleanup of GDI resources. Bitmaps for 3 PreviewForm color boxes are now stored as fields and updated, rather than creating new Bitmaps each time.
* Added 2 new PreviewForm checkbox menu items:
    * Models > Enable Transparency (checked). Can be used to turn off semi-transparency behavior.
    * Models > Force Double-Sided (unchecked). Can be used to use the old behavior of PSXPrev and double-side all polygons. Useful for viewing models from unintended angles.