### PR TITLE
MOD reader fixes

### DIFF
--- a/Classes/BRenderHelper.cs
+++ b/Classes/BRenderHelper.cs
@@ -12,7 +12,7 @@ namespace PSXPrev.Classes
 {
     public static class BRenderHelper
     {
-        public static uint ReadU32LE(Stream s)
+        public static uint ReadU32BE(Stream s)
         {
             ulong result = 0;
             result = (byte)s.ReadByte();
@@ -22,7 +22,7 @@ namespace PSXPrev.Classes
             return (uint)result;
         }
 
-        public static ushort ReadU16LE(Stream s)
+        public static ushort ReadU16BE(Stream s)
         {
             ulong result = 0;
             result = (byte)s.ReadByte();
@@ -30,7 +30,7 @@ namespace PSXPrev.Classes
             return (ushort)result;
         }
 
-        public static uint ReadU32BE(Stream s)
+        public static uint ReadU32LE(Stream s)
         {
             ulong result = 0;
             result = (byte)s.ReadByte();
@@ -40,7 +40,7 @@ namespace PSXPrev.Classes
             return (uint)result;
         }
 
-        public static ushort ReadU16BE(Stream s)
+        public static ushort ReadU16LE(Stream s)
         {
             ulong result = 0;
             result = (byte)s.ReadByte();

--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -27,28 +27,59 @@ namespace PSXPrev.Classes
             }
         }
 
+        // The real divisor is supposedly 4096f, but that creates VERY SMALL models.
+        private const float FIXED_DIV = 16f; // 4096f;
+
+        private static Vector3 ReadVector(BinaryReader reader, bool normal = false, bool readPad = true)
+        {
+            var div = (normal ? 4096f : FIXED_DIV);
+            var x = reader.ReadInt16() / div;
+            var y = reader.ReadInt16() / div;
+            var z = reader.ReadInt16() / div;
+            if (readPad)
+            {
+                var pad = reader.ReadUInt16();
+            }
+            // Note: With this order, some models do seem right-side up,
+            // but many seem to be pitched at a 90deg angle (up?/down?).
+            // Note that the later models don't look flipped or anything. i.e. letters and buttons are correct.
+            return new Vector3(x, -z, y);
+        }
+
         private static RootEntity ReadModels(BinaryReader reader)
         {
-            var count = BRenderHelper.ReadU16BE(reader.BaseStream);
-            if (count == 0 || count > 10000)
+            // Some data is properly handled thanks to vs49688's work on CrocUtils.
+            // Notably: Fixed point size, flags, bounding box indices, color, UVs, and the collision section.
+            // <https://github.com/vs49688/CrocUtils>
+
+            // Many MOD files with sub-models seem to lack positioning information for each sub-model.
+            // For example, TK##_TRK files are a giant collection of grid pieces all occupying the same space.
+            // This may be handled by another file...
+
+            var count = reader.ReadUInt16();
+            if (count == 0 || count > Program.MaxMODModels)
             {
                 return null;
             }
-            var flags = BRenderHelper.ReadU16BE(reader.BaseStream);
+            var flags = reader.ReadUInt16();
+            var collision = ((flags >> 0) & 0x1) == 1;
+
             var models = new List<ModelEntity>();
-            for (var i = 0; i < count; i++)
+            for (uint i = 0; i < count; i++)
             {
-                var modelEntity = new ModelEntity();
-                var radius = (int)BRenderHelper.ReadU32BE(reader.BaseStream);
+                // Same fixed point fraction size used for Int16's.
+                var radius = reader.ReadInt32() / FIXED_DIV;
+
+                // Bounding box indices: <https://github.com/vs49688/CrocUtils/blob/5e07b7cb60fb5edec465a509d8924ae6682eaba7/libcroc/include/libcroc/moddef.h#L97-L108>
+                var boundingBox = new Vector3[9]; // 0 is the center.
                 for (var j = 0; j < 9; j++)
                 {
-                    for (var k = 0; k < 4; k++)
-                    {
-                        BRenderHelper.ReadU16BE(reader.BaseStream);
-                    }
+                    boundingBox[j] = ReadVector(reader);
                 }
-                var countVerts = BRenderHelper.ReadU32BE(reader.BaseStream);
-                if (countVerts == 0 || countVerts > 1000)
+
+                // See notes by countFaces.
+                var countVerts = reader.ReadUInt32();
+                if (countVerts > Program.MaxMODVertices)
                 {
                     return null;
                 }
@@ -56,90 +87,197 @@ namespace PSXPrev.Classes
                 var normals = new Vector3[countVerts];
                 for (var j = 0; j < countVerts; j++)
                 {
-                    var x = (short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    var z = (short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    var y = -(short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    BRenderHelper.ReadU16BE(reader.BaseStream);
-                    vertices[j] = new Vector3(x, y, z);
+                    vertices[j] = ReadVector(reader);
                 }
                 for (var j = 0; j < countVerts; j++)
                 {
-                    var x = (short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    var z = (short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    var y = -(short)BRenderHelper.ReadU16BE(reader.BaseStream) / 16f;
-                    BRenderHelper.ReadU16BE(reader.BaseStream);
-                    normals[j] = new Vector3(x, y, z);
+                    normals[j] = ReadVector(reader, normal: true);
                 }
-                var countFaces = BRenderHelper.ReadU32BE(reader.BaseStream);
-                if (countFaces == 0)
+
+                // It's valid for some models to define 0 vertices and/or faces.
+                // When this happens, it's likely that the MOD file is split up into multiple sub-models,
+                // and the one at this index is intended to be empty.
+                // 
+                // Even if the counts are zero, we need to keep reading till the end of this sub-model,
+                // so that the reader offset for the next sub-model is correct.
+                var countFaces = reader.ReadUInt32();
+                if (countFaces > 0 && countVerts == 0)
+                {
+                    // Although this check is technically handled in the faces loop,
+                    // we can check this now to set the capacity of triangles without wasting memory.
+                    return null;
+                }
+                if (countFaces > Program.MaxMODFaces)
                 {
                     return null;
                 }
-                var triangles = new List<Triangle>();
-                //var header = Encoding.ASCII.GetString(reader.ReadBytes(64));
+                var triangles = new List<Triangle>((int)countFaces);
+
+                // Groups are observed as consecutive faces that share some similar properties.
+                // They are defined by the fourth uint16 in a face. When non-zero, a new group is started.
+                // A non-zero value specifies how many faces (including this one) remain in the group.
+                // After that many values have passed, either a new group is started, or the end of the face list is reached.
+                // The only similar properties observed in groups is that each face always uses the same texture/quad flags.
+                //var groupRemaining = 0;
+
                 for (var j = 0; j < countFaces; j++)
                 {
-                    var unk1 = reader.BaseStream.ReadByte();
-                    var unk2 = reader.BaseStream.ReadByte();
-                    var unk3 = reader.BaseStream.ReadByte();
-                    var unk4 = reader.BaseStream.ReadByte();
-                    var unk5 = reader.BaseStream.ReadByte();
-                    var unk6 = reader.BaseStream.ReadByte();
-                    var unk7 = reader.BaseStream.ReadByte();
-                    var unk8 = reader.BaseStream.ReadByte();
-                    var f0 = BRenderHelper.ReadU16BE(reader.BaseStream);
-                    var f1 = BRenderHelper.ReadU16BE(reader.BaseStream);
-                    var f2 = BRenderHelper.ReadU16BE(reader.BaseStream);
-                    var f3 = BRenderHelper.ReadU16BE(reader.BaseStream);
-                    if (f0 >= vertices.Length || f1 >= vertices.Length || f2 >= vertices.Length || f3 >= vertices.Length)
+                    // Not present in MOD files for the PSX.
+                    //var materialName = Encoding.ASCII.GetString(reader.ReadBytes(64));
+
+                    // This vector almost always has a length nearing 1 (more often than the normals list).
+                    // Only two files has been found where the vector length was 0.
+                    // (NEPT00.MOD and NEPTD00.MOD, where flags=0x00)
+                    // 
+                    // My theory is that this is an opportunity to allow using
+                    // a normal that differs from the vertex indices.
+                    var unitVec = ReadVector(reader, normal: true, readPad: false);
+                    var groupLength = reader.ReadUInt16(); // Zero means we're already in a group.
+
+                    var index0 = reader.ReadUInt16();
+                    var index1 = reader.ReadUInt16();
+                    var index2 = reader.ReadUInt16();
+                    var index3 = reader.ReadUInt16();
+                    if (index0 >= countVerts || index1 >= countVerts || index2 >= countVerts || index3 >= countVerts)
                     {
                         return null;
                     }
-                    var unk9 = BRenderHelper.ReadU16BE(reader.BaseStream);
-                    var unk10 = reader.BaseStream.ReadByte();
-                    var primFlags = reader.BaseStream.ReadByte();
-                    var vertex0 = vertices[f0];
-                    var vertex1 = vertices[f1];
-                    var vertex2 = vertices[f2];
-                    var normal0 = normals[f0];
-                    var normal1 = normals[f1];
-                    var normal2 = normals[f2];
-                    //if (Math.Abs((normal0 + normal1 + normal2).Length) <= 0.0f)
+
+                    var faceInfo = reader.ReadUInt32();
+                    var faceFlags = (faceInfo >> 24) & 0xff;
+                    var texture = ((faceFlags >> 0) & 0x1) == 1;
+                    var quad    = ((faceFlags >> 3) & 0x1) == 1;
+                    var uvFlip  = ((faceFlags >> 4) & 0x1) == 1;
+                    // This is just a guess, and I'm not confident in it.
+                    //var gouraud = ((faceFlags >> 7) & 0x1) == 0;
+                    // All other flag bits have been spotted (set and unset), the most common being 0x80.
+
+                    //if (groupLength != 0)
                     //{
+                    //    groupRemaining = groupLength;
+                    //}
+                    //else if (groupRemaining <= 0)
+                    //{
+                    //}
+                    //groupRemaining--;
+
+                    var vertex0 = vertices[index0];
+                    var vertex1 = vertices[index1];
+                    var vertex2 = vertices[index2];
+                    var normal0 = normals[index0];
+                    var normal1 = normals[index1];
+                    var normal2 = normals[index2];
+                    // Just a guess.
+                    //if (!gouraud && !unitVec.IsZero())
+                    //{
+                    //    normal0 = normal1 = normal2 = unitVec;
+                    //}
+                    //else
+                    if (normal0.IsZero() || normal1.IsZero() || normal2.IsZero())
+                    {
                         normal0 = Vector3.Cross(vertex1 - vertex0, vertex2 - vertex0).Normalized();
                         normal1 = normal0;
                         normal2 = normal0;
-                    //}
+                    }
+
+                    // We can't actually use UVs yet, since they're likely scaled for the material, and not the whole VRAM page.
+                    Vector2 uv0, uv1, uv2, uv3;
+                    float r, g, b;
+                    if (texture)
+                    {
+                        if (!quad)
+                        {
+                            // Is uvFlip flag ignored for tri? (flag has been observed both set and unset)
+                            uv0 = new Vector2(0, 0);
+                            uv1 = new Vector2(0, 1);
+                            uv2 = new Vector2(1, 0);
+                            uv3 = Vector2.Zero;
+                        }
+                        else
+                        {
+                            if (!uvFlip)
+                            {
+                                uv0 = new Vector2(1, 0);
+                                uv1 = new Vector2(0, 0);
+                                uv2 = new Vector2(1, 1);
+                                uv3 = new Vector2(0, 1);
+                            }
+                            else
+                            {
+                                uv0 = new Vector2(0, 0);
+                                uv1 = new Vector2(1, 0);
+                                uv2 = new Vector2(0, 1);
+                                uv3 = new Vector2(1, 1);
+                            }
+                        }
+
+                        var materialId = faceInfo & 0xffff;
+                        r = g = b = Color.DefaultColorTone;
+                    }
+                    else
+                    {
+                        uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
+
+                        r = ((faceInfo >>  0) & 0xff) / 255f;
+                        g = ((faceInfo >>  8) & 0xff) / 255f;
+                        b = ((faceInfo >> 16) & 0xff) / 255f;
+                    }
+                    var color = new Color(r, g, b);
+
                     triangles.Add(new Triangle
                     {
                         Vertices = new[] { vertex0, vertex1, vertex2 },
                         Normals = new[] { normal0, normal1, normal2 },
-                        Colors = new[] { Color.Grey, Color.Grey, Color.Grey },
+                        Colors = new[] { color, color, color },
                         Uv = new[] { Vector2.Zero, Vector2.Zero, Vector2.Zero },
                         AttachableIndices = new [] {uint.MaxValue, uint.MaxValue, uint.MaxValue}
                     });
-                    if ((primFlags & 0x8) != 0)
+                    if (quad)
                     {
-                        var vertex3 = vertices[f3];
-                        var normal3 = normals[f3];
-                        //if (Math.Abs((normal1 + normal3 + normal2).Length) <= 0.0f)
+                        var vertex3 = vertices[index3];
+                        var normal3 = normals[index3];
+                        // Just a guess.
+                        //if (!gouraud && !unitVec.IsZero())
+                        //{
+                        //    normal1 = normal3 = normal2 = unitVec;
+                        //}
+                        //else
+                        if (normal1.IsZero() || normal3.IsZero() || normal2.IsZero())
                         {
                             normal3 = Vector3.Cross(vertex3 - vertex1, vertex2 - vertex1).Normalized();
                             normal1 = normal3;
                             normal2 = normal3;
                         }
+
                         triangles.Add(new Triangle
                         {
                             Vertices = new[] { vertex1, vertex3, vertex2 },
                             Normals = new[] { normal1, normal3, normal2 },
-                            Colors = new[] { Color.Grey, Color.Grey, Color.Grey },
+                            Colors = new[] { color, color, color },
                             Uv = new[] { Vector2.Zero, Vector2.Zero, Vector2.Zero },
                             AttachableIndices = new[] { uint.MaxValue, uint.MaxValue, uint.MaxValue }
                         });
                     }
                 }
-                modelEntity.Triangles = triangles.ToArray();
-                models.Add(modelEntity);
+
+                if (collision)
+                {
+                    // Skip collision(?) data.
+                    var size1 = reader.ReadUInt16();
+                    var size2 = reader.ReadUInt16();
+                    reader.BaseStream.Seek((size1 + size2) * 44, SeekOrigin.Current);
+                }
+
+                // Don't add empty models.
+                if (triangles.Count > 0)
+                {
+                    var modelEntity = new ModelEntity
+                    {
+                        Triangles = triangles.ToArray(),
+                        TMDID = i,
+                    };
+                    models.Add(modelEntity);
+                }
             }
             if (models.Count > 0)
             {

--- a/Classes/GeomUtils.cs
+++ b/Classes/GeomUtils.cs
@@ -219,6 +219,12 @@ namespace PSXPrev.Classes
             }
         }
 
+        public static bool IsZero(this Vector3 v)
+        {
+            return (v.X == 0f && v.Y == 0f && v.Z == 0f);
+            // Or just: return v == Vector3.Zero;
+        }
+
         public static float InterpolateValue(float src, float dst, float delta)
         {
             // Uncomment if we want clamping. Or add bool clamp as an optional parameter.

--- a/Program.cs
+++ b/Program.cs
@@ -104,6 +104,9 @@ namespace PSXPrev
         public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
         public static ulong MaxHMDMimeDiffs = 100;
         public static ulong MaxHMDVertCount = 5000;
+        public static ulong MaxMODModels = 1000;
+        public static ulong MaxMODVertices = 10000;
+        public static ulong MaxMODFaces = 10000;
         public static uint MaxANJoints = 512;
         public static uint MaxANFrames = 5000;
 


### PR DESCRIPTION
This PR fixes reader issues with MOD (Croc) model files. All supplied MOD files used for testing now read without error. RGB color is now used when the texture face flag is unset, and collision data is skipped if the flag for that data section is present. Additionally, zero countVerts is now allowed (while continuing to read the rest of the sub-model, so that we're on the correct reader offset for the next sub-model).

* Stopped using BRenderHelper to read uint16s and uint32s, because reading BE was actually reading as little endian, so BinaryReader can just be used as-is. BRenderHelper is now unused.
* Fixed BRenderHelper's swapped BE and LE function names.
* Added MOD constants to Program to replace using constants in the reader. Also fixed MaxMODModels and MaxMODVertices being swapped.
* Normals list is now used unless any of the normals have a length of zero.
* Put more research into understanding of the remaining unknown values. Some of it is thanks to @vs49688 :)
* Discovered that the first 3 int16s of a face are a unit vector, but how it's used is unknown. My guess is it might be an alternative to using the normals provided by vertex indices.
* Discovered the uint16 after the unit vector describes a count for a following number of faces (when non-zero).
* Added `GeomUtils.IsZero(this Vector3)` for quickly checking for zero-length vectors.