### PR TITLE
Allow HMD category 5 and 7 (envmap and device primitive)

### DIFF
--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -255,7 +255,8 @@ namespace PSXPrev.Classes
                         return;
                     }
 
-                    if (category > 5)
+                    // Categories 0-5 and 7 are defined by the spec, but there's no category 6.
+                    if (category == 6 || category > 7)
                     {
                         return;
                     }
@@ -377,6 +378,32 @@ namespace PSXPrev.Classes
                         // Note: Second divide-by-4 added since dataSize is now stored in byte units, not 4-byte units.
                         var groundDataCount = (dataSize / 4) / 4;
                         ProcessGroundData(groupedTriangles, reader, driver, primitiveType, primitiveHeaderPointer, nextPrimitivePointer, polygonIndex, groundDataCount, gridIndex, vertexIndex);
+                    }
+                    else if (category == 7)
+                    {
+                        if (primitiveType == 0x100)
+                        {
+                            if (Program.Debug)
+                            {
+                                Program.Logger.WriteLine($"HMD Device Camera");
+                                // driver: 0-Projection, 1-World camera, 2-Fix camera, 3-Aim camera
+                            }
+                        }
+                        else if (primitiveType == 0x200)
+                        {
+                            if (Program.Debug)
+                            {
+                                Program.Logger.WriteLine($"HMD Device Light");
+                                // driver: 0-Ambient color, 1-World light, 2-Fix light, 3-Aim light
+                            }
+                        }
+                        else
+                        {
+                            if (Program.Debug)
+                            {
+                                Program.Logger.WriteLine($"HMD Device 0x{primitiveType:x}");
+                            }
+                        }
                     }
 
                     // Seek to the next type. This is necessary since not all types will fully read up to the next type (i.e. Image Data).

--- a/Program.cs
+++ b/Program.cs
@@ -96,6 +96,7 @@ namespace PSXPrev
         public static ulong MaxHMDDataSize = 20000;
         public static ulong MaxHMDDataCount = 5000;
         public static ulong MaxHMDPrimitiveChainLength = 512;
+        public static ulong MaxHMDHeaderLength = 100;
         public static ulong MinHMDStripMeshLength = 1;
         public static ulong MaxHMDStripMeshLength = 1024;
         public static ulong MaxHMDAnimSequenceSize = 20000;


### PR DESCRIPTION
Category 7 is defined by the spec as either being a camera or light. Currently category 7 is not only ignored, but ends the current block. This fixes things so that category 7 is silently allowed so that other primitives in the block can be read.

**Edit:** It turns out category 6 also exists, and is well documented by PsyQ. Category 6, for the most part, is just another form of Non-Shared and Shared geometry, with extra attributes that can be attached to surfaces.

* Added ProcessEnvmapData to read non-shared envmap polygons.
* Added ProcessDeviceData to read device cameras and lights. HOWEVER, this data isn't used for anything yet, it's just reading for show.
* Added ProcessDevicePrimitiveHeader.
* Added ReadMappedPointer, which is shortcut for ReadMappedValue, then multiplying the value by 4.