### PR TITLE
Select triangles with Shift+Click

### DIFF
--- a/Classes/AnimationBatch.cs
+++ b/Classes/AnimationBatch.cs
@@ -20,6 +20,7 @@ namespace PSXPrev.Classes
             var objectCount = animation.ObjectCount;
             _scene.MeshBatch.Reset(objectCount + 1);
             _scene.BoundsBatch.Reset();
+            _scene.TriangleOutlineBatch.Reset();
             _scene.SkeletonBatch.Reset();
             _scene.GizmosMeshBatch.Reset(0);
             _animation = animation;

--- a/Classes/LineBatch.cs
+++ b/Classes/LineBatch.cs
@@ -129,5 +129,15 @@ namespace PSXPrev.Classes
             AddLine(corners[1], corners[5], Color.White);
             AddLine(corners[3], corners[0], Color.White);
         }
+
+        public void SetupTriangleOutline(Triangle triangle, Matrix4 worldMatrix)
+        {
+            var vertex0 = Vector3.TransformPosition(triangle.Vertices[0], worldMatrix);
+            var vertex1 = Vector3.TransformPosition(triangle.Vertices[1], worldMatrix);
+            var vertex2 = Vector3.TransformPosition(triangle.Vertices[2], worldMatrix);
+            AddLine(vertex0, vertex1, Color.White);
+            AddLine(vertex1, vertex2, Color.White);
+            AddLine(vertex2, vertex0, Color.White);
+        }
     }
 }

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -9,6 +9,9 @@ namespace PSXPrev.Classes
         // Default flags for when a reader doesn't assign any.
         public const RenderFlags DefaultRenderFlags = RenderFlags.DoubleSided;
 
+
+        private Triangle[] _triangles;
+
         [DisplayName("VRAM Page")]
         public uint TexturePage { get; set; }
         
@@ -22,7 +25,21 @@ namespace PSXPrev.Classes
         public int TrianglesCount => Triangles.Length;
 
         [Browsable(false)]
-        public Triangle[] Triangles { get; set; }
+        public Triangle[] Triangles
+        {
+            get => _triangles;
+            set
+            {
+                if (value != null)
+                {
+                    for (var i = 0; i < value.Length; i++)
+                    {
+                        value[i].ParentEntity = this;
+                    }
+                }
+                _triangles = value;
+            }
+        }
 
         [Browsable(false)]
         public Texture Texture { get; set; }

--- a/Classes/Triangle.cs
+++ b/Classes/Triangle.cs
@@ -49,23 +49,32 @@ namespace PSXPrev.Classes
             _poly_g4c
         }
 
-        [Browsable(false)]
+        [ReadOnly(true), DisplayName("Parent")]
+        public EntityBase ParentEntity { get; set; }
+
+        [ReadOnly(true)]
         public Vector3[] Vertices { get; set; }
 
-        [Browsable(false)]
+        [ReadOnly(true)]
         public Vector3[] Normals { get; set; }
 
-        [Browsable(false)]
+        [ReadOnly(true), DisplayName("UVs")]
         public Vector2[] Uv { get; set; }
 
         // Defines the area of the texture page that Uv is wrapped around.
-        [Browsable(false)]
+        [ReadOnly(true), Browsable(false)]
         public TiledUV TiledUv { get; set; }
 
-        [Browsable(false)]
+        [ReadOnly(true), DisplayName("Tiled Base UVs")]
+        public Vector2[] TiledBaseUv => TiledUv?.BaseUv;
+
+        [ReadOnly(true), DisplayName("Tiled Area UVs")]
+        public Vector4? TiledArea => TiledUv?.Area;
+
+        [ReadOnly(true), DisplayName("Is Tiled Texture")]
         public bool IsTiled => TiledUv != null;
 
-        [Browsable(false)]
+        [ReadOnly(true)]
         public Color[] Colors { get; set; }
 
         [Browsable(false)]
@@ -83,6 +92,9 @@ namespace PSXPrev.Classes
         // HMD: Attached (shared) normal indices from other model entities.
         [Browsable(false)]
         public uint[] AttachedNormalIndices { get; set; }
+
+        [Browsable(false)]
+        public float IntersectionDistance { get; set; }
 
         public List<Tuple<uint, uint>> ExtraPaddingData { get; set; } = new List<Tuple<uint, uint>>();
 

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -242,6 +242,7 @@
             this.entitiesTreeView.TabIndex = 9;
             this.entitiesTreeView.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterCheck);
             this.entitiesTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterSelect);
+            this.entitiesTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.entitiesTreeView_NodeMouseClick);
             // 
             // tableLayoutPanel5
             // 
@@ -1346,11 +1347,14 @@
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.mainMenuStrip);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
             this.MainMenuStrip = this.mainMenuStrip;
             this.Name = "PreviewForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "PSXPrev";
             this.Load += new System.EventHandler(this.previewForm_Load);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyDown);
+            this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyUp);
             this.entitiesTabPage.ResumeLayout(false);
             this.modelsSplitContainer.Panel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.modelsSplitContainer)).EndInit();

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -674,7 +674,9 @@ namespace PSXPrev
             // handle unselecting triangle when clicking on a node in the tree view if that node is already selected.
             if (e.Node != null)
             {
-                UnselectTriangle();
+                // Removed for now, because this also triggers when pressing
+                // the expand button (which doesn't perform selection).
+                //UnselectTriangle();
             }
         }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -35,12 +35,15 @@ namespace PSXPrev
         private bool _inAnimationTab;
         private float _lastMouseX;
         private float _lastMouseY;
+        private bool _shiftKeyDown;
+        private bool _controlKeyDown;
         private GLControl _openTkControl;
         private Vector3 _pickedPosition;
         private bool _playing;
         private Timer _redrawTimer;
         private readonly Scene _scene;
         private Scene.GizmoId _selectedGizmo;
+        private Tuple<ModelEntity, Triangle> _selectedTriangle;
         private ModelEntity _selectedModelEntity;
         private RootEntity _selectedRootEntity;
         private EntitySelectionSource _selectionSource;
@@ -186,11 +189,11 @@ namespace PSXPrev
             }
             else
             {
-                if (entitiesTreeView.Nodes.Count > 0)
+                // Don't select the first model if we already have a selection.
+                // Doing that would interrupt the user.
+                if (entitiesTreeView.SelectedNode == null && _rootEntities.Count > 0)
                 {
-                    // I don't think the user will necessarily want the entity checked too.
-                    //entitiesTreeView.Nodes[0].Checked = true;
-                    entitiesTreeView.SelectedNode = entitiesTreeView.Nodes[0];
+                    SelectEntity(_rootEntities[0], true); // Select and focus
                 }
             }
         }
@@ -427,24 +430,61 @@ namespace PSXPrev
             MessageBox.Show("Textures exported");
         }
 
-        private void SelectEntity(EntityBase entity)
+        private void SelectEntity(EntityBase entity, bool focus = false)
         {
-            _selectionSource = EntitySelectionSource.Click;
+            if (!focus)
+            {
+                _selectionSource = EntitySelectionSource.Click;
+            }
+            TreeNode newNode = null;
             if (entity is RootEntity rootEntity)
             {
                 var rootIndex = _rootEntities.IndexOf(rootEntity);
-                entitiesTreeView.SelectedNode = entitiesTreeView.Nodes[rootIndex];
+                newNode = entitiesTreeView.Nodes[rootIndex];
             }
-            else
+            else if (entity != null)
             {
                 if (entity.ParentEntity is RootEntity rootEntityFromSub)
                 {
                     var rootIndex = _rootEntities.IndexOf(rootEntityFromSub);
                     var rootNode = entitiesTreeView.Nodes[rootIndex];
                     var subIndex = Array.IndexOf(rootEntityFromSub.ChildEntities, entity);
-                    entitiesTreeView.SelectedNode = rootNode.Nodes[subIndex];
+                    newNode = rootNode.Nodes[subIndex];
                 }
             }
+            if (newNode != null && newNode == entitiesTreeView.SelectedNode)
+            {
+                // entitiesTreeView_AfterSelect won't be called. Reset the selection source.
+                _selectionSource = EntitySelectionSource.None;
+                if (entity != null)
+                {
+                    UnselectTriangle();
+                }
+            }
+            else
+            {
+                entitiesTreeView.SelectedNode = newNode;
+            }
+        }
+
+        private void SelectTriangle(Tuple<ModelEntity, Triangle> triangle)
+        {
+            if (_selectedTriangle?.Item2 != triangle?.Item2)
+            {
+                _selectedTriangle = triangle;
+                UpdateSelectedTriangle();
+                UpdateModelPropertyGrid();
+            }
+        }
+
+        private void UnselectTriangle()
+        {
+            SelectTriangle(null);
+        }
+
+        private bool IsTriangleSelectMode()
+        {
+            return _shiftKeyDown;
         }
 
         private void openTkControl_MouseEvent(MouseEventArgs e, MouseEventType eventType)
@@ -489,10 +529,29 @@ namespace PSXPrev
                             {
                                 rootEntity = _selectedModelEntity.GetRootEntity();
                             }
-                            var newSelectedEntity = _scene.GetEntityUnderMouse(checkedEntities, rootEntity, e.Location.X, e.Location.Y, controlWidth, controlHeight);
-                            if (newSelectedEntity != null)
+                            if (IsTriangleSelectMode())
                             {
-                                SelectEntity(newSelectedEntity);
+                                var newSelectedTriangle = _scene.GetTriangleUnderMouse(checkedEntities, rootEntity, e.Location.X, e.Location.Y, controlWidth, controlHeight);
+                                if (newSelectedTriangle != null)
+                                {
+                                    SelectTriangle(newSelectedTriangle);
+                                }
+                                else
+                                {
+                                    UnselectTriangle();
+                                }
+                            }
+                            else
+                            {
+                                var newSelectedEntity = _scene.GetEntityUnderMouse(checkedEntities, rootEntity, e.Location.X, e.Location.Y, controlWidth, controlHeight);
+                                if (newSelectedEntity != null)
+                                {
+                                    SelectEntity(newSelectedEntity, false);
+                                }
+                                else
+                                {
+                                    UnselectTriangle();
+                                }
                             }
                         }
                         else
@@ -605,8 +664,18 @@ namespace PSXPrev
             {
                 _selectedRootEntity = selectedNode.Tag as RootEntity;
                 _selectedModelEntity = selectedNode.Tag as ModelEntity;
+                UnselectTriangle();
             }
             UpdateSelectedEntity();
+        }
+
+        private void entitiesTreeView_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
+        {
+            // handle unselecting triangle when clicking on a node in the tree view if that node is already selected.
+            if (e.Node != null)
+            {
+                UnselectTriangle();
+            }
         }
 
         private void UpdateGizmos(Scene.GizmoId selectedGizmo = Scene.GizmoId.None, Scene.GizmoId hoveredGizmo = Scene.GizmoId.None, bool updateMeshData = true)
@@ -644,20 +713,45 @@ namespace PSXPrev
             if (selectedEntityBase != null)
             {
                 selectedEntityBase.ComputeBoundsRecursively();
-                modelPropertyGrid.SelectedObject = selectedEntityBase;
                 var checkedEntities = GetCheckedEntities();
                 _scene.BoundsBatch.SetupEntityBounds(selectedEntityBase);
                 _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, _selectedModelEntity, _selectedRootEntity, _scene.TextureBinder, updateMeshData || _scene.AutoAttach, _selectionSource == EntitySelectionSource.TreeView && _selectedModelEntity == null);
             }
             else
             {
-                modelPropertyGrid.SelectedObject = null;
                 _scene.MeshBatch.Reset(0);
                 _selectedGizmo = Scene.GizmoId.None;
                 _hoveredGizmo = Scene.GizmoId.None;
             }
+            UpdateSelectedTriangle();
+            UpdateModelPropertyGrid();
             UpdateGizmos(_selectedGizmo, _hoveredGizmo, updateMeshData);
             _selectionSource = EntitySelectionSource.None;
+        }
+
+        private void UpdateSelectedTriangle()
+        {
+            _scene.TriangleOutlineBatch.Reset();
+            if (_selectedTriangle != null)
+            {
+                _scene.TriangleOutlineBatch.SetupTriangleOutline(_selectedTriangle.Item2, _selectedTriangle.Item1.WorldMatrix);
+            }
+        }
+
+        private void UpdateModelPropertyGrid()
+        {
+            var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
+
+            object propertyObject = null;
+            if (_selectedTriangle != null)
+            {
+                propertyObject = _selectedTriangle.Item2;
+            }
+            else if (selectedEntityBase != null)
+            {
+                propertyObject = selectedEntityBase;
+            }
+            modelPropertyGrid.SelectedObject = propertyObject;
         }
 
         private void UpdateSelectedAnimation()
@@ -1293,6 +1387,12 @@ namespace PSXPrev
             Wheel
         }
 
+        private enum KeyEventType
+        {
+            Down,
+            Up,
+        }
+
         private enum EntitySelectionSource
         {
             None,
@@ -1353,6 +1453,33 @@ namespace PSXPrev
         private void pauseScanningToolStripMenuItem_CheckedChanged(object sender, EventArgs e)
         {
             Program.HaltRequested = pauseScanningToolStripMenuItem.Checked;
+        }
+
+        private void previewForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            previewForm_KeyEvent(e, KeyEventType.Down);
+        }
+
+        private void previewForm_KeyUp(object sender, KeyEventArgs e)
+        {
+            previewForm_KeyEvent(e, KeyEventType.Up);
+        }
+
+        private void previewForm_KeyEvent(KeyEventArgs e, KeyEventType eventType)
+        {
+            if (eventType == KeyEventType.Down || eventType == KeyEventType.Up)
+            {
+                var state = eventType == KeyEventType.Down;
+                switch (e.KeyCode)
+                {
+                    case Keys.ShiftKey:
+                        _shiftKeyDown = state;
+                        break;
+                    case Keys.ControlKey:
+                        _controlKeyDown = state;
+                        break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Main changes

This implements issue #87.

Holding shift and clicking on a triangle will now select the triangle with a 2px white outline. Selecting anything else will unselect a selected triangle. Selected triangles show up in the property grid. Most Triangle properties have had the `Browsable(false)` attribute removed. Triangles now store their ParentEntity, which is assigned by the ModelEntity Triangles property setter. This is useful for the property grid to see what owns the triangle.

<details>
<summary>Preview of selected triangle</summary>

![image](https://github.com/rickomax/psxprev/assets/9752430/e4823ef0-88d2-4874-b42f-42a45b7ba10d)

</details>

## Refactor changes
* `-selectmodel` startup option now does nothing if a model is already selected when the scan finishes. Because changing the user's current selection is inconvenient.
* `_selectionSource` is properly reset when SelectEntity is called for the currently-selected entity.
* Set `PreviewForm.KeyPreview` to true so that Shift key modifier can be captured.
* SelectEntity now takes a second argument `bool focus`, when set to false, the `_selectionSource` will be set to Click (which prevents focusing on the selection).
* SelectEntity now allows null entity as an argument.
* `modelPropertyGrid` updates have been moved to a new function `UpdateModelPropertyGrid`, which is now used in multiple places.
* Changed `Double.Epsilon` comparison in GeomUtils.ProjectOnNormal to `float.Epsilon`, because it's impossible for a float to equal that value. Although currently using `< Epsilon` is the same as `<= 0f`.
* Switched to using Math.Abs in GeomUtils.UnProject.