### PR TITLE
Fix HMD no-light numColors and other packet issues

### DIFF
--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -547,24 +547,32 @@ namespace PSXPrev.Classes
                 var packetStructure = TMDHelper.CreateHMDPacketStructure(driver, flag, reader, out var renderFlags, out var primitiveType);
                 if (packetStructure != null)
                 {
-                    TMDHelper.AddTrianglesToGroup(primitiveType, groupedTriangles, packetStructure, renderFlags, shared,
-                        index =>
-                        {
-                            if (shared)
-                            {
-                                return Vector3.Zero; // This is an attached vertex.
-                            }
-                            return ReadVertex(reader, vertTop, index);
-                        },
-                        index =>
-                        {
-                            if (shared)
-                            {
-                                return Vector3.UnitZ; // This is an attached normal. Return Unit vector in-case it somehow gets used in a calculation.
-                            }
-                            return ReadNormal(reader, normTop, index);
-                        }
-                    );
+                    switch (primitiveType)
+                    {
+                        case PrimitiveType.Triangle:
+                        case PrimitiveType.Quad:
+                            TMDHelper.AddTrianglesToGroup(primitiveType, groupedTriangles, packetStructure, renderFlags, shared,
+                                index =>
+                                {
+                                    if (shared)
+                                    {
+                                        return Vector3.Zero; // This is an attached vertex.
+                                    }
+                                    return ReadVertex(reader, vertTop, index);
+                                },
+                                index =>
+                                {
+                                    if (shared)
+                                    {
+                                        return Vector3.UnitZ; // This is an attached normal. Return Unit vector in-case it somehow gets used in a calculation.
+                                    }
+                                    return ReadNormal(reader, normTop, index);
+                                }
+                            );
+                            break;
+                        case PrimitiveType.StripMesh:
+                            break;
+                    }
                 }
             }
             reader.BaseStream.Seek(primitivePosition, SeekOrigin.Begin);

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -44,18 +44,23 @@ namespace PSXPrev.Classes
             }
         }
 
-       //[ReadOnly(true)]
-       //public uint PrimitiveIndex { get; set; }
+        //[ReadOnly(true)]
+        //public uint PrimitiveIndex { get; set; }
 
         [Browsable(false)]
         public int MeshIndex { get; set; }
 
         public bool Visible { get; set; } = true;
 
+        [Browsable(false)]
         public float Interpolator { get; set; }
+        [Browsable(false)]
         public Vector3[] InitialVertices { get; set; }
+        [Browsable(false)]
         public Vector3[] FinalVertices { get; set; }
+        [Browsable(false)]
         public Vector3[] FinalNormals { get; set; }
+        [Browsable(false)]
         public Vector3[] InitialNormals { get; set; }
 
         // HMD: Attachable (shared) vertices and normals that aren't tied to an existing triangle.

--- a/Classes/PMDParser.cs
+++ b/Classes/PMDParser.cs
@@ -62,10 +62,11 @@ namespace PSXPrev.Classes
                     }
                     var primType = reader.ReadUInt16();
 
-                    var lgtCalcBit = ((primType >> 4) & 0x1) == 1; // Light source calc: 0-Off, 1-On
-                    var botBit     = ((primType >> 5) & 0x1) == 1; // Both sides: 0-Single sided, 1-Double sided
+                    var lgtBit = ((primType >> 4) & 0x1) == 1; // Light: 0-Unlit, 1-Lit
+                    var botBit = ((primType >> 5) & 0x1) == 1; // Both sides: 0-Single sided, 1-Double sided
 
                     var renderFlags = RenderFlags.None;
+                    if (!lgtBit) renderFlags |= RenderFlags.Unlit;
                     if (botBit) renderFlags |= RenderFlags.DoubleSided;
 
                     var primTypeSwitch = primType & ~0x30; // These two bits don't effect packet structure

--- a/Classes/PrimitiveType.cs
+++ b/Classes/PrimitiveType.cs
@@ -2,8 +2,12 @@
 {
     public enum PrimitiveType
     {
-        Polygon = 0b001,
-        StraightLine = 0b010,
-        Sprite = 0b011
+        None,
+
+        Triangle,
+        Quad,
+        StraightLine,
+        Sprite,
+        StripMesh,
     }
 }

--- a/Classes/Scene.cs
+++ b/Classes/Scene.cs
@@ -298,7 +298,7 @@ namespace PSXPrev.Classes
             GL.Uniform1(UniformLightIntensity, LightIntensity);
             GL.Uniform1(UniformRenderMode, LightEnabled ? 0 : 1);
             GL.Uniform1(UniformSemiTransparentMode, 0);
-            MeshBatch.Draw(_viewMatrix, _projectionMatrix, TextureBinder, Wireframe, standard: true, VerticesOnly);
+            MeshBatch.Draw(_viewMatrix, _projectionMatrix, TextureBinder, Wireframe, true, VerticesOnly);
             GL.Uniform1(UniformRenderMode, 2);
             if (ShowBounds)
             {

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -171,7 +171,8 @@ namespace PSXPrev.Classes
                     {
                         switch (primitiveType)
                         {
-                            case PrimitiveType.Polygon:
+                            case PrimitiveType.Triangle:
+                            case PrimitiveType.Quad:
                                 TMDHelper.AddTrianglesToGroup(primitiveType, groupedTriangles, packetStructure, renderFlags, false, delegate (uint index)
                                 {
                                     if (index >= vertices.Length)


### PR DESCRIPTION
## Actual changes
* Fixed numColors for HMD not being numVerts when !light && gouraud. In this case, the gradation bit is ignored. This fixes parsing for some models.
* Added support for Unlit render flag in PMDParser, because before I didn't realise Unlit == No light source calculation.
* Made animation state variables in ModelEntity unbrowsable.
* Fixed `standard:` argument name in Scene appearing before an un-named argument. This was breaking compiling.

## Refactor changes
* Changed lmdBit when parsing HMD packet to being inverted to match that false == no normals.
* Added other unused bits when parsing HMD packet.
* Changed PrimitiveType to be assigned with a switch statement for the code, because casting from code wouldn't work for both TMD and HMD.
* Removed PrimitiveType Polygon and replaced it with Triangle and Quad. Also added StripMesh and None.
* HMDParser now uses primitiveType switch statement like TMDParser.