### PR TITLE
Refactor LineMesh to match changes made to Mesh

### DIFF
--- a/Classes/LineBatch.cs
+++ b/Classes/LineBatch.cs
@@ -35,45 +35,37 @@ namespace PSXPrev.Classes
             {
                 return;
             }
-            var numPoints = numLines * 2;
-            var elementCount = numPoints * 3;
+            var numElements = numLines * 2;
             var baseIndex = 0;
-            var positionList = new float[elementCount];
-            var normalList = new float[elementCount];
-            var colorList = new float[elementCount];
-            var uvList = new float[elementCount];
+            var positionList = new float[numElements * 3]; // Vector3
+            var colorList    = new float[numElements * 3]; // Vector3 (Color)
             for (var l = 0; l < numLines; l++)
             {
                 var line = _lines[l];
-                FillVertex(line.P1, line.Color, ref baseIndex, ref positionList, ref normalList, ref colorList, ref uvList);
-                FillVertex(line.P2, line.Color, ref baseIndex, ref positionList, ref normalList, ref colorList, ref uvList);
+                FillVertex(line.P1, line.Color, ref baseIndex, ref positionList, ref colorList);
+                FillVertex(line.P2, line.Color, ref baseIndex, ref positionList, ref colorList);
             }
             var lineMesh = GetLine(0);
-            lineMesh.SetData(numPoints, positionList, normalList, colorList, uvList);
+            lineMesh.SetData(numElements, positionList, null, colorList, null);
             Draw(viewMatrix, projectionMatrix, width);
         }
 
-        private static void FillVertex(Vector4 position, Color color, ref int baseIndex, ref float[] positionList, ref float[] normalList, ref float[] colorList, ref float[] uvList)
+        private static void FillVertex(Vector4 position, Color color, ref int baseIndex, ref float[] positionList, ref float[] colorList)
         {
-            var index1 = baseIndex++;
-            var index2 = baseIndex++;
-            var index3 = baseIndex++;
+            var index3d = baseIndex * 3;
+            baseIndex++;
 
-            positionList[index1] = position.X;
-            positionList[index2] = position.Y;
-            positionList[index3] = position.Z;
+            positionList[index3d + 0] = position.X;
+            positionList[index3d + 1] = position.Y;
+            positionList[index3d + 2] = position.Z;
 
-            normalList[index1] = 0f;
-            normalList[index2] = 0f;
-            normalList[index3] = 0f;
+            // Normals are all 0f (passing null will default to a zeroed list).
 
-            colorList[index1] = color.R;
-            colorList[index2] = color.G;
-            colorList[index3] = color.B;
+            colorList[index3d + 0] = color.R;
+            colorList[index3d + 1] = color.G;
+            colorList[index3d + 2] = color.B;
 
-            uvList[index1] = 0f;
-            uvList[index2] = 0f;
-            uvList[index3] = 0f;
+            // UVs are all 0f (passing null will default to a zeroed list).
         }
 
         private void ResetMeshes(int nLines)

--- a/Classes/LineMesh.cs
+++ b/Classes/LineMesh.cs
@@ -5,7 +5,7 @@ namespace PSXPrev.Classes
 {
     public class LineMesh
     {
-        private const int BufferCount = 4;
+        private const int BufferCount = 5;
 
         private readonly uint _meshId;
         private int _numElements;
@@ -14,6 +14,7 @@ namespace PSXPrev.Classes
         private uint _colorBuffer;
         private uint _normalBuffer;
         private uint _uvBuffer;
+        private uint _tiledAreaBuffer;
 
         private readonly uint[] _ids;
 
@@ -32,10 +33,11 @@ namespace PSXPrev.Classes
         private void GenBuffer()
         {
             GL.GenBuffers(BufferCount, _ids);
-            _positionBuffer = _ids[0];
-            _colorBuffer = _ids[1];
-            _normalBuffer = _ids[2];
-            _uvBuffer = _ids[3];
+            _positionBuffer  = _ids[0];
+            _colorBuffer     = _ids[1];
+            _normalBuffer    = _ids[2];
+            _uvBuffer        = _ids[3];
+            _tiledAreaBuffer = _ids[4];
         }
 
         public void Draw(float width = 1f)
@@ -56,7 +58,11 @@ namespace PSXPrev.Classes
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBuffer);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexUv);
-            GL.VertexAttribPointer((uint)Scene.AttributeIndexUv, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+            GL.VertexAttribPointer((uint)Scene.AttributeIndexUv, 2, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _tiledAreaBuffer);
+            GL.EnableVertexAttribArray((uint)Scene.AttributeIndexTiledArea);
+            GL.VertexAttribPointer((uint)Scene.AttributeIndexTiledArea, 4, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
             GL.LineWidth(width);
             GL.DrawArrays(OpenTK.Graphics.OpenGL.PrimitiveType.Lines, 0, _numElements);
@@ -66,40 +72,36 @@ namespace PSXPrev.Classes
             GL.BindVertexArray(0);
         }
 
-        public void SetData(int numElements, float[] positionList, float[] normalList, float[] colorList, float[] uvList)
+        public void SetData(int numElements, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList = null)
         {
             _numElements = numElements;
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBuffer);
-            BufferData(positionList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _normalBuffer);
-            BufferData(normalList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _colorBuffer);
-            BufferData(colorList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBuffer);
-            BufferData(uvList);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            BufferData(_positionBuffer,  positionList,  3);
+            BufferData(_normalBuffer,    normalList,    3);
+            BufferData(_colorBuffer,     colorList,     3);
+            BufferData(_uvBuffer,        uvList,        2);
+            BufferData(_tiledAreaBuffer, tiledAreaList, 4);
         }
 
         //public void SetData(int numElements, float[] positionList)
         //{
         //    _numElements = numElements;
         //
-        //    GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBuffer);
-        //    BufferData(positionList);
-        //    GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        //    BufferData(_positionBuffer,  positionList,  3);
         //}
 
-        public void BufferData(float[] list)
+        // Passing null for list will fill the data with zeros.
+        private void BufferData(uint buffer, float[] list, int elementSize)
         {
+            if (list == null)
+            {
+                list = new float[_numElements * elementSize]; // Treat null as zeroed data.
+            }
             var size = (IntPtr)(list.Length * sizeof(float));
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);
             GL.BufferData(BufferTarget.ArrayBuffer, size, list, BufferUsageHint.StaticDraw);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
         }
     }
 }


### PR DESCRIPTION
* LineMesh now also has the `_tiledAreaBuffer` field.
* LineMesh UVs buffer is now 2D instead of 3D.
* LineMesh now accepts null lists, and will default these to all zeroed values.
* SetData now handles all three GL calls.
* Refactored LineBatch SetupAndDraw and FillVertex to skip normals and UVs.