### PR TITLE
HMD curve animations and enhanced animator timing

### DIFF
--- a/Classes/Animation.cs
+++ b/Classes/Animation.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace PSXPrev.Classes
 {
@@ -22,8 +25,9 @@ namespace PSXPrev.Classes
         public uint FrameCount { get; set; }
 
         [DisplayName("Frames per Second")]
-        public float FPS { get; set; }
+        public float FPS { get; set; } = 1f;
 
+        // Total number of objects managed by this animation, not just number of children in RootAnimationObject.
         [DisplayName("Children"), ReadOnly(true)]
         public int ObjectCount { get; set; }
 
@@ -33,5 +37,83 @@ namespace PSXPrev.Classes
         [DisplayName("Animation Type")]
         public AnimationType AnimationType { get; set; }
 
+
+        // When animation objects have their own frame counts/speeds, they will become unsynced as the animation loops.
+        [DisplayName("Unsynced Objects")]
+        public bool HasUnsyncedObjects
+        {
+            get
+            {
+                var queue = new Queue<AnimationObject>();
+                queue.Enqueue(RootAnimationObject);
+                while (queue.Count > 0)
+                {
+                    var animationObject = queue.Dequeue();
+                    var objectFrameCount = animationObject.FrameCount;
+                    // This lazily checks if frame count or speed doesn't match.
+                    // It doesn't check if the different speed would actually result in the same frame count.
+                    if (objectFrameCount != 0 && (objectFrameCount != FrameCount || animationObject.Speed != 1f))
+                    {
+                        return true;
+                    }
+                    foreach (var child in animationObject.Children)
+                    {
+                        queue.Enqueue(child);
+                    }
+                }
+                return false;
+            }
+        }
+
+
+        // Assign a flat collection of objects and setup parenting and hierarchy.
+        public void AssignObjects(Dictionary<uint, AnimationObject> animationObjects, bool calcObjectFrameCounts, bool calcFrameDurations)
+        {
+            RootAnimationObject = new AnimationObject();
+            ObjectCount = animationObjects.Count;
+
+            var maxAnimFrameCount = 0d;
+            foreach (var animationObject in animationObjects.Values)
+            {
+                // Compute frame count for object and durations for frames.
+                AnimationFrame lastAnimationFrame = null;
+                uint maxObjectFrameCount = 0;
+                foreach (var animationFrame in animationObject.AnimationFrames.Values.OrderBy(af => af.FrameTime))
+                {
+                    if (calcFrameDurations && lastAnimationFrame != null)
+                    {
+                        lastAnimationFrame.FrameDuration = animationFrame.FrameTime - lastAnimationFrame.FrameTime;
+                    }
+                    lastAnimationFrame = animationFrame;
+                    maxObjectFrameCount = Math.Max(maxObjectFrameCount, animationFrame.FrameEnd);
+                }
+
+                if (calcObjectFrameCounts)
+                {
+                    animationObject.FrameCount = maxObjectFrameCount;
+                }
+                // Faster speeds means the actual animation has less frames.
+                var speed = animationObject.Speed;
+                maxAnimFrameCount = Math.Max(maxAnimFrameCount, (speed == 0 ? 0 : (double)maxObjectFrameCount / speed));
+
+                // Assign parent and add to animation.
+                if (animationObject.ParentID != 0 && animationObjects.TryGetValue(animationObject.ParentID, out var parent))
+                {
+                    animationObject.Parent = parent;
+                    parent.Children.Add(animationObject);
+                }
+                else
+                {
+                    animationObject.Parent = RootAnimationObject;
+                    RootAnimationObject.Children.Add(animationObject);
+                }
+            }
+
+            FrameCount = (uint)Math.Ceiling(maxAnimFrameCount);
+            if (calcObjectFrameCounts)
+            {
+                RootAnimationObject.FrameCount = FrameCount;
+            }
+        }
     }
 }

--- a/Classes/AnimationBatch.cs
+++ b/Classes/AnimationBatch.cs
@@ -7,39 +7,221 @@ namespace PSXPrev.Classes
 {
     public class AnimationBatch
     {
-        private Animation _animation;
+        // How close to be near the end of a looping animation while staying at the end (and not being modulused).
+        private const double EPSILON = 0.0001d;
+
         private readonly Scene _scene;
+        private Animation _animation;
+        private WeakReference<RootEntity> _lastRootEntity; // Optimize: Use weak reference because we only need to check reference equals.
+        private double _time;
+        private double _loopDelayTime;
+        private double _playbackFrameTime;
+        private double _lastPlaybackFrameTime; // Optimize: For animation state updates. Not relevant when _finished is true.
+        private bool _finished;
+        private bool _lastFinished; // Optimize: For animation state updates.
+        private bool _delaying;
+        private bool _mirroring;
+        private bool _playbackStateChanged; // Optimize: Do we need to call ComputePlaybackFrameTime?
+        private bool _animationStateChanged; // Optimize: Force animation state updates.
+        private bool _reverse;
+        private AnimationLoopMode _loopMode = AnimationLoopMode.Loop;
+
+        // Real time in seconds (including looping and delayed time).
+        public double Time
+        {
+            get => _time;
+            set
+            {
+                // todo: Should we cap time at 0, or handle negative time?
+                value = Math.Max(0d, value);
+                if (_time != value)
+                {
+                    _time = value;
+                    _playbackStateChanged = true;
+                    // Don't assume changes to time will invalidate the animation state.
+                    // We'll figure this out after ComputePlaybackFrameTime().
+                }
+            }
+        }
+
+        // Play animation in reverse. AddTime subtracts seconds instead of adding them.
+        public bool Reverse
+        {
+            get => _reverse;
+            set
+            {
+                if (_reverse != value)
+                {
+                    _reverse = value;
+                    Invalidate();
+                }
+            }
+        }
+
+        // How to handle restarting animation after reaching FrameCount.
+        public AnimationLoopMode LoopMode
+        {
+            get => _loopMode;
+            set
+            {
+                if (_loopMode != value)
+                {
+                    _loopMode = value;
+                    Invalidate();
+                }
+            }
+        }
+
+        // Seconds to wait before restarting loop.
+        public double LoopDelayTime
+        {
+            get => _loopDelayTime;
+            set
+            {
+                value = Math.Max(0d, value);
+                if (_loopDelayTime != value)
+                {
+                    _loopDelayTime = value;
+                    Invalidate();
+                }
+            }
+        }
+
+        // LoopMode is a Once type, and the animation has finished.
+        // It's only recommended to check this after SetupAnimationFrame, because this is calculated before then.
+        public bool IsFinished
+        {
+            get
+            {
+                ComputePlaybackFrameTime();
+                return _finished;
+            }
+        }
+
+        // The playback time is currently in the middle of LoopDelayTime.
+        public bool IsDelaying
+        {
+            get
+            {
+                ComputePlaybackFrameTime();
+                return _delaying;
+            }
+        }
+
+        // The playback time is past FrameCount and is reversing back to the beginning.
+        public bool IsMirroring
+        {
+            get
+            {
+                ComputePlaybackFrameTime();
+                return _mirroring;
+            }
+        }
+
+        // Frame rate of animation for converting Time to FrameTime.
+        public float FPS => _animation?.FPS ?? 1f;
+        // The duration of the animation in seconds.
+        public double Duration => (FPS == 0 ? 0 : FrameCount / FPS);
+        // Number of frames in the animation.
+        public double FrameCount => (FPS == 0 ? 0 : (_animation?.FrameCount ?? 0));
+        // Frames to wait before restarting loop.
+        public double LoopDelayFrameCount => LoopDelayTime * FPS;
+        // Total number of frames in animation and frames to wait between restarting loops.
+        public double TotalFrameCount => FrameCount + LoopDelayFrameCount;
+        // Real time in frames (including looping and delayed time). (Time x FPS)
+        public double FrameTime => Time * FPS;
+        // Looped, capped, and mirrored playback time in frames.
+        public double CurrentFrameTime => Math.Max(0, Math.Min(FrameCount, LoopFrameTime()));
+
 
         public AnimationBatch(Scene scene)
         {
             _scene = scene;
+            _lastRootEntity = new WeakReference<RootEntity>(null);
         }
+
+
+        // Invalidate animation state to force an update during the next call to SetupAnimationFrame.
+        public void Invalidate()
+        {
+            _playbackStateChanged = true;
+            _animationStateChanged = true;
+        }
+
+        // Calling this also calls Invalidate.
+        public void Restart()
+        {
+            Time = 0d;
+            Invalidate();
+        }
+
+        public void AddTime(double seconds)
+        {
+            Time += seconds;
+        }
+
+        public void SetTimeToFrame(AnimationFrame frame)
+        {
+            var timeMultiplier = FPS * Math.Abs(frame.AnimationObject.Speed);
+            if (timeMultiplier != 0)
+            {
+                //const double EPSILON = 0.0001d;
+                Time = (frame.FrameEnd - EPSILON) / timeMultiplier;
+            }
+            else
+            {
+                Time = 0d;
+            }
+        }
+
 
         public void SetupAnimationBatch(Animation animation)
         {
-            var objectCount = animation.ObjectCount;
-            _scene.MeshBatch.Reset(objectCount + 1);
+            // todo: Is this correct for handling reseting the mesh batch?
+            // What if the animation doesn't match the object?
+            var objectCount = animation == null ? 0 : (animation.ObjectCount + 1);
+            _scene.MeshBatch.Reset(objectCount);
             _scene.BoundsBatch.Reset();
             _scene.TriangleOutlineBatch.Reset();
             _scene.SkeletonBatch.Reset();
             _scene.GizmosMeshBatch.Reset(0);
-            _animation = animation;
+            if (_animation != animation)
+            {
+                _animation = animation;
+                _playbackStateChanged = true;
+                Invalidate();
+            }
+            Restart();
         }
 
-        public bool SetupAnimationFrame(float frameIndex, RootEntity[] checkedEntities, RootEntity selectedRootEntity, ModelEntity selectedModelEntity, bool updateMeshData = false)
+        // Returns true if the animation has been processed (updated), or false if nothing needed to be updated.
+        public bool SetupAnimationFrame(RootEntity[] checkedEntities, RootEntity selectedRootEntity, ModelEntity selectedModelEntity, bool updateMeshData = false)
         {
             _scene.SkeletonBatch.Reset();
-            RootEntity rootEntity = null;
-            if (selectedRootEntity != null)
-            {
-                rootEntity = selectedRootEntity;
-            }
-            else if (selectedModelEntity != null)
-            {
-                rootEntity = selectedModelEntity.GetRootEntity();
-            }
+            var rootEntity = selectedRootEntity ?? selectedModelEntity?.GetRootEntity();
+
             _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, selectedModelEntity, selectedRootEntity, _scene.TextureBinder, updateMeshData || _scene.AutoAttach, false, true);
-            return ProcessAnimationObject(_animation.RootAnimationObject, frameIndex, rootEntity, Matrix4.Identity);
+
+            ComputePlaybackFrameTime();
+
+            var needsUpdate = (_animationStateChanged) ||
+                              (_lastFinished != _finished) ||
+                              (!_finished && _lastPlaybackFrameTime != _playbackFrameTime) ||
+                              (!_lastRootEntity.TryGetTarget(out var lastRootEntity) || lastRootEntity != rootEntity);
+
+            _animationStateChanged = false;
+            _lastPlaybackFrameTime = _playbackFrameTime;
+            _lastFinished = _finished;
+            _lastRootEntity.SetTarget(rootEntity);
+            
+            // The result has been changed to signal if anything has been processed or not.
+            if (needsUpdate)
+            {
+                // todo: What does ProcessAnimationObject's return boolean signify?
+                ProcessAnimationObject(_animation.RootAnimationObject, rootEntity, Matrix4.Identity);
+                return true;
+            }
+            return false;
         }
 
         private void ResetAnimationCoords(AnimationObject animationObject, RootEntity selectedRootEntity)
@@ -68,7 +250,7 @@ namespace PSXPrev.Classes
             }
         }
 
-        private bool ProcessAnimationObject(AnimationObject animationObject, float frameIndex, RootEntity selectedRootEntity, Matrix4 worldMatrix)
+        private bool ProcessAnimationObject(AnimationObject animationObject, RootEntity selectedRootEntity, Matrix4 worldMatrix)
         {
             // Reset coordinate matrices in-case a frame requires the last state of the matrix.
             // This is important because there's no guarantee the animation won't skip a frame due to lag.
@@ -76,6 +258,8 @@ namespace PSXPrev.Classes
             {
                 ResetAnimationCoords(animationObject, selectedRootEntity);
             }
+
+            var frameTime = LoopFrameTime(animationObject, out var frameIndex, out var frameDelta);
 
             switch (_animation.AnimationType)
             {
@@ -91,15 +275,14 @@ namespace PSXPrev.Classes
                                 {
                                     if (childModel.TMDID == objectId)
                                     {
-                                        var intFrameIndex = (uint)frameIndex;
-                                        if (intFrameIndex > animationObject.AnimationFrames.Count - 1)
+                                        if (frameIndex > animationObject.AnimationFrames.Count - 1)
                                         {
                                             return false;
                                         }
-                                        var animationFrame = animationObject.AnimationFrames[intFrameIndex];
-                                        if (intFrameIndex > 0)
+                                        var animationFrame = animationObject.AnimationFrames[(uint)frameIndex];
+                                        if (frameIndex > 0)
                                         {
-                                            var lastFrame = animationObject.AnimationFrames[intFrameIndex - 1];
+                                            var lastFrame = animationObject.AnimationFrames[(uint)frameIndex - 1];
                                             for (uint j = 0; j < animationFrame.Vertices.Length; j++)
                                             {
                                                 if (j < lastFrame.Vertices.Length)
@@ -119,7 +302,8 @@ namespace PSXPrev.Classes
                                                 animationFrame.TempVertices[j] = Vector3.Zero;
                                             }
                                         }
-                                        var interpolator = frameIndex % 1;
+                                        var interpolator = frameDelta;
+                                        //var interpolator = GetInterpolator(animationFrame, frameTime);
                                         var initialVertices = _animation.AnimationType == AnimationType.VertexDiff ? animationFrame.TempVertices : null;
                                         var finalVertices = _animation.AnimationType == AnimationType.VertexDiff ? animationFrame.Vertices : null;
                                         var initialNormals = _animation.AnimationType == AnimationType.NormalDiff ? animationFrame.TempVertices : null;
@@ -222,25 +406,12 @@ namespace PSXPrev.Classes
                             }
                             var totalFrames = animationFrames.Values.Max(af => af.FrameTime + Math.Max(1u, af.FrameDuration));
 
-
                             for (uint f = 0; f <= frameIndex && f < totalFrames; f++)
                             {
                                 if (!animationFrames.TryGetValue(f, out var srcFrame))
                                 {
                                     continue;
                                 }
-                                /*AnimationFrame dstFrame = null;
-                                for (uint fdst = f + 1; fdst < totalFrames; fdst++)
-                                {
-                                    if (animationFrames.TryGetValue(fdst, out dstFrame))
-                                    {
-                                        break;
-                                    }
-                                }
-                                if (dstFrame == null)
-                                {
-                                    dstFrame = srcFrame;
-                                }*/
 
                                 // todo: How to properly handle certain None interpolation types is not fully understood.
 
@@ -252,39 +423,36 @@ namespace PSXPrev.Classes
                                     }
                                     var coord = selectedRootEntity.Coords[tmdid - 1];
 
-                                    float start = srcFrame.FrameTime;
-                                    //float range = dstFrame.FrameTime - srcFrame.FrameTime;
-                                    float range = srcFrame.FrameDuration;
-                                    float delta = (range != 0f ? Math.Max(0f, Math.Min(1f, (frameIndex - start) / range)) : 1f);
+                                    var delta = GetInterpolator(srcFrame, frameTime);
 
                                     Matrix4 frameMatrix;
                                     var needsTranslation = false;
-                                    if (srcFrame.RotationType == InterpolationType.Linear || srcFrame.ScaleType == InterpolationType.Linear)
+                                    var typeR = srcFrame.RotationType;
+                                    var typeS = srcFrame.ScaleType;
+                                    if (typeR != InterpolationType.None || typeS != InterpolationType.None)
                                     {
                                         // Use new matrix.
                                         frameMatrix = Matrix4.Identity;
                                         needsTranslation = true;
 
-                                        if (srcFrame.ScaleType == InterpolationType.Linear) // has supported scale
+                                        if (typeS != InterpolationType.None) // has supported scale
                                         {
-                                            var srcS = srcFrame.Scale.Value;
-                                            //var dstS = dstFrame.Scale ?? srcS;
-                                            var dstS = srcFrame.FinalScale ?? srcS;
-                                            var scale = GeomUtils.InterpolateVector(srcS, dstS, delta);
-                                            //var scale = HMDHelper.Interpolate(srcFrame.ScaleType, srcFrame.Scale, srcFrame.CurveScales, srcFrame.FinalScale, delta);
+                                            var srcS = srcFrame.Scale;
+                                            var curveS = srcFrame.CurveScales;
+                                            var dstS = srcFrame.FinalScale;
+                                            var scale = HMDHelper.Interpolate(typeS, srcS, curveS, dstS, delta);
                                             var s = GeomUtils.CreateS(scale);
                                             frameMatrix *= s;
                                         }
 
                                         Vector3 e;
                                         RotationOrder rotOrder;
-                                        if (srcFrame.RotationType == InterpolationType.Linear) // has supported rotation
+                                        if (typeR != InterpolationType.None) // has supported rotation
                                         {
-                                            var srcR = srcFrame.EulerRotation.Value;
-                                            //var dstR = dstFrame.EulerRotation ?? srcR;
-                                            var dstR = srcFrame.FinalEulerRotation ?? srcR;
-                                            e = GeomUtils.InterpolateVector(srcR, dstR, delta);
-                                            //e = HMDHelper.Interpolate(srcFrame.RotationType, srcFrame.EulerRotation, srcFrame.CurveEulerRotations, srcFrame.FinalEulerRotation, delta);
+                                            var srcR = srcFrame.EulerRotation;
+                                            var curveR = srcFrame.CurveEulerRotations;
+                                            var dstR = srcFrame.FinalEulerRotation;
+                                            e = HMDHelper.Interpolate(typeR, srcR, curveR, dstR, delta);
                                             rotOrder = srcFrame.RotationOrder;
                                         }
                                         else
@@ -302,14 +470,14 @@ namespace PSXPrev.Classes
                                         frameMatrix = coord.LocalMatrix;
                                     }
 
-                                    if (srcFrame.TranslationType == InterpolationType.Linear) // has supported translation
+                                    var typeT = srcFrame.TranslationType;
+                                    if (typeT != InterpolationType.None) // has supported translation
                                     {
                                         var origT = GeomUtils.CreateT(frameMatrix.ExtractTranslation());
-                                        var srcT = srcFrame.Translation.Value;
-                                        //var dstT = dstFrame.Translation ?? srcT;
-                                        var dstT = srcFrame.FinalTranslation ?? srcT;
-                                        var translation = GeomUtils.InterpolateVector(srcT, dstT, delta);
-                                        //var translation = HMDHelper.Interpolate(srcFrame.TranslationType, srcFrame.Translation, srcFrame.CurveTranslations, srcFrame.FinalTranslation, delta);
+                                        var srcT = srcFrame.Translation;
+                                        var curveT = srcFrame.CurveTranslations;
+                                        var dstT = srcFrame.FinalTranslation;
+                                        var translation = HMDHelper.Interpolate(typeT, srcT, curveT, dstT, delta);
                                         var t = GeomUtils.CreateT(translation);
                                         frameMatrix *= origT.Inverted(); // Overwrite old translation
                                         frameMatrix *= t;
@@ -336,7 +504,7 @@ namespace PSXPrev.Classes
             }
             foreach (var childAnimationObject in animationObject.Children)
             {
-                if (!ProcessAnimationObject(childAnimationObject, frameIndex, selectedRootEntity, worldMatrix))
+                if (!ProcessAnimationObject(childAnimationObject, selectedRootEntity, worldMatrix))
                 {
                     return false;
                 }
@@ -368,6 +536,244 @@ namespace PSXPrev.Classes
             }
 
             return true;
+        }
+
+
+        private void ComputePlaybackFrameTime()
+        {
+            // Well... this got a lot more complicated than I was expecting it to...
+            // The biggest thing to blame is LoopDelayTime and objects with different frame counts/speeds.
+
+            if (!_playbackStateChanged)
+            {
+                // Everything is already calculated.
+                return;
+            }
+
+            var frameTime = FrameTime;
+            var animFrameCount = (double)FrameCount;
+
+            // When mirrored, we play twice as many animation frames before finishing/delaying.
+            var mirroredFrameCount = animFrameCount * (_loopMode.IsMirrored() ? 2 : 1);
+
+            // Compute playback frame time and delaying state.
+            if (FrameCount == 0)
+            {
+                // No frames, default to frame 0...maybe?
+                _delaying = false;
+                _playbackFrameTime = 0d;
+            }
+            else if (LoopDelayTime == 0 || frameTime == 0)
+            {
+                // No delay, loopFrameTime is just frameTime, without any extra work.
+                _delaying = false;
+                _playbackFrameTime = frameTime;
+            }
+            else
+            {
+                // If we have a delay between loops, then we need to do extra calculations to get the real frameTime.
+
+                // New time:   [0|......animation......|count]             + [[repeat]]
+                // Frame time: [0|......animation......|~~delayed~~|count] + [[repeat]]
+                //               ^                     ^           ^
+                //             begin(start)           end(stop)  resume
+                // Reverse: ==========================================================
+                // Frame time: [0|~~delayed~~|......animation......|count]
+                //               ^           ^                     ^
+                //             resume      stop(begin)           start(end)
+
+                // This reverse diagram above isn't related anymore, but I've
+                // kept it, since it's a good reference for reversed animation.
+                // If reversed, then don't pause at the start of the animation playback.
+
+                var delayFrameCount = (double)LoopDelayFrameCount;
+                var totalFrameCount = mirroredFrameCount + delayFrameCount;
+
+                // Count number of times repeated with delay, and add that while taking out the delay time.
+                var repeatFrameTime = Math.Floor(frameTime / totalFrameCount) * mirroredFrameCount;
+
+                var totalFrameTime = GeomUtils.PositiveModulus(frameTime, totalFrameCount);
+                _delaying = totalFrameTime >= mirroredFrameCount;
+                _playbackFrameTime = repeatFrameTime + (_delaying ? mirroredFrameCount : totalFrameTime);
+
+                //_delayed = reverseTotalFrameTime <= delayFrameCount;
+                //_reversePlaybackFrameTime = (_delayed ? 0d : reverseTotalFrameTime - delayFrameCount);
+                //// Count number of times repeated with delay, and add that while taking out the delay time.
+                //_reversePlaybackFrameTime -= repeatFrameTime;
+            }
+
+            // Compute finished state. Only set to finished if delay has ended.
+            _finished = false;
+            if (FrameCount == 0)
+            {
+                // todo: Should a zero-frame animation always be finished or never be finished?
+                _finished = true;
+            }
+            else if (!_loopMode.IsLooping() && !_delaying)
+            {
+                _finished = _playbackFrameTime >= mirroredFrameCount;
+            }
+
+            // Compute mirroring state. We're mirroring if we're in the second half of the animation.
+            _mirroring = false;
+            if (_loopMode.IsMirrored() && !_finished && FrameCount != 0)
+            {
+                if (_loopMode.IsLooping())
+                {
+                    var mirroredFrameTime = GeomUtils.PositiveModulus(_playbackFrameTime, mirroredFrameCount);
+                    _mirroring = mirroredFrameTime >= animFrameCount;
+                }
+                else
+                {
+                    _mirroring = (_playbackFrameTime >= animFrameCount && _playbackFrameTime < mirroredFrameCount);
+                }
+            }
+
+            _playbackStateChanged = false;
+        }
+
+
+        // Note: Currently loopedFrameDelta is no different than the unlooped FrameDelta,
+        // but keep it in-case we add support for non-integer frame counts (due to varying FPS of animation objects).
+        private double LoopFrameTime(AnimationObject animationObject = null)
+        {
+            ComputePlaybackFrameTime();
+
+            var speed = animationObject?.Speed ?? 1f;
+            double frameCount = animationObject?.FrameCount ?? 0;
+            if (frameCount == 0)
+            {
+                // Not all animation objects define individual frame counts.
+                // todo: We can't use Speed if the object doesn't have its own frame count... or can we?
+                speed = 1f;
+                frameCount = FrameCount;
+            }
+            // We can't animate if animation frame count is zero, even if using object's frame count.
+            if (FrameCount == 0 || frameCount == 0 || speed == 0)
+            {
+                return 0d;
+            }
+
+            // Check if timing is done in reverse. DON'T use the Reverse property from here on out!
+            // If speed is negative and Reverse is true, then we're just going forwards.
+            var reverse = Reverse != (speed < 0);
+            // Convert from animation to object frame time.
+            var frameTime = _playbackFrameTime * Math.Abs(speed);
+            // Convert from animation to object frame counts.
+            var animFrameCount = (double)FrameCount * Math.Abs(speed);
+
+            var closeToStart = false;
+
+            switch (_loopMode)
+            {
+                default:
+                case AnimationLoopMode.Once:
+                    frameTime = Math.Min(frameTime, animFrameCount);
+                    // Same functionality as Loop after capping.
+                    goto case AnimationLoopMode.Loop;
+
+                case AnimationLoopMode.Loop:
+                    if (reverse)
+                    {
+                        frameTime = -frameTime;
+                    }
+                    frameTime = GeomUtils.PositiveModulus(frameTime, frameCount);
+                    closeToStart = reverse != (Time == 0);
+                    break;
+
+                case AnimationLoopMode.UnsyncedLoop:
+                    if (reverse)
+                    {
+                        frameTime = -frameTime;
+                    }
+                    // This loop method effectively resets all object times
+                    // to 0 after looping, so % animFrameCount first.
+                    frameTime = GeomUtils.PositiveModulus(frameTime, animFrameCount);
+                    frameTime = GeomUtils.PositiveModulus(frameTime, frameCount);
+                    closeToStart = reverse != (Time == 0);
+                    break;
+
+                case AnimationLoopMode.MirrorOnce:
+                    frameTime = Math.Min(frameTime, animFrameCount * 2);
+                    // Same functionality as MirrorLoop after capping.
+                    goto case AnimationLoopMode.MirrorLoop;
+
+                case AnimationLoopMode.MirrorLoop:
+                    frameTime = GeomUtils.PositiveModulus(frameTime, animFrameCount * 2);
+                    if (_mirroring) //if (frameTime >= animFrameCount)
+                    {
+                        frameTime = animFrameCount * 2 - frameTime; // Mirror animation on way back.
+                    }
+                    if (reverse)
+                    {
+                        frameTime = -frameTime; // Animation starts from end then mirrors at beginning.
+                    }
+                    frameTime = GeomUtils.PositiveModulus(frameTime, frameCount);
+                    closeToStart = !reverse;
+                    break;
+            }
+
+            if (_finished || _delaying || Time == 0)
+            {
+                var timeMultiplier = FPS * Math.Abs(speed);
+                frameTime = CloseToFrameCount(closeToStart, frameTime, frameCount, timeMultiplier);
+            }
+
+            // Enforce >=0 so that objects will at least animate their first frame.
+            return Math.Max(0d, frameTime);
+        }
+
+        private double LoopFrameTime(AnimationObject animationObject, out long loopedFrameIndex, out float loopedFrameDelta)
+        {
+            var loopedFrameTime = LoopFrameTime(animationObject);
+            loopedFrameIndex = (long)Math.Floor(loopedFrameTime);
+            loopedFrameDelta = (float)GeomUtils.PositiveModulus(loopedFrameTime, 1d);
+            return loopedFrameTime;
+        }
+
+
+        // Returns 0 or frameCount if frameTime is close to it.
+        // Useful for when Modulus calculations prevent the animation from displaying in its end state.
+        private static double CloseToFrameCount(bool start, double frameTime, double frameCount, double timeMultiplier)
+        {
+            //const double EPSILON = 0.0001d;
+            var frameEpsilon = EPSILON / timeMultiplier;
+
+            bool near;
+            if (frameTime >= frameCount / 2)
+            {
+                near = (frameTime + frameEpsilon >= frameCount); // Check near frameCount
+            }
+            else
+            {
+                near = (frameTime - frameEpsilon <= 0d); // Check near zero
+            }
+            if (near)
+            {
+                frameTime = start ? 0d : frameCount; //(frameCount - frameEpsilon);
+            }
+            return frameTime;
+        }
+
+        private static float GetInterpolator(AnimationFrame frame, double frameTime)
+        {
+            if (frameTime < frame.FrameTime)
+            {
+                return 0f;
+            }
+            else if (frameTime >= frame.FrameEnd)
+            {
+                return 1f; // Also accounts for if range is zero.
+            }
+            else
+            {
+                return Math.Max(0f, Math.Min(1f, (float)(frameTime - frame.FrameTime) / frame.FrameDuration));
+            }
+        }
+
+        private static float GetInterpolator(AnimationFrame frame, long frameIndex, float frameDelta)
+        {
+            return GetInterpolator(frame, (double)frameIndex + frameDelta);
         }
     }
 }

--- a/Classes/AnimationFrame.cs
+++ b/Classes/AnimationFrame.cs
@@ -20,8 +20,8 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public Vector3? FinalEulerRotation { get; set; }
         // HMD: Used for Bezier Curve and B-Spline.
-        //[Browsable(false)]
-        //public Vector3[] CurveEulerRotations { get; set; }
+        [Browsable(false)]
+        public Vector3[] CurveEulerRotations { get; set; }
 
         [Browsable(false)]
         public InterpolationType RotationType { get; set; }
@@ -35,8 +35,8 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public Vector3? FinalScale { get; set; }
         // HMD: Used for Bezier Curve and B-Spline.
-        //[Browsable(false)]
-        //public Vector3[] CurveScales { get; set; }
+        [Browsable(false)]
+        public Vector3[] CurveScales { get; set; }
 
         [Browsable(false)]
         public InterpolationType ScaleType { get; set; }
@@ -47,24 +47,24 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public Vector3? FinalTranslation { get; set; }
         // HMD: Used for Bezier Curve and B-Spline.
-        //[Browsable(false)]
-        //public Vector3[] CurveTranslations { get; set; }
+        [Browsable(false)]
+        public Vector3[] CurveTranslations { get; set; }
 
         [Browsable(false)]
         public InterpolationType TranslationType { get; set; }
         
-        [ReadOnly(true)]
+        [DisplayName("Frame Time"), ReadOnly(true)]
         public uint FrameTime { get; set; }
 
         // HMD: Not incorporated into any other animation types.
-        [ReadOnly(true)]
+        [DisplayName("Frame Duration"), ReadOnly(true)]
         public uint FrameDuration { get; set; }
 
+        [Browsable(false)]
+        public uint FrameEnd => FrameTime + FrameDuration;
+
         [ReadOnly(true)]
-        public int VertexCount
-        {
-            get => Vertices == null ? 0 : Vertices.Length;
-        }
+        public int VertexCount => Vertices == null ? 0 : Vertices.Length;
         
         [Browsable(false)]
         public Vector3[] Vertices;
@@ -74,20 +74,17 @@ namespace PSXPrev.Classes
 
         public float RotationX => Rotation?.X ?? 0f;
 
-
         public float RotationY => Rotation?.Y ?? 0f;
 
         public float RotationZ => Rotation?.Z ?? 0f;
 
         public float ScaleX => Scale?.X ?? 0f;
 
-
         public float ScaleY => Scale?.Y ?? 0f;
 
         public float ScaleZ => Scale?.Z ?? 0f;
 
         public float PositionX => Translation?.X ?? 0f;
-
 
         public float PositionY => Translation?.Y ?? 0f;
 

--- a/Classes/AnimationLoopMode.cs
+++ b/Classes/AnimationLoopMode.cs
@@ -1,0 +1,24 @@
+﻿namespace PSXPrev.Classes
+{
+    public enum AnimationLoopMode
+    {
+        Once,         // Animation stops after reaching the end.
+        Loop,         // Animation repeats, but allows objects with unsynced frame counts to continue at their own pace.
+        UnsyncedLoop, // Animation repeats, and resets even if objects have unsynced frame counts.
+        MirrorOnce,   // Animation plays forwards and backwards, and then stops.
+        MirrorLoop,   // Animation plays forwards and backwards, and then repeats.
+    }
+
+    public static class AnimationLoopModeExtensions
+    {
+        public static bool IsLooping(this AnimationLoopMode loopMode)
+        {
+            return loopMode != AnimationLoopMode.Once && loopMode != AnimationLoopMode.MirrorOnce;
+        }
+
+        public static bool IsMirrored(this AnimationLoopMode loopMode)
+        {
+            return loopMode == AnimationLoopMode.MirrorOnce || loopMode == AnimationLoopMode.MirrorLoop;
+        }
+    }
+}

--- a/Classes/AnimationObject.cs
+++ b/Classes/AnimationObject.cs
@@ -23,6 +23,14 @@ namespace PSXPrev.Classes
         [ReadOnly(true)]
         public uint ID { get; set; }
 
+        // Looping frame count for individual animation objects. Keep as 0 to use Animation.FrameCount.
+        [DisplayName("Object Frame Count"), ReadOnly(true)]
+        public uint FrameCount { get; set; }
+
+        // Speed multiplier for individual animation objects.
+        [DisplayName("Object Speed")]
+        public float Speed { get; set; } = 1f;
+
         [DisplayName("TMD ID")]
         public List<uint> TMDID { get; set; } = new List<uint>();
 

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -147,7 +147,7 @@ namespace PSXPrev.Classes
                 foreach (var triangle in Triangles)
                 {
                     // If we have cached connections, then use those. It'll make things much faster.
-                    if (triangle.AttachedCache != null && false)
+                    if (triangle.AttachedCache != null)
                     {
                         for (var i = 0; i < 3; i++)
                         {
@@ -171,6 +171,12 @@ namespace PSXPrev.Classes
                         var attachedNormalIndex = triangle.AttachedNormalIndices?[i] ?? uint.MaxValue;
                         if (attachedIndex != uint.MaxValue)
                         {
+                            // In the event that some attached indices are not found,
+                            // we don't want to waste time looking for them again. Create an attached cache now.
+                            if (triangle.AttachedCache == null)
+                            {
+                                triangle.AttachedCache = new Tuple<EntityBase, Vector3>[3];
+                            }
                             foreach (ModelEntity subModel in rootEntity.ChildEntities)
                             {
                                 if (subModel != this)
@@ -183,10 +189,6 @@ namespace PSXPrev.Classes
                                             {
                                                 var attachedVertex = subTriangle.Vertices[j];
                                                 // Cache connection to speed up FixConnections in the future.
-                                                if (triangle.AttachedCache == null)
-                                                {
-                                                    triangle.AttachedCache = new Tuple<EntityBase, Vector3>[3];
-                                                }
                                                 triangle.AttachedCache[i] = new Tuple<EntityBase, Vector3>(subModel, attachedVertex);
                                                 triangle.Vertices[i] = ConnectVertex(subModel, attachedVertex);
                                                 break;
@@ -202,10 +204,6 @@ namespace PSXPrev.Classes
                                     if (subModel.AttachableVertices != null && subModel.AttachableVertices.TryGetValue(attachedIndex, out var attachedVertex))
                                     {
                                         // Cache connection to speed up FixConnections in the future.
-                                        if (triangle.AttachedCache == null)
-                                        {
-                                            triangle.AttachedCache = new Tuple<EntityBase, Vector3>[3];
-                                        }
                                         triangle.AttachedCache[i] = new Tuple<EntityBase, Vector3>(subModel, attachedVertex);
                                         triangle.Vertices[i] = ConnectVertex(subModel, attachedVertex);
                                     }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Classes\Animation.cs" />
     <Compile Include="Classes\AnimationBatch.cs" />
     <Compile Include="Classes\AnimationFrame.cs" />
+    <Compile Include="Classes\AnimationLoopMode.cs" />
     <Compile Include="Classes\AnimationObject.cs" />
     <Compile Include="Classes\ANParser.cs" />
     <Compile Include="Classes\BFFModelReader.cs" />


### PR DESCRIPTION
To test animation modes, a block of code commented out with `#if false` has been left at the bottom of PreviewForm, which enables keys to change modes and times.

* Fix FixConnections always ignoring cached connections because of `&& false` left in during testing.
* FixConnections now always creates a cache for an attached index, even if an attachable index wasn't found. This way we don't need to waste time looking for connections that don't exist every call.
* Added GeomUtils.PositiveModulus, for getting the non-negative modulus of a value.
* Added GeomUtils.InterpolateBezierCurve and GeomUtils.InterpolateBSpline, needed for HMD animations.
* HMD animations now support Bezier and BSpline interpolation types.
* Rewrote most of the handling for building HMD animation sequences. This helps support curves and fixes a lot of issues with looping and stuttering with the PsyQ models, while somehow managing to *not* break anything else. By pure luck, the rewrite made the code a lot simplier too.
* TODParser now explicitly assigns AnimationType.Common, rather than letting it default to that because the value is 0.
* All animation builders in parsers now use TryGetValue, rather than ContainsKey and indexers.
* All animation builders now assign FrameDuration = 1 by default.
* Added Animation.AssignChildren, which replaces the duplicate code used in all animation builders to assign object children and calculate animation frame count.
* Animation.FPS now has a default value of `1f`.
* AnimationObject now has its own FrameCount property, and a Speed property. This allows objects with different time scales to animate and loop at their own pace.
* AnimationBatch now handles all timing (except incrementing the timer). This includes support for new looping modes, reverse modes, and an optional pause time to wait between the end of one loop and the start of the next.
* AnimationBatch tracks if an object has finished animating when LoopMode is a Once type.
* AnimationBatch timers use doubles rather than floats to avoid issues with float precession.
* The rewrite for AnimationBatch handling time is a bit complex and convoluted, but that's mostly due to supporting LoopDelayTime, objects with their own frame counts/speeds, and Mirrored loop modes.

***

* Added Refresh when changing Playing state so that Play/Stop is always the correct text on the button.
* "Animation-Object #" text is now 0-indexed to match Sub-Models.
* Renamed UpdateAnimationFPS to UpdateAnimationTimerSpeed, so that it's clearer.
* Renamed UpdateFrameLabel to UpdateAnimationProgressLabel, so that it's clearer, and tells that it relates to animations.
* Made the distinction between the Models and Animations tab clearer. Animations should stop and reset the model when leaving the animation tab. The player should also stop too.