### PR TITLE
BoundingBox and Camera refactoring and center on model

### DIFF
--- a/Classes/MeshBatch.cs
+++ b/Classes/MeshBatch.cs
@@ -34,7 +34,7 @@ namespace PSXPrev
 
             //count the selected entity
             var modelCount = 1;
-            //count checked, excecpt, the selected
+            //count checked, except, the selected
             if (checkedEntities != null)
             {
                 foreach (var checkedEntity in checkedEntities)
@@ -46,7 +46,7 @@ namespace PSXPrev
                     modelCount += checkedEntity.ChildEntities.Length;
                     if (focus)
                     {
-                        bounds.AddPoints(checkedEntity.Bounds3D.Corners);
+                        bounds.AddBounds(checkedEntity.Bounds3D);
                     }
                 }
             }
@@ -58,7 +58,7 @@ namespace PSXPrev
                     modelCount++;
                     if (focus)
                     {
-                        bounds.AddPoints(subEntity.Bounds3D.Corners);
+                        bounds.AddBounds(subEntity.Bounds3D);
                     }
                 }
             }

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -96,7 +96,6 @@ namespace PSXPrev.Classes
             base.ComputeBounds();
             var bounds = new BoundingBox();
             var worldMatrix = WorldMatrix;
-            var hasBounds = false;
             foreach (var triangle in Triangles)
             {
                 if (triangle.Vertices != null)
@@ -112,12 +111,11 @@ namespace PSXPrev.Classes
                         }
                         var vertex = triangle.Vertices[i];
                         bounds.AddPoint(Vector3.TransformPosition(vertex, worldMatrix));
-                        hasBounds = true;
                     }
 
                 }
             }
-            if (!hasBounds)
+            if (!bounds.IsSet)
             {
                 // When a model has all attached limb vertices, the model itself will have no bounds
                 // and will always be positioned at (0, 0, 0), even if the root entity has translation.

--- a/Classes/RootEntity.cs
+++ b/Classes/RootEntity.cs
@@ -17,7 +17,7 @@ namespace PSXPrev.Classes
             var bounds = new BoundingBox();
             foreach (var entity in ChildEntities)
             {
-                bounds.AddPoints(entity.Bounds3D.Corners);
+                bounds.AddBounds(entity.Bounds3D);
             }
             Bounds3D = bounds;
         }


### PR DESCRIPTION
## BoundingBox changes
* Added AddBounds function, which only needs the Min and Max of a bounding box, rather than 8 updated corners. All calls to AddPoints were just adding bounds, so AddPoints is now unused. Not that AddPoints was a bottleneck before... but it's faster with AddBounds now.
* Changed AddPoints to accept an IEnumerable of points, rather than an array.
* Made public property IsSet, which is now used by ModelEntity, rather than tracking hasBounds manually.
* Added Reset function to change IsSet back to false.
* Renamed MagnitudeFromCenter to a more fitting name: MagnitudeFromOrigin.
* Added MagnitudeFromCenter property (which is just Extents.Length). Note that Scene still uses the renamed MagnitudeFromOrigin property.
* Added MagnitudeFromPosition function for any other position that isn't (0, 0, 0) or the bounds center.
* Replaced GetMinMax with individual calls to Vector3.ComponentMin and Vector3.ComponentMax.
* Simplified ToString, since Vector3.ToString() already outputs the same format used for both Min and Max.

## Scene changes
* Added comments in Scene.UpdateViewMatrix describing how the camera translation works, because I spent a good one hour trying to do something the camera wasn't designed to do.
* Simplified eye to use the Xyz property, rather than constructing a new Vector3 by hand.
* View Matrix now supports a non-(0, 0, 0) origin (which is assigned to `_viewTarget`). Added `_viewOriginMatrix`, which is the transform before `_viewTarget` translation is applied. This origin view matrix is needed for some properties like getting the camera rotation and distance to the target (which effects camera movement speed). View target is assigned in FocusOnBounds.