### PR TITLE
Support tiled texture rendering

### DIFF
--- a/Classes/BFFModelReader.cs
+++ b/Classes/BFFModelReader.cs
@@ -623,17 +623,17 @@ namespace PSXPrev.Classes
                 },
                 Uv = new[]
                 {
-                    new Vector3
+                    new Vector2
                     {
                         X = u0/255f,
                         Y = v0/255f
                     },
-                    new Vector3
+                    new Vector2
                     {
                         X = u1/255f,
                         Y = v1/255f
                     },
-                    new Vector3
+                    new Vector2
                     {
                         X = u2/255f,
                         Y = v2/255f

--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -115,7 +115,7 @@ namespace PSXPrev.Classes
                         Vertices = new[] { vertex0, vertex1, vertex2 },
                         Normals = new[] { normal0, normal1, normal2 },
                         Colors = new[] { Color.Grey, Color.Grey, Color.Grey },
-                        Uv = new[] { Vector3.Zero, Vector3.Zero, Vector3.Zero },
+                        Uv = new[] { Vector2.Zero, Vector2.Zero, Vector2.Zero },
                         AttachableIndices = new [] {uint.MaxValue, uint.MaxValue, uint.MaxValue}
                     });
                     if ((primFlags & 0x8) != 0)
@@ -133,7 +133,7 @@ namespace PSXPrev.Classes
                             Vertices = new[] { vertex1, vertex3, vertex2 },
                             Normals = new[] { normal1, normal3, normal2 },
                             Colors = new[] { Color.Grey, Color.Grey, Color.Grey },
-                            Uv = new[] { Vector3.Zero, Vector3.Zero, Vector3.Zero },
+                            Uv = new[] { Vector2.Zero, Vector2.Zero, Vector2.Zero },
                             AttachableIndices = new[] { uint.MaxValue, uint.MaxValue, uint.MaxValue }
                         });
                     }

--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -1089,7 +1089,7 @@ namespace PSXPrev.Classes
                         uint tPage;
                         Color color;
                         Vector3 n0, n1, n2, n3;
-                        Vector3 uv0, uv1, uv2, uv3;
+                        Vector2 uv0, uv1, uv2, uv3;
 
                         var renderFlags = RenderFlags.None; // todo
                         var mixtureRate = MixtureRate.None;
@@ -1108,7 +1108,7 @@ namespace PSXPrev.Classes
 
                             reader.ReadUInt16();
                             tPage = 0;
-                            uv0 = uv1 = uv2 = uv3 = Vector3.Zero;
+                            uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
                         }
                         else
                         {
@@ -1117,7 +1117,7 @@ namespace PSXPrev.Classes
 
                             //todo
                             tPage = 0;
-                            uv0 = uv1 = uv2 = uv3 = Vector3.Zero;
+                            uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
 
                             color = Color.Grey;
                             n0 = n1 = n2 = n3 = Vector3.Zero;

--- a/Classes/Logger.cs
+++ b/Classes/Logger.cs
@@ -37,10 +37,13 @@ namespace PSXPrev.Classes
             Console.ForegroundColor = ConsoleColor.White;
             Write(format, args);
         }
-
         public void WriteLine(object text)
         {
-            WriteLine("{0}", new[] { text });
+            WriteLine("{0}", text);
+        }
+        public void WriteLine(string text)
+        {
+            WriteLine("{0}", text);
         }
 
         public void WriteErrorLine(string format, params object[] args)
@@ -50,7 +53,11 @@ namespace PSXPrev.Classes
         }
         public void WriteErrorLine(object text)
         {
-            WriteErrorLine("{0}", new[] { text });
+            WriteErrorLine("{0}", text);
+        }
+        public void WriteErrorLine(string text)
+        {
+            WriteErrorLine("{0}", text);
         }
 
 
@@ -59,10 +66,13 @@ namespace PSXPrev.Classes
             Console.ForegroundColor = ConsoleColor.Green;
             Write(format, args);
         }
-
         public void WritePositiveLine(object text)
         {
-            WritePositiveLine("{0}", new[] { text });
+            WritePositiveLine("{0}", text);
+        }
+        public void WritePositiveLine(string text)
+        {
+            WritePositiveLine("{0}", text);
         }
 
         public void Dispose()

--- a/Classes/Mesh.cs
+++ b/Classes/Mesh.cs
@@ -6,7 +6,7 @@ namespace PSXPrev.Classes
 {
     public class Mesh
     {
-        private const int BufferCount = 4;
+        private const int BufferCount = 5;
 
         public Matrix4 WorldMatrix { get; set; }
         public uint Texture { get; set; }
@@ -20,6 +20,7 @@ namespace PSXPrev.Classes
         private uint _colorBuffer;
         private uint _normalBuffer;
         private uint _uvBuffer;
+        private uint _tiledAreaBuffer;
 
         private readonly uint[] _ids;
 
@@ -39,10 +40,11 @@ namespace PSXPrev.Classes
         private void GenBuffer()
         {
             GL.GenBuffers(BufferCount, _ids);
-            _positionBuffer = _ids[0];
-            _colorBuffer = _ids[1];
-            _normalBuffer = _ids[2];
-            _uvBuffer = _ids[3];
+            _positionBuffer  = _ids[0];
+            _colorBuffer     = _ids[1];
+            _normalBuffer    = _ids[2];
+            _uvBuffer        = _ids[3];
+            _tiledAreaBuffer = _ids[4];
         }
 
         public void Draw(TextureBinder textureBinder = null, bool wireframe = false)
@@ -63,7 +65,11 @@ namespace PSXPrev.Classes
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBuffer);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexUv);
-            GL.VertexAttribPointer((uint)Scene.AttributeIndexUv, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+            GL.VertexAttribPointer((uint)Scene.AttributeIndexUv, 2, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _tiledAreaBuffer);
+            GL.EnableVertexAttribArray((uint)Scene.AttributeIndexTiledArea);
+            GL.VertexAttribPointer((uint)Scene.AttributeIndexTiledArea, 4, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
             if (textureBinder != null && Texture != 0)
             {
@@ -83,37 +89,42 @@ namespace PSXPrev.Classes
             GL.BindVertexArray(0);
         }
 
-        public void SetData(int numElements, float[] positionList, float[] normalList, float[] colorList, float[] uvList)//, int[] indexList)
+        public void SetData(int numElements, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList = null)
         {
             _numElements = numElements;
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBuffer);
-            BufferData(positionList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _normalBuffer);
-            BufferData(normalList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _colorBuffer);
-            BufferData(colorList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBuffer);
-            BufferData(uvList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            BufferData(_positionBuffer,  positionList,  3);
+            BufferData(_normalBuffer,    normalList,    3);
+            BufferData(_colorBuffer,     colorList,     3);
+            BufferData(_uvBuffer,        uvList,        2);
+            BufferData(_tiledAreaBuffer, tiledAreaList, 4);
         }
 
-        private void BufferData(float[] list)
+        // Passing null for list will fill the data with zeros.
+        private void BufferData(uint buffer, float[] list, int elementSize)
         {
+            if (list == null)
+            {
+                list = new float[_numElements * elementSize]; // Treat null as zeroed data.
+            }
             var size = (IntPtr)(list.Length * sizeof(float));
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);
             GL.BufferData(BufferTarget.ArrayBuffer, size, list, BufferUsageHint.StaticDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
         }
 
-        //private void BufferData(int[] list)
+        //private void BufferData(uint buffer, int[] list, int elementSize)
         //{
+        //    if (list == null)
+        //    {
+        //        list = new float[_numElements * elementSize]; // Treat null as zeroed data.
+        //    }
         //    var size = (IntPtr)(list.Length * sizeof(int));
+        //
+        //    GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);
         //    GL.BufferData(BufferTarget.ArrayBuffer, size, list, BufferUsageHint.StaticDraw);
+        //    GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
         //}
     }
 }

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -30,6 +30,20 @@ namespace PSXPrev.Classes
         [DisplayName("TMD ID")]
         public uint TMDID { get; set; }
 
+        [ReadOnly(true), DisplayName("Has Tiled Texture")]
+        public bool HasTiled
+        {
+            get
+            {
+                foreach (var triangle in Triangles)
+                {
+                    if (triangle.IsTiled)
+                        return true;
+                }
+                return false;
+            }
+        }
+
        //[ReadOnly(true)]
        //public uint PrimitiveIndex { get; set; }
 

--- a/Classes/PMDParser.cs
+++ b/Classes/PMDParser.cs
@@ -868,17 +868,17 @@ namespace PSXPrev.Classes
                 },
                 Uv = new[]
                 {
-                    new Vector3
+                    new Vector2
                     {
                         X = u0/255f,
                         Y = v0/255f
                     },
-                    new Vector3
+                    new Vector2
                     {
                         X = u1/255f,
                         Y = v1/255f
                     },
-                    new Vector3
+                    new Vector2
                     {
                         X = u2/255f,
                         Y = v2/255f

--- a/Classes/PSXParser.cs
+++ b/Classes/PSXParser.cs
@@ -214,10 +214,10 @@ namespace PSXPrev.Classes
                         var normal1 = normals[planeIndex];
                         var normal2 = normals[planeIndex];
                         var normal3 = normals[planeIndex];
-                        var uv0 = Vector3.Zero;
-                        var uv1 = Vector3.Zero;
-                        var uv2 = Vector3.Zero;
-                        var uv3 = Vector3.Zero;
+                        var uv0 = Vector2.Zero;
+                        var uv1 = Vector2.Zero;
+                        var uv2 = Vector2.Zero;
+                        var uv3 = Vector2.Zero;
                         uint tPage = 0;
                         if (textured)
                         {
@@ -230,10 +230,10 @@ namespace PSXPrev.Classes
                             var v2 = reader.ReadByte() / 255f;
                             var u3 = reader.ReadByte() / 255f;
                             var v3 = reader.ReadByte() / 255f;
-                            uv0 = new Vector3(u0, v0, 0f);
-                            uv1 = new Vector3(u1, v1, 0f);
-                            uv2 = new Vector3(u2, v2, 0f);
-                            uv3 = new Vector3(u3, v3, 0f);
+                            uv0 = new Vector2(u0, v0);
+                            uv1 = new Vector2(u1, v1);
+                            uv2 = new Vector2(u2, v2);
+                            uv3 = new Vector2(u3, v3);
                         }
                         if (!invisible)
                         {
@@ -311,10 +311,10 @@ namespace PSXPrev.Classes
                         var normal1 = normals[planeIndex];
                         var normal2 = normals[planeIndex];
                         var normal3 = normals[planeIndex];
-                        var uv0 = Vector3.Zero;
-                        var uv1 = Vector3.Zero;
-                        var uv2 = Vector3.Zero;
-                        var uv3 = Vector3.Zero;
+                        var uv0 = Vector2.Zero;
+                        var uv1 = Vector2.Zero;
+                        var uv2 = Vector2.Zero;
+                        var uv3 = Vector2.Zero;
                         uint tPage = 0;
                         if (textured)
                         {
@@ -327,10 +327,10 @@ namespace PSXPrev.Classes
                             var v2 = reader.ReadByte() / 255f;
                             var u3 = reader.ReadByte() / 255f;
                             var v3 = reader.ReadByte() / 255f;
-                            uv0 = new Vector3(u0, v0, 0f);
-                            uv1 = new Vector3(u1, v1, 0f);
-                            uv2 = new Vector3(u2, v2, 0f);
-                            uv3 = new Vector3(u3, v3, 0f);
+                            uv0 = new Vector2(u0, v0);
+                            uv1 = new Vector2(u1, v1);
+                            uv2 = new Vector2(u2, v2);
+                            uv3 = new Vector2(u3, v3);
                         }
                         if (!invisible)
                         {

--- a/Classes/Scene.cs
+++ b/Classes/Scene.cs
@@ -28,7 +28,8 @@ namespace PSXPrev.Classes
         public static int AttributeIndexColour = 1;
         public static int AttributeIndexNormal = 2;
         public static int AttributeIndexUv = 3;
-        public static int AttributeIndexTexture = 4;
+        public static int AttributeIndexTiledArea = 4;
+        public static int AttributeIndexTexture = 5;
 
         public static int UniformIndexMVP;
         public static int UniformIndexLightDirection;
@@ -42,6 +43,7 @@ namespace PSXPrev.Classes
         public const string AttributeNameColour = "in_Color";
         public const string AttributeNameNormal = "in_Normal";
         public const string AttributeNameUv = "in_Uv";
+        public const string AttributeNameTiledArea = "in_TiledArea";
         public const string AttributeNameTexture = "mainTex";
 
         public const string UniformNameMVP = "mvpMatrix";
@@ -219,6 +221,7 @@ namespace PSXPrev.Classes
                 {AttributeIndexNormal, AttributeNameNormal},
                 {AttributeIndexColour, AttributeNameColour},
                 {AttributeIndexUv, AttributeNameUv},
+                {AttributeIndexTiledArea, AttributeNameTiledArea},
                 {AttributeIndexTexture, AttributeNameTexture}
             };
             foreach (var vertexAttributeLocation in attributes)

--- a/Classes/TMDHelper.cs
+++ b/Classes/TMDHelper.cs
@@ -410,8 +410,6 @@ namespace PSXPrev.Classes
             return primitiveDataDictionary;
         }
 
-        public static HashSet<MixtureRate> mixtureRates = new HashSet<MixtureRate>();
-
         public static void AddTrianglesToGroup(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, Dictionary<PrimitiveDataType, uint> primitiveData, RenderFlags renderFlags, bool attached, Func<uint, Vector3> vertexCallback, Func<uint, Vector3> normalCallback)
         {
             var tPage = primitiveData.TryGetValue(PrimitiveDataType.TSB, out var tsbValue) ? tsbValue & 0x1F : 0;

--- a/Classes/TiledUV.cs
+++ b/Classes/TiledUV.cs
@@ -1,0 +1,47 @@
+﻿using OpenTK;
+
+namespace PSXPrev.Classes
+{
+    public class TiledUV
+    {
+        public Vector2[] BaseUv { get; set; }
+        public Vector2 Offset { get; set; } // Position added to BaseUv after wrapping.
+        public Vector2 Size { get; set; }   // Denominator of modulus with BaseUv for wrapping.
+
+        public Vector4 Area => new Vector4(Offset.X, Offset.Y, Size.X, Size.Y);
+
+        public TiledUV(Vector2[] baseUv, float x, float y, float width, float height)
+        {
+            BaseUv = baseUv;
+            Offset = new Vector2(x, y);
+            Size   = new Vector2(width, height);
+        }
+
+        public TiledUV(TiledUV fromTiledUv)
+        {
+            BaseUv = fromTiledUv.BaseUv;
+            Offset = fromTiledUv.Offset;
+            Size   = fromTiledUv.Size;
+        }
+
+        // This function isn't used, since the tiled (display) UV can be calculated with integer math.
+        public Vector2[] ConvertBaseUv()
+        {
+            var uv = new Vector2[BaseUv.Length];
+            for (var i = 0; i < uv.Length; i++)
+            {
+                uv[i] = Convert(BaseUv[i], Offset.X, Offset.Y, Size.X, Size.Y);
+            }
+            return uv;
+        }
+
+        public Vector2 Convert(Vector2 uv) => Convert(uv, Offset.X, Offset.Y, Size.X, Size.Y);
+
+
+        public static Vector2 Convert(Vector2 uv, float x, float y, float width, float height)
+        {
+            return new Vector2((width  == 0f ? uv.X : (x + uv.X % width)),
+                               (height == 0f ? uv.Y : (y + uv.Y % height)));
+        }
+    }
+}

--- a/Classes/Triangle.cs
+++ b/Classes/Triangle.cs
@@ -56,7 +56,14 @@ namespace PSXPrev.Classes
         public Vector3[] Normals { get; set; }
 
         [Browsable(false)]
-        public Vector3[] Uv { get; set; }
+        public Vector2[] Uv { get; set; }
+
+        // Defines the area of the texture page that Uv is wrapped around.
+        [Browsable(false)]
+        public TiledUV TiledUv { get; set; }
+
+        [Browsable(false)]
+        public bool IsTiled => TiledUv != null;
 
         [Browsable(false)]
         public Color[] Colors { get; set; }
@@ -89,11 +96,13 @@ namespace PSXPrev.Classes
             Vertices = fromTriangle.Vertices;
             Normals = fromTriangle.Normals;
             Uv = fromTriangle.Uv;
+            TiledUv = fromTriangle.TiledUv;
             Colors = fromTriangle.Colors;
             OriginalVertexIndices = fromTriangle.OriginalVertexIndices;
             OriginalNormalIndices = fromTriangle.OriginalNormalIndices;
             AttachableIndices = fromTriangle.AttachableIndices;
             AttachedIndices = fromTriangle.AttachedIndices;
+            AttachedNormalIndices = fromTriangle.AttachedNormalIndices;
         }
     }
 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Classes\PngExporter.cs" />
     <Compile Include="Classes\PXLParser.cs" />
     <Compile Include="Classes\TextureBinder.cs" />
+    <Compile Include="Classes\TiledUV.cs" />
     <Compile Include="Classes\TMDHelper.cs" />
     <Compile Include="Classes\TMDParser.cs" />
     <Compile Include="Classes\RootEntitySelectorEditor.cs" />

--- a/Shaders/Shader.frag
+++ b/Shaders/Shader.frag
@@ -1,5 +1,6 @@
 ﻿#version 150
 in vec2 pass_Uv;
+in vec4 pass_TiledArea;
 in vec4 pass_Ambient;
 in vec4 pass_Color;
 
@@ -24,20 +25,34 @@ void main(void) {
 	}
 	vec4 finalColor;
 	if (renderMode == 0 || renderMode == 1) {
-		vec4 tex2D = texture(mainTex, vec2(pass_Uv.x * 0.5,       pass_Uv.y));
-		vec4 stp2D = texture(mainTex, vec2(pass_Uv.x * 0.5 + 0.5, pass_Uv.y));
-		int stp = (stp2D.x == 0.0 ? 0 : 1);
-		if (stp == 0 && tex2D.xyz == maskColor) {
+		vec2 uv = pass_Uv;
+		// X,Y is tiled U,V offset and Z,W is tiled U,V wrap size.
+		if (pass_TiledArea.z != 0.0) {
+			uv.x = pass_TiledArea.x + mod(pass_Uv.x, pass_TiledArea.z);
+		}
+		if (pass_TiledArea.w != 0.0) {
+			uv.y = pass_TiledArea.y + mod(pass_Uv.y, pass_TiledArea.w);
+		}
+		//if (pass_TiledArea.z != 0.0 && pass_TiledArea.w != 0.0) {
+		//	uv = pass_TiledArea.xy + mod(pass_Uv, pass_TiledArea.zw);
+		//}
+
+		vec4 tex2D = texture(mainTex, vec2(uv.x * 0.5,       uv.y));
+		vec4 stp2D = texture(mainTex, vec2(uv.x * 0.5 + 0.5, uv.y));
+		bool stp = (stp2D.x != 0.0);
+
+		if (!stp && tex2D.xyz == maskColor) {
 			discard; // Black surfaces are transparent when stp bit is unset.
 		} else if (semiTransparentMode == 1) {
-			if (stp == 1) {
+			if (stp) {
 				discard; // Semi-transparent surface during no-stp bit pass.
 			}
 		} else if (semiTransparentMode == 2) {
-			if (stp == 0) {
+			if (!stp) {
 				discard; // Opaque surface during stp bit pass.
 			}
 		}
+
 		if (renderMode == 0) {
 			finalColor = (pass_Ambient + pass_NormalDotLight) * tex2D * pass_Color;
 		} else {

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -2,9 +2,11 @@
 in vec3 in_Position;
 in vec3 in_Color; 
 in vec3 in_Normal;
-in vec3 in_Uv;
+in vec2 in_Uv;
+in vec4 in_TiledArea;
 
 out vec2 pass_Uv;
+out vec4 pass_TiledArea;
 out vec4 pass_Ambient;
 out vec4 pass_Color;
 out float pass_NormalDotLight;
@@ -27,7 +29,8 @@ void main(void) {
 	discardPixel = step(discardValue, in_Position.x);
 	pass_NormalDotLight = clamp(dot(in_Normal, lightDirection), 0.0, 1.0) * lightIntensity;
 	pass_NormalLength = length(in_Normal);
-	pass_Uv = in_Uv.st;
+	pass_Uv = in_Uv;
+	pass_TiledArea = in_TiledArea;
 	pass_Ambient = vec4(ambientColor, 1.0);
 	pass_Color = vec4(in_Color, 1.0);
 }


### PR DESCRIPTION
## Renderer change
This fully implements renderer support for tiled textures. This works by taking the `tuva` and `tuvm` values from the `TILE` data of a packet, and restoring them to their original values. `tuva` points to the starting offset where wrapping occurs, and `tuvm` describes the size of the area that will be wrapped. UV coordinates are treated as base coordinates, where (0,0) is the start of `tuva`. When UV coordinates exceed the boundaries of `tuvm`, they will be wrapped.

To handle texture tiling, the fragment shader needed to be updated to receive the tiled area coordinates, and to perform tiled conversion on the UV coordinates. It's assumed that tiling width and tiling height can be independently assigned, meaning if the tiled width is zero, tiled height could still be non-zero and only affect the V coordinate, and so on.

**Note:** Objects **will not** be exported with tiled textures, because there's currently no way to preserve that information. Only the renderer can display tiled textures correctly. Exported models will have UVs displayed like they were before this commit, with each vertex UV converted to their tiled counterparts.

## Refactor changes
* Changed local variable `stp` in fragment shader to a bool... Because I didn't know bool was a supported type before.
* `Triangle.Uv` and `in_Uv` are now Vector2s instead of Vector3s.
* Mesh.SetData now allows null for individual list arguments. When null is passed, a zeroed list is created for assinging the buffer data.
* Mesh.BufferData now performs all 3 GL calls, and handles creating a zeroed list when null. (Note that passing a null list instead to the GL call *is* valid, but this will produce garbage data).
* Simplified MeshBatch.BindCube by skipping assignment of normalList and uvList, since they can now be passed as null.
* Refactored MeshBatch.BindCube and BindMesh to handle assigning to lists of different element sizes (UVs and tiled areas).
* Added TiledUV class to store tiled UV/area information in Triangles.
* Added `IsTiled` property to Triangles, which returns true if the `TiledUv` property is non-null.
* Added "Has Tiled Textures" display property to ModelEntity.
* Fixed Triangle fromTriangle constructor not assigning `AttachedNormalIndices`, and also added assignment for `TiledUv`.
* Added `Logger.Write*Line(string)` function overloads because passing just a string would default to calling the format args overload, which would treat text as a format string.

