### PR TITLE
Fix lag when using gizmos on models with limbs

### DIFF
--- a/Classes/EntityBase.cs
+++ b/Classes/EntityBase.cs
@@ -250,6 +250,18 @@ namespace PSXPrev.Classes
             }
         }
 
+        public virtual void ClearConnectionsCache()
+        {
+            if (ChildEntities == null)
+            {
+                return;
+            }
+            foreach (var child in ChildEntities)
+            {
+                child.ClearConnectionsCache();
+            }
+        }
+
         public RootEntity GetRootEntity()
         {
             var entity = this;

--- a/Classes/GeomUtils.cs
+++ b/Classes/GeomUtils.cs
@@ -11,17 +11,19 @@ namespace PSXPrev.Classes
         public static string CompleteFloatFormat = "{0:0.00000}";
         public const float Deg2Rad = (float)((Math.PI * 2f) / 360.0f);
 
-        public static Vector3 XVector = new Vector3(1f, 0f, 0f);
-        public static Vector3 YVector = new Vector3(0f, 1f, 0f);
-        public static Vector3 ZVector = new Vector3(0f, 0f, 1f);
+        // Use Vector3.Unit(XYZ) fields instead.
+        //public static Vector3 XVector = new Vector3(1f, 0f, 0f);
+        //public static Vector3 YVector = new Vector3(0f, 1f, 0f);
+        //public static Vector3 ZVector = new Vector3(0f, 0f, 1f);
 
-        public static float VecDistance(Vector3 a, Vector3 b)
-        {
-            var x = a.X - b.X;
-            var y = a.Y - b.Y;
-            var z = a.Z - b.Z;
-            return (float)Math.Sqrt((x * x) + (y * y) + (z * z));
-        }
+        // Use Vector3.Distance instead.
+        //public static float VecDistance(Vector3 a, Vector3 b)
+        //{
+        //    var x = a.X - b.X;
+        //    var y = a.Y - b.Y;
+        //    var z = a.Z - b.Z;
+        //    return (float)Math.Sqrt((x * x) + (y * y) + (z * z));
+        //}
 
         public static string WriteVector3(Vector3? v)
         {

--- a/Classes/Scene.cs
+++ b/Classes/Scene.cs
@@ -145,7 +145,7 @@ namespace PSXPrev.Classes
 
         public Quaternion CameraRotation => _viewMatrix.Inverted().ExtractRotation();
 
-        public Vector3 CameraDirection => CameraRotation * GeomUtils.ZVector;
+        public Vector3 CameraDirection => CameraRotation * Vector3.UnitZ;
 
         public float CameraDistanceToOrigin => -_viewMatrix.ExtractTranslation().Z;
 

--- a/Classes/Triangle.cs
+++ b/Classes/Triangle.cs
@@ -93,6 +93,10 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public uint[] AttachedNormalIndices { get; set; }
 
+        // Cache of already-attached entities/vertices to speed up FixConnections.
+        [Browsable(false)]
+        public Tuple<EntityBase, Vector3>[] AttachedCache { get; set; }
+
         [Browsable(false)]
         public float IntersectionDistance { get; set; }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -586,7 +586,7 @@ namespace PSXPrev
                     if (mouseLeft && eventType == MouseEventType.Move && selectedEntityBase != null)
                     {
                         var pickedPosition = _scene.GetPickedPosition(-_scene.CameraDirection);
-                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(GeomUtils.XVector);
+                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(Vector3.UnitX);
                         selectedEntityBase.PositionX += projectedOffset.X;
                         selectedEntityBase.PositionY += projectedOffset.Y;
                         selectedEntityBase.PositionZ += projectedOffset.Z;
@@ -603,7 +603,7 @@ namespace PSXPrev
                     if (mouseLeft && eventType == MouseEventType.Move && selectedEntityBase != null)
                     {
                         var pickedPosition = _scene.GetPickedPosition(-_scene.CameraDirection);
-                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(GeomUtils.YVector);
+                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(Vector3.UnitY);
                         selectedEntityBase.PositionX += projectedOffset.X;
                         selectedEntityBase.PositionY += projectedOffset.Y;
                         selectedEntityBase.PositionZ += projectedOffset.Z;
@@ -620,7 +620,7 @@ namespace PSXPrev
                     if (mouseLeft && eventType == MouseEventType.Move && selectedEntityBase != null)
                     {
                         var pickedPosition = _scene.GetPickedPosition(-_scene.CameraDirection);
-                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(GeomUtils.ZVector);
+                        var projectedOffset = (pickedPosition - _pickedPosition).ProjectOnNormal(Vector3.UnitZ);
                         selectedEntityBase.PositionX += projectedOffset.X;
                         selectedEntityBase.PositionY += projectedOffset.Y;
                         selectedEntityBase.PositionZ += projectedOffset.Z;


### PR DESCRIPTION
When using the gizmo to translate a model with lots of connections, the movement wouldn't draw to the panel until letting go of the mouse (or waiting a period of time without movement). This is due to WinForms delaying the paint event until it's not busy, and it was always busy because FixConnections was causing enough lag to keep it occuppied. One solution could have been to call `_openTkControl.Refresh()` during the gizmo mover updates, but that's a drastic approach, when trying to speed things up would be better approach. Additionally the Refresh solution wouldn't fix other controls, like the property grid not updating.

* FixConnections now caches found connections in Triangle, when calling FixConnections again, cached connections will be used so that we don't need to look through up to `N^N` triangle vertices each call. This speed-up is enough to allow Paint to be called for the render during gizmo translation. It also drastically speeds up animating models with attached limbs (such as PsyQ's `YESNO5.HMD`).
* Added ClearConnectionsCache to EntityBase, so that cached connections can be reset if changes have been made that would change the initial vertices and attached entities.
* ModelEntity now calls base.FixConnections.
* Switched all uses of `GeomUtils.(XYZ)Vector` to `Vector3.Unit(XYZ)`, since it's already provided for us.
* Commented out `GeomUtils.VecDistance` and left a note to use `Vector3.Distance` instead. This function was unused.