### PR TITLE
Fix HMD ground parsing, some MIMe fixes, and general HMD refactoring

### DIFF
--- a/Classes/CrocModelReader.cs
+++ b/Classes/CrocModelReader.cs
@@ -175,9 +175,7 @@ namespace PSXPrev.Classes
                     //else
                     if (normal0.IsZero() || normal1.IsZero() || normal2.IsZero())
                     {
-                        normal0 = Vector3.Cross(vertex1 - vertex0, vertex2 - vertex0).Normalized();
-                        normal1 = normal0;
-                        normal2 = normal0;
+                        normal0 = normal1 = normal2 = GeomUtils.CalculateNormal(vertex0, vertex1, vertex2);
                     }
 
                     // We can't actually use UVs yet, since they're likely scaled for the material, and not the whole VRAM page.
@@ -244,9 +242,7 @@ namespace PSXPrev.Classes
                         //else
                         if (normal1.IsZero() || normal3.IsZero() || normal2.IsZero())
                         {
-                            normal3 = Vector3.Cross(vertex3 - vertex1, vertex2 - vertex1).Normalized();
-                            normal1 = normal3;
-                            normal2 = normal3;
+                            normal1 = normal3 = normal2 = GeomUtils.CalculateNormal(vertex1, vertex3, vertex2);
                         }
 
                         triangles.Add(new Triangle

--- a/Classes/GeomUtils.cs
+++ b/Classes/GeomUtils.cs
@@ -225,6 +225,16 @@ namespace PSXPrev.Classes
             // Or just: return v == Vector3.Zero;
         }
 
+        public static Vector3 CalculateNormal(Vector3 vertex0, Vector3 vertex1, Vector3 vertex2)
+        {
+            var cross = Vector3.Cross(vertex1 - vertex0, vertex2 - vertex0);
+            if (!cross.IsZero())
+            {
+                cross.Normalize();
+            }
+            return cross;
+        }
+
         public static float InterpolateValue(float src, float dst, float delta)
         {
             // Uncomment if we want clamping. Or add bool clamp as an optional parameter.

--- a/Program.cs
+++ b/Program.cs
@@ -104,8 +104,9 @@ namespace PSXPrev
         public static ulong MaxHMDAnimSequenceSize = 20000;
         public static ulong MaxHMDAnimSequenceCount = 1024;
         public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
-        public static ulong MaxHMDMimeDiffs = 100;
-        public static ulong MaxHMDVertCount = 5000;
+        public static ulong MaxHMDMIMEeDiffs = 100;
+        public static ulong MaxHMDMIMEeOriginals = 100;
+        public static ulong MaxHMDVertices = 5000;
         public static ulong MaxMODModels = 1000;
         public static ulong MaxMODVertices = 10000;
         public static ulong MaxMODFaces = 10000;


### PR DESCRIPTION
Note that the ground format seems poorly thought out, and it's not clear what's intended for how to reach certain data. For example, there's no index to read the last row/column of vertices, so what's the point of vertexStart? Additionally there's no way to specify the order of quad vertices, so traingles are always facing the same direction.

* Grid is now properly read, before only the first grid column was being read.
* Vertices (Z positions) are now properly read. This includes reading ahead to the next vertex row/column, and also using different Z values for each vertex of a grid cell.
* Normals are read.
* UVs are read and TSB is parsed.
* Ground HAS NOT been changed to not be facing vertical. At first I thought I should just flip the Z and Y assignments, but maybe that's not it, because the normal was a UnitZ vector too...
* dataCount is no longer an argument, as only one grid can be defined per type in ProcessPrimitive.
* 3 indexes are now read inside the function instead of outside.

<details>
<summary>Preview of PsyQ's GROUND.HMD</summary>

![image](https://github.com/rickomax/psxprev/assets/9752430/de9daf91-eafb-43a4-9500-64228d5f8bd5)

</details>

## Other changes
* Added ParseCBA and ParseTSB helper functions to TMDHelper.
* Added CalculateNormal helper function to GeomUtils, and replaced all instances where this was done manually (CrocModelReader and TMDHelper).
* TMDHelper now calculates normals for quad triangles when NORMAL3 is missing (like is done for the first triangle).
* Fixed ProcessMIMe not reading diffIndex each loop for dataCount.
* ProcessMIMe no longer assigns oNum (numOriginals) as objectId of the animation. Currently it's (`mimeId + 1`), but this doesn't seem any more correct. It's temporary for now...

## HMDParser refactoring
* Renamed category 7 Devices to Equipment, because that's what the library reference calls them.
* Renamed all uses of Mime to MIMe.
* Renamed some MIMe variables with horribly short names to be clearer (i.e. rst -> reset, org -> orig).
* Added more MIMe sanity check constants.
* Renamed MaxHMDVertCount to MaxHMDVertices (to match other similar constants).
* Renamed use of dataTop (when referring to polygons) to polyTop.
* All ProcessHeader functions now list their output variables in the order they appear in the header.
* Removed nextPrimitivePointer argument from all Process functions, since they weren't used.
* Renamed ProcessPrimitive to ProcessPrimitiveSet, to match how these chains are named in LAB files.
* Moved ProcessImageData below ProcessSharedIndicesData, to have the order match the category numbers. Also so that its grouped with similar functions and ReadMapped/Vertex/Normal functions aren't just randomly in the middle.