### PR TITLE
Fix texture pages exporting with semi-transparency section

### DIFF
--- a/Classes/PngExporter.cs
+++ b/Classes/PngExporter.cs
@@ -6,7 +6,19 @@ namespace PSXPrev.Classes
     {
         public void Export(Texture selectedTexture, int textureIndex, string selectedPath)
         {
-            selectedTexture.Bitmap.Save(selectedPath + "/" + textureIndex + ".png", ImageFormat.Png);
+            var filePath = $"{selectedPath}/{textureIndex}.png";
+            if (selectedTexture.IsVRAMPage)
+            {
+                // Remove the semi-transparency section from the exported bitmap.
+                using (var bitmap = VRAMPages.GetTextureOnly(selectedTexture))
+                {
+                    bitmap.Save(filePath, ImageFormat.Png);
+                }
+            }
+            else
+            {
+                selectedTexture.Bitmap.Save(filePath, ImageFormat.Png);
+            }
         }
 
         public void Export(Texture[] selectedTextures, string selectedPath)

--- a/Classes/TIMParser.cs
+++ b/Classes/TIMParser.cs
@@ -123,6 +123,7 @@ namespace PSXPrev.Classes
                         var g = (clut & 0x3E0) >> 5;
                         var b = (clut & 0x7C00) >> 10;
                         var stpBit = ((clut & 0x8000) >> 15) == 1; // Semi-transparency: 0-Off, 1-On
+                        var a = 255;
 
                         // Note: stpMode (not stpBit) is defined on a per polygon basis. We can't apply alpha now, only during rendering.
                         if (stpBit)
@@ -133,8 +134,12 @@ namespace PSXPrev.Classes
                             }
                             semiTransparentPalette[c] = true;
                         }
+                        else if (r == 0 && g == 0 && b == 0)
+                        {
+                            a = 0; // Transparent when black and !stpBit
+                        }
 
-                        color = System.Drawing.Color.FromArgb(255, r * 8, g * 8, b * 8);
+                        color = System.Drawing.Color.FromArgb(a, r * 8, g * 8, b * 8);
                     }
                     palette[c] = color;
                 }
@@ -336,10 +341,7 @@ namespace PSXPrev.Classes
                             var g0 = (data1 & 0x3E0) >> 5;
                             var b0 = (data1 & 0x7C00) >> 10;
                             var stpBit = ((data1 & 0x8000) >> 11) == 1; // Semi-transparency: 0-Off, 1-On
-
-                            var color1 = System.Drawing.Color.FromArgb(255, r0 * 8, g0 * 8, b0 * 8);
-
-                            bitmap.SetPixel(x, y, color1);
+                            var a0 = 255;
 
                             // Note: stpMode (not stpBit) is defined on a per polygon basis. We can't apply alpha now, only during rendering.
                             if (stpBit)
@@ -350,6 +352,14 @@ namespace PSXPrev.Classes
                                 }
                                 semiTransparentMap.SetPixel(x, y, Texture.SemiTransparentFlag);
                             }
+                            else if (r0 == 0 && g0 == 0 && b0 == 0)
+                            {
+                                a0 = 0; // Transparent when black and !stpBit
+                            }
+
+                            var color1 = System.Drawing.Color.FromArgb(a0, r0 * 8, g0 * 8, b0 * 8);
+
+                            bitmap.SetPixel(x, y, color1);
                         }
                     }
 

--- a/Classes/Texture.cs
+++ b/Classes/Texture.cs
@@ -9,13 +9,14 @@ namespace PSXPrev.Classes
         public static readonly System.Drawing.Color NoSemiTransparentFlag = System.Drawing.Color.FromArgb(255, 0, 0, 0);
         public static readonly System.Drawing.Color SemiTransparentFlag = System.Drawing.Color.FromArgb(255, 255, 255, 255);
 
-        public Texture(int width, int height, int x, int y, int bpp, int texturePage)
+        public Texture(int width, int height, int x, int y, int bpp, int texturePage, bool isVRAMPage = false)
         {
             Bitmap = new Bitmap(width, height);
             X = x;
             Y = y;
             Bpp = bpp;
             TexturePage = texturePage;
+            IsVRAMPage = isVRAMPage;
         }
 
         [DisplayName("Name")]
@@ -38,6 +39,9 @@ namespace PSXPrev.Classes
 
         [ReadOnly(true), DisplayName("Height")]
         public int Height => Bitmap.Height;
+
+        [Browsable(false)]
+        public bool IsVRAMPage { get; set; }
 
         [Browsable(false)]
         public Bitmap Bitmap { get; set; }

--- a/Classes/VRAMPages.cs
+++ b/Classes/VRAMPages.cs
@@ -54,7 +54,7 @@ namespace PSXPrev.Classes
                 {
                     // X coordinates [0,256) store texture data.
                     // X coordinates [256,512) store semi-transparency information for textures.
-                    _vramPage[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i);
+                    _vramPage[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i, true); // Is VRAM page
                     ClearPage(i, suppressUpdate);
                 }
             }
@@ -164,6 +164,29 @@ namespace PSXPrev.Classes
             }
         }
 
+
+        // Returns a bitmap of the VRAM texture page without the semi-transparency section.
+        // Must dispose of Bitmap after use.
+        public static Bitmap GetTextureOnly(Texture texture)
+        {
+            var bitmap = new Bitmap(PageSize, PageSize);
+            try
+            {
+                using (var graphics = Graphics.FromImage(bitmap))
+                {
+                    graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
+                    graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+
+                    graphics.DrawImage(texture.Bitmap, 0, 0, texture.Width, texture.Height);
+                }
+                return bitmap;
+            }
+            catch
+            {
+                bitmap?.Dispose();
+                throw;
+            }
+        }
 
         public static uint ClampTexturePage(uint index) => (uint)ClampTexturePage((int)index);
 


### PR DESCRIPTION
Textures now have a new property IsVRAMPage, which states if its used directly in rendering (and has a semi-transparency section). A new function VRAMPages.GetTextureOnly has been added, which returns a texture page bitmap without the transparency section. This is used by PngExporter when IsVRAMPage is true.

Additionally, textures now store transparent black with alpha=0. This means exported textures can preserve mask information (although this will not honor changes to Mask Color). This also affects how texture pages look in the VRAM tab, as black transparent pixels will now be transparent and show the color behind the PictureBox.