### PR TITLE
Change HMD no-clut pmode to 16bit

### DIFF
--- a/Classes/HMDParser.cs
+++ b/Classes/HMDParser.cs
@@ -549,7 +549,7 @@ namespace PSXPrev.Classes
             }
             else
             {
-                pmode = 3u; // 24bpp
+                pmode = 2u; // 16bpp
                 palette = null;
                 semiTransparentPalette = null;
             }


### PR DESCRIPTION
HMD images without color lookup tables use 16bit color, not 24bit. Confirmed with PsyQ files.