### PR TITLE
Support HMD strip mesh packets

### DIFF
--- a/Classes/FileOffsetScanner.cs
+++ b/Classes/FileOffsetScanner.cs
@@ -96,7 +96,7 @@ namespace PSXPrev.Classes
                 {
                     //if (Program.Debug)
                     //{
-                    //    Program.Logger.WriteLine(exp);
+                    //    Program.Logger.WriteErrorLine(exp);
                     //}
                 }
 

--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -544,14 +544,15 @@ namespace PSXPrev.Classes
 
             for (var j = 0; j < dataCount; j++)
             {
-                var packetStructure = TMDHelper.CreateHMDPacketStructure(driver, flag, reader, out var renderFlags, out var primitiveType);
+                var packetStructure = TMDHelper.CreateHMDPacketStructure(driver, flag, reader);
                 if (packetStructure != null)
                 {
-                    switch (primitiveType)
+                    switch (packetStructure.PrimitiveType)
                     {
                         case PrimitiveType.Triangle:
                         case PrimitiveType.Quad:
-                            TMDHelper.AddTrianglesToGroup(primitiveType, groupedTriangles, packetStructure, renderFlags, shared,
+                        case PrimitiveType.StripMesh:
+                            TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, shared,
                                 index =>
                                 {
                                     if (shared)
@@ -567,10 +568,7 @@ namespace PSXPrev.Classes
                                         return Vector3.UnitZ; // This is an attached normal. Return Unit vector in-case it somehow gets used in a calculation.
                                     }
                                     return ReadNormal(reader, normTop, index);
-                                }
-                            );
-                            break;
-                        case PrimitiveType.StripMesh:
+                                });
                             break;
                     }
                 }

--- a/Classes/PrimitiveData.cs
+++ b/Classes/PrimitiveData.cs
@@ -1,0 +1,309 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace PSXPrev.Classes
+{
+    public class PrimitiveData
+    {
+        // Vertex type used for repeat mesh packets.
+        public const PrimitiveDataType MESHVERTEX = PrimitiveDataType.VERTEX0;
+
+
+        public PrimitiveType PrimitiveType { get; set; }
+        public RenderFlags RenderFlags { get; set; }
+
+        public int MeshLength { get; private set; } = 1;
+
+        // We have a separate dictionary for Data at index 0 as an optimization
+        // for reading packets that are generally never meshes.
+        public Dictionary<PrimitiveDataType, uint> Data { get; private set; } = new Dictionary<PrimitiveDataType, uint>();
+        public Dictionary<PrimitiveDataType, uint[]> MeshData { get; private set; } // Excludes index 0, which is in Data
+
+        public int[] PadCount { get; private set; } = new int[1]; // Includes index 0
+
+        private bool UseMeshData => MeshLength > 1;
+
+        public uint this[int index, PrimitiveDataType dataType]
+        {
+            get
+            {
+                if (index == 0)
+                {
+                    return Data[dataType];
+                }
+                else
+                {
+                    return MeshData[dataType][index - 1];
+                }
+            }
+            set
+            {
+                if (index == 0)
+                {
+                    Data[dataType] = value;
+                }
+                else
+                {
+                    MeshData[dataType][index - 1] = value;
+                }
+            }
+        }
+
+
+        public int GetCount(int index)
+        {
+            if (index == 0)
+            {
+                return Data.Count;
+            }
+            else
+            {
+                return MeshData.Count;
+            }
+        }
+
+        public IEnumerable<PrimitiveDataType> GetKeys(int index)
+        {
+            if (index == 0)
+            {
+                return Data.Keys;
+            }
+            else
+            {
+                return MeshData.Keys;
+            }
+        }
+
+        public IEnumerable<uint> GetValues(int index)
+        {
+            if (index == 0)
+            {
+                return Data.Values;
+            }
+            else
+            {
+                return MeshData.Select(kvp => kvp.Value[index - 1]);
+            }
+        }
+
+        public IEnumerable<KeyValuePair<PrimitiveDataType, uint>> GetData(int index)
+        {
+            if (index == 0)
+            {
+                return Data;
+            }
+            else
+            {
+                return MeshData.Select(kvp => new KeyValuePair<PrimitiveDataType, uint>(kvp.Key, kvp.Value[index - 1]));
+            }
+        }
+
+
+        public void SetMeshLength(int length)
+        {
+            MeshLength = Math.Max(1, length);
+            if (UseMeshData)
+            {
+                MeshData = new Dictionary<PrimitiveDataType, uint[]>();
+                PadCount = new int[MeshLength];
+            }
+        }
+
+
+        public bool ContainsKey(int index, PrimitiveDataType dataType)
+        {
+            if (index == 0)
+            {
+                return Data.ContainsKey(dataType);
+            }
+            else
+            {
+                return MeshData.ContainsKey(dataType);
+            }
+        }
+
+        public bool TryGetValue(int index, PrimitiveDataType dataType, out uint value)
+        {
+            if (index == 0)
+            {
+                return Data.TryGetValue(dataType, out value);
+            }
+            else
+            {
+                if (MeshData.TryGetValue(dataType, out var values))
+                {
+                    value = values[index - 1];
+                    return true;
+                }
+                value = 0;
+                return false;
+            }
+        }
+
+        // DOES NOT support getting VERTEX3 for quads!
+        public bool TryGetVertex(int index, int vertex, out uint vertexIndex)
+        {
+            if (index == 0)
+            {
+                // Support for getting VERTEX3.
+                return Data.TryGetValue(PrimitiveDataType.VERTEX0 + vertex, out vertexIndex);
+            }
+            else
+            {
+                vertex += index;
+                if (vertex < 3)
+                {
+                    return Data.TryGetValue(PrimitiveDataType.VERTEX0 + vertex, out vertexIndex);
+                }
+                else
+                {
+                    // +1 because MeshData starts at index 1.
+                    return TryGetValue(vertex - 3 + 1, PrimitiveData.MESHVERTEX, out vertexIndex);
+                }
+            }
+        }
+
+        public bool TryGetNormal(int index, int normal, out uint normalIndex)
+        {
+            return TryGetValue(index, PrimitiveDataType.NORMAL0 + normal, out normalIndex);
+        }
+
+        public void Add(int index, PrimitiveDataType dataType, uint value)
+        {
+            if (index == 0)
+            {
+                Data.Add(dataType, value);
+            }
+            //else if (index == 1)
+            //{
+            //    var values = new uint[MeshLength - 1];
+            //    MeshData.Add(dataType, values);
+            //    values[index - 1] = value;
+            //}
+            else
+            {
+                //MeshData[dataType][index - 1] = value;
+                if (!MeshData.TryGetValue(dataType, out var values))
+                {
+                    values = new uint[MeshLength - 1];
+                    MeshData.Add(dataType, values);
+                }
+                values[index - 1] = value;
+            }
+        }
+
+        public void ReadData(BinaryReader reader, int index, PrimitiveDataType dataType, int? dataLength = null)
+        {
+            uint value = 0;
+            if (dataLength == null)
+            {
+                switch (PrimitiveData.GetDataLength(dataType))
+                {
+                    case 1:
+                        value = reader.ReadByte();
+                        break;
+                    case 2:
+                        value = reader.ReadUInt16();
+                        break;
+                    case 4:
+                        value = reader.ReadUInt32();
+                        break;
+                }
+            }
+            else
+            {
+                for (var i = 0; i < dataLength.Value; i++)
+                {
+                    reader.ReadByte();
+                }
+                value = (uint)dataLength.Value;
+            }
+            var isPadding = dataType >= PrimitiveDataType.PAD1;
+            if (!isPadding || Program.Debug)
+            {
+                // Unlike MeshData, PadCount includes index 0.
+                var key = isPadding ? PrimitiveDataType.PAD1 + PadCount[index]++ : dataType;
+                Add(index, key, value);
+
+                // Useful for packet debugging, but too verbose for Program.Debug. Keep commented out!
+                //Program.Logger.WriteLine($"ReadData({index}, {dataType}, {value} (0x{value:x}))");
+            }
+        }
+
+        //public override string ToString()
+        //{
+        //    return Data.Keys.Aggregate("", (current, key) => current + (key + "-"));
+        //}
+
+        public string PrintPrimitiveData()
+        {
+            var value = new StringBuilder();
+            if (UseMeshData)
+            {
+                value.Append("\t[0]");
+            }
+            foreach (var kvp in Data)
+            {
+                value.Append("\t").Append(kvp.Key).Append(":").Append(kvp.Value);
+            }
+            for (var m = 1; m < MeshLength; m++)
+            {
+                value.Append("\n\t[").Append(m).Append("]");
+                foreach (var kvp in MeshData)
+                {
+                    value.Append("\t").Append(kvp.Key).Append(":").Append(kvp.Value[m - 1]);
+                }
+            }
+            return value.ToString();
+        }
+
+
+        public static int GetDataLength(PrimitiveDataType dataType)
+        {
+            switch (dataType)
+            {
+                case PrimitiveDataType.S0:
+                case PrimitiveDataType.S1:
+                case PrimitiveDataType.S2:
+                case PrimitiveDataType.S3:
+                case PrimitiveDataType.T0:
+                case PrimitiveDataType.T1:
+                case PrimitiveDataType.T2:
+                case PrimitiveDataType.T3:
+                case PrimitiveDataType.R0:
+                case PrimitiveDataType.R1:
+                case PrimitiveDataType.R2:
+                case PrimitiveDataType.R3:
+                case PrimitiveDataType.G0:
+                case PrimitiveDataType.G1:
+                case PrimitiveDataType.G2:
+                case PrimitiveDataType.G3:
+                case PrimitiveDataType.B0:
+                case PrimitiveDataType.B1:
+                case PrimitiveDataType.B2:
+                case PrimitiveDataType.B3:
+                case PrimitiveDataType.Mode:
+                case PrimitiveDataType.PAD1:
+                    return 1;
+                case PrimitiveDataType.CBA:
+                case PrimitiveDataType.TSB:
+                case PrimitiveDataType.VERTEX0:
+                case PrimitiveDataType.VERTEX1:
+                case PrimitiveDataType.VERTEX2:
+                case PrimitiveDataType.VERTEX3:
+                case PrimitiveDataType.NORMAL0:
+                case PrimitiveDataType.NORMAL1:
+                case PrimitiveDataType.NORMAL2:
+                case PrimitiveDataType.NORMAL3:
+                case PrimitiveDataType.PAD2:
+                    return 2;
+                case PrimitiveDataType.TILE:
+                    return 4;
+            }
+            return 0;
+        }
+    }
+}

--- a/Classes/PrimitiveType.cs
+++ b/Classes/PrimitiveType.cs
@@ -9,5 +9,6 @@
         StraightLine,
         Sprite,
         StripMesh,
+        //RoundedMesh, // Library overview documents this type of mesh, but it may not appear in file formats.
     }
 }

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -166,38 +166,40 @@ namespace PSXPrev.Classes
                     var flag = reader.ReadByte();
                     var mode = reader.ReadByte();
                     var offset = reader.BaseStream.Position;
-                    var packetStructure = TMDHelper.CreateTMDPacketStructure(flag, mode, reader, p, out var renderFlags, out var primitiveType);
+                    var packetStructure = TMDHelper.CreateTMDPacketStructure(flag, mode, reader, p);
                     if (packetStructure != null)
                     {
-                        switch (primitiveType)
+                        switch (packetStructure.PrimitiveType)
                         {
                             case PrimitiveType.Triangle:
                             case PrimitiveType.Quad:
-                                TMDHelper.AddTrianglesToGroup(primitiveType, groupedTriangles, packetStructure, renderFlags, false, delegate (uint index)
-                                {
-                                    if (index >= vertices.Length)
+                                TMDHelper.AddTrianglesToGroup(groupedTriangles, packetStructure, false,
+                                    index =>
                                     {
-                                        if (Program.IgnoreTmdVersion)
+                                        if (index >= vertices.Length)
                                         {
-                                            return new Vector3(index, 0, 0);
+                                            if (Program.IgnoreTmdVersion)
+                                            {
+                                                return new Vector3(index, 0, 0);
+                                            }
+                                            Program.Logger.WriteErrorLine("Vertex index error : " + fileTitle);
+                                            throw new Exception("Vertex index error: " + fileTitle);
                                         }
-                                        Program.Logger.WriteErrorLine("Vertex index error : " + fileTitle);
-                                        throw new Exception("Vertex index error: " + fileTitle);
-                                    }
-                                    return vertices[index];
-                                }, delegate (uint index)
-                                {
-                                    if (index >= normals.Length)
+                                        return vertices[index];
+                                    },
+                                    index =>
                                     {
-                                        if (Program.IgnoreTmdVersion)
+                                        if (index >= normals.Length)
                                         {
-                                            return new Vector3(index, 0, 0);
+                                            if (Program.IgnoreTmdVersion)
+                                            {
+                                                return new Vector3(index, 0, 0);
+                                            }
+                                            Program.Logger.WriteErrorLine("Vertex index error: " + fileTitle);
+                                            throw new Exception("Vertex index error: " + fileTitle);
                                         }
-                                        Program.Logger.WriteErrorLine("Vertex index error: " + fileTitle);
-                                        throw new Exception("Vertex index error: " + fileTitle);
-                                    }
-                                    return normals[index];
-                                });
+                                        return normals[index];
+                                    });
                                 break;
                             case PrimitiveType.StraightLine:
                                 break;

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Classes\FileOffsetScanner.cs" />
     <Compile Include="Classes\PlyExporter.cs" />
     <Compile Include="Classes\PMDParser.cs" />
+    <Compile Include="Classes\PrimitiveData.cs" />
     <Compile Include="Classes\PrimitiveDataType.cs" />
     <Compile Include="Classes\CrocModelReader.cs" />
     <Compile Include="Classes\PrimitiveType.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -96,6 +96,8 @@ namespace PSXPrev
         public static ulong MaxHMDDataSize = 20000;
         public static ulong MaxHMDDataCount = 5000;
         public static ulong MaxHMDPrimitiveChainLength = 512;
+        public static ulong MinHMDStripMeshLength = 1;
+        public static ulong MaxHMDStripMeshLength = 1024;
         public static ulong MaxHMDAnimSequenceSize = 20000;
         public static ulong MaxHMDAnimSequenceCount = 1024;
         public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap


### PR DESCRIPTION
This implements issue #64.

Strip meshes are a type of polygon that can be loaded by HMD primitive packets. These meshes follow an identical structure to a triangle, except that a number is prefixed for the number of triangles (so 1 would mean there is no extra strip mesh data). After the identical packet data, repeat packets appear that again follow an identical format to triangles, with one exception that only one vertex is read.

The one awkward part of strip meshes was that you had to figure out the order for reading vertices and normals.

The order is vertex `m + (0, 1, 2)` / normal `(0, 1, 2)` for even indexes, and vertex `m + (0, 2, 1)` / normal `(0, 2, 1)` for odd packets. It was strange that normals weren't used in the order they were defined in, considering all normals are used from their respective mesh repeat packet.

* packetStructure has been changed into the class PrimitiveData, which handles reading and dictionary lookup.
    * PrimitiveData now stores the PrimitiveType and RenderFlags, so they're no longer output by packet structure parsing functions.
    * This class holds a second dictionary when meshLength > 1, that holds repeated packets from strip meshes.
    * This can alternatively be changed to always use an array (even for index 0), but I figure this is probably the better approach for faster loading, since most primitives won't be strip meshes.
* Some minor cleanup so that TMDParser calls AddTrianglesToGroup in the same way HMDParser does.
* Changed the commented out printing of WriteLine(exp) in FileOffsetScanner to WriteErrorLine, for easier identifying.