### PR TITLE
Untextured semi-transparency and Textured render flag

### DIFF
--- a/Classes/Mesh.cs
+++ b/Classes/Mesh.cs
@@ -10,7 +10,7 @@ namespace PSXPrev.Classes
 
         public Matrix4 WorldMatrix { get; set; }
         public uint Texture { get; set; }
-        public RenderFlags RenderFlags { get; set; }
+        public RenderFlags RenderFlags { get; set; } = RenderFlags.DoubleSided; // Default flags
         public MixtureRate MixtureRate { get; set; }
 
         private readonly uint _meshId;
@@ -71,7 +71,7 @@ namespace PSXPrev.Classes
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexTiledArea);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexTiledArea, 4, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
-            if (textureBinder != null && Texture != 0)
+            if (textureBinder != null && Texture != 0 && RenderFlags.HasFlag(RenderFlags.Textured))
             {
                 textureBinder.BindTexture(Texture);
             }
@@ -80,7 +80,7 @@ namespace PSXPrev.Classes
             GL.DrawArrays(verticesOnly ? OpenTK.Graphics.OpenGL.PrimitiveType.Points : OpenTK.Graphics.OpenGL.PrimitiveType.Triangles, 0, _numElements);
             GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
 
-            if (textureBinder != null && Texture != 0)
+            if (textureBinder != null && Texture != 0 && RenderFlags.HasFlag(RenderFlags.Textured))
             {
                 textureBinder.Unbind();
             }

--- a/Classes/MeshBatch.cs
+++ b/Classes/MeshBatch.cs
@@ -342,9 +342,13 @@ namespace PSXPrev
                 }
                 mesh.SetData(numElements, positionList, normalList, colorList, uvList, tiledAreaList);
             }
-            if (textureBinder != null)
+            if (textureBinder != null && modelEntity.Texture != null && modelEntity.RenderFlags.HasFlag(RenderFlags.Textured))
             {
-                mesh.Texture = modelEntity.Texture != null ? textureBinder.GetTexture((int)modelEntity.TexturePage) : 0;
+                mesh.Texture = textureBinder.GetTexture((int)modelEntity.TexturePage);
+            }
+            else
+            {
+                mesh.Texture = 0;
             }
         }
 
@@ -395,14 +399,22 @@ namespace PSXPrev
                 {
                     GL.Uniform1(Scene.UniformRenderMode, 0); // Enable lighting
                 }
+                if (mesh.RenderFlags.HasFlag(RenderFlags.Textured))
+                {
+                    GL.Uniform1(Scene.UniformTextureMode, 0); // Enable texture
+                }
+                else
+                {
+                    GL.Uniform1(Scene.UniformTextureMode, 1); // Disable texture
+                }
             }
             if (_scene.ForceDoubleSided || mesh.RenderFlags.HasFlag(RenderFlags.DoubleSided))
             {
-                GL.Disable(EnableCap.CullFace);
+                GL.Disable(EnableCap.CullFace); // Double-sided
             }
             else
             {
-                GL.Enable(EnableCap.CullFace);
+                GL.Enable(EnableCap.CullFace);  // Single-sided
                 GL.CullFace(CullFaceMode.Front);
             }
             var modelMatrix = mesh.WorldMatrix;
@@ -441,6 +453,10 @@ namespace PSXPrev
                     if (mesh == null || !mesh.RenderFlags.HasFlag(RenderFlags.SemiTransparent))
                     {
                         continue; // Not a semi-transparent mesh
+                    }
+                    if (!mesh.RenderFlags.HasFlag(RenderFlags.Textured))
+                    {
+                        continue; // Untextured surfaces always have stp bit SET.
                     }
                     DrawMesh(mesh, viewMatrix, projectionMatrix, textureBinder, wireframe, standard, verticesOnly);
                 }

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -7,23 +7,37 @@ namespace PSXPrev.Classes
 {
     public class ModelEntity : EntityBase
     {
-        // Default flags for when a reader doesn't assign any.
-        public const RenderFlags DefaultRenderFlags = RenderFlags.DoubleSided;
-
-
         private Triangle[] _triangles;
 
         [DisplayName("VRAM Page")]
         public uint TexturePage { get; set; }
-        
+
+        // Use default flags for when a reader doesn't assign any.
         [DisplayName("Render Flags")]
-        public RenderFlags RenderFlags { get; set; } = DefaultRenderFlags;
-        
+        public RenderFlags RenderFlags { get; set; } = RenderFlags.DoubleSided | RenderFlags.Textured;
+
         [DisplayName("Mixture Rate")]
         public MixtureRate MixtureRate { get; set; }
 
-        [ReadOnly(true), DisplayName("Total Triangles")]
+        [DisplayName("Triangles"), ReadOnly(true)]
         public int TrianglesCount => Triangles.Length;
+
+        [Browsable(false)]
+        public int TotalTriangles
+        {
+            get
+            {
+                var count = TrianglesCount;
+                if (ChildEntities != null)
+                {
+                    foreach (ModelEntity subModel in ChildEntities)
+                    {
+                        count += subModel.TotalTriangles;
+                    }
+                }
+                return count;
+            }
+        }
 
         [Browsable(false)]
         public Triangle[] Triangles
@@ -48,7 +62,7 @@ namespace PSXPrev.Classes
         [DisplayName("TMD ID")]
         public uint TMDID { get; set; }
 
-        [ReadOnly(true), DisplayName("Has Tiled Texture")]
+        [DisplayName("Has Tiled Texture"), ReadOnly(true)]
         public bool HasTiled
         {
             get

--- a/Classes/ObjExporter.cs
+++ b/Classes/ObjExporter.cs
@@ -68,7 +68,7 @@ namespace PSXPrev.Classes
 
         private void WriteModel(ModelEntity model)
         {
-            if (model.Texture != null)
+            if (model.Texture != null && model.RenderFlags.HasFlag(RenderFlags.Textured))
             {
                 if (_mtlExporter.AddMaterial((int) model.TexturePage))
                 {

--- a/Classes/PlyExporter.cs
+++ b/Classes/PlyExporter.cs
@@ -28,11 +28,14 @@ namespace PSXPrev.Classes
                 {
                     var model = (ModelEntity)entityBase;
                     faceCount += model.Triangles.Count();
-                    var texturePage = model.TexturePage;
-                    if (!materialsDic.ContainsKey((int) texturePage))
+                    if (model.RenderFlags.HasFlag(RenderFlags.Textured))
                     {
-                        materialsDic.Add((int) texturePage, numMaterials++);
-                        pngExporter.Export(model.Texture, (int) texturePage, selectedPath);
+                        var texturePage = model.TexturePage;
+                        if (!materialsDic.ContainsKey((int)texturePage))
+                        {
+                            materialsDic.Add((int)texturePage, numMaterials++);
+                            pngExporter.Export(model.Texture, (int)texturePage, selectedPath);
+                        }
                     }
                 }
                 var vertexCount = faceCount * 3;

--- a/Classes/RenderInfo.cs
+++ b/Classes/RenderInfo.cs
@@ -11,12 +11,10 @@ namespace PSXPrev.Classes
         Unlit             = (1 << 1),
         SemiTransparent   = (1 << 3),
         Fog               = (1 << 4),
-        // Are these even render-related?
-        Subdivision       = (1 << 5),
-        AutomaticDivision = (1 << 6),
-
-        // Use this mask when separating meshes by render info.
-        SupportedFlags = DoubleSided | Unlit | SemiTransparent,
+        Textured          = (1 << 5),
+        // todo: Are these even render-related?
+        Subdivision       = (1 << 6),
+        AutomaticDivision = (1 << 7),
 
         // Bits 30 and 31 are reserved for MixtureRate.
     }
@@ -34,6 +32,10 @@ namespace PSXPrev.Classes
     // A named Tuple<uint, RenderFlags, MixtureRate> for render information used to separate models/meshes.
     public struct RenderInfo : IEquatable<RenderInfo>
     {
+        // Use this mask when separating meshes by render info.
+        public const RenderFlags SupportedFlags = RenderFlags.DoubleSided | RenderFlags.Unlit |
+                                                  RenderFlags.SemiTransparent | RenderFlags.Textured;
+
         public uint TexturePage { get; }
         public RenderFlags RenderFlags { get; }
         public MixtureRate MixtureRate { get; }
@@ -52,7 +54,7 @@ namespace PSXPrev.Classes
         public RenderInfo(uint texturePage, RenderFlags renderFlags, MixtureRate mixtureRate = MixtureRate.None)
         {
             TexturePage = texturePage;
-            RenderFlags = renderFlags & RenderFlags.SupportedFlags; // Ignore flags that we can't use for now
+            RenderFlags = renderFlags & SupportedFlags; // Ignore flags that we can't use for now
             MixtureRate = mixtureRate;
         }
 

--- a/Classes/RootEntity.cs
+++ b/Classes/RootEntity.cs
@@ -11,6 +11,23 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public CoordUnit[] Coords { get; set; }
 
+        [DisplayName("Total Triangles"), ReadOnly(false)]
+        public int TotalTriangles
+        {
+            get
+            {
+                var count = 0;
+                if (ChildEntities != null)
+                {
+                    foreach (ModelEntity subModel in ChildEntities)
+                    {
+                        count += subModel.TrianglesCount;
+                    }
+                }
+                return count;
+            }
+        }
+
         public override void ComputeBounds()
         {
             base.ComputeBounds();

--- a/Classes/Scene.cs
+++ b/Classes/Scene.cs
@@ -36,6 +36,7 @@ namespace PSXPrev.Classes
         public static int UniformMaskColor;
         public static int UniformAmbientColor;
         public static int UniformRenderMode;
+        public static int UniformTextureMode;
         public static int UniformSemiTransparentMode;
         public static int UniformLightIntensity;
 
@@ -51,6 +52,7 @@ namespace PSXPrev.Classes
         public const string UniformMaskColorName = "maskColor";
         public const string UniformAmbientColorName = "ambientColor";
         public const string UniformRenderModeName = "renderMode";
+        public const string UniformTextureModeName = "textureMode";
         public const string UniformSemiTransparentModeName = "semiTransparentMode";
         public const string UniformLightIntensityName = "lightIntensity";
 
@@ -251,6 +253,7 @@ namespace PSXPrev.Classes
             UniformMaskColor = GL.GetUniformLocation(_shaderProgram, UniformMaskColorName);
             UniformAmbientColor = GL.GetUniformLocation(_shaderProgram, UniformAmbientColorName);
             UniformRenderMode = GL.GetUniformLocation(_shaderProgram, UniformRenderModeName);
+            UniformTextureMode = GL.GetUniformLocation(_shaderProgram, UniformTextureModeName);
             UniformSemiTransparentMode = GL.GetUniformLocation(_shaderProgram, UniformSemiTransparentModeName);
             UniformLightIntensity = GL.GetUniformLocation(_shaderProgram, UniformLightIntensityName);
         }
@@ -315,6 +318,7 @@ namespace PSXPrev.Classes
             GL.Uniform3(UniformAmbientColor, AmbientColor.R / 255f, AmbientColor.G / 255f, AmbientColor.B / 255f);
             GL.Uniform1(UniformLightIntensity, LightIntensity);
             GL.Uniform1(UniformRenderMode, LightEnabled ? 0 : 1);
+            GL.Uniform1(UniformTextureMode, 0);
             GL.Uniform1(UniformSemiTransparentMode, 0);
             MeshBatch.Draw(_viewMatrix, _projectionMatrix, TextureBinder, Wireframe, true, VerticesOnly);
             GL.Uniform1(UniformRenderMode, 2);

--- a/Classes/TMDHelper.cs
+++ b/Classes/TMDHelper.cs
@@ -26,6 +26,7 @@ namespace PSXPrev.Classes
             if (!lgtBit) renderFlags |= RenderFlags.Unlit;
             if (fceBit) renderFlags |= RenderFlags.DoubleSided;
             if (abeBit) renderFlags |= RenderFlags.SemiTransparent;
+            if (tmeBit) renderFlags |= RenderFlags.Textured;
 
             if (Program.Debug)
             {
@@ -101,6 +102,7 @@ namespace PSXPrev.Classes
             if (advBit) renderFlags |= RenderFlags.AutomaticDivision;
             if (botBit) renderFlags |= RenderFlags.DoubleSided;
             if (stpBit) renderFlags |= RenderFlags.SemiTransparent;
+            if (tmeBit) renderFlags |= RenderFlags.Textured;
 
             var primitiveType = PrimitiveType.None; // invalid
             var supported = false;

--- a/Classes/TMDParser.cs
+++ b/Classes/TMDParser.cs
@@ -227,18 +227,15 @@ namespace PSXPrev.Classes
                 {
                     var renderInfo = kvp.Key;
                     var triangles = kvp.Value;
-                    if (triangles.Count > 0)
+                    var model = new ModelEntity
                     {
-                        var model = new ModelEntity
-                        {
-                            Triangles = triangles.ToArray(),
-                            TexturePage = renderInfo.TexturePage,
-                            RenderFlags = renderInfo.RenderFlags,
-                            MixtureRate = renderInfo.MixtureRate,
-                            TMDID = o
-                        };
-                        models.Add(model);
-                    }
+                        Triangles = triangles.ToArray(),
+                        TexturePage = renderInfo.TexturePage,
+                        RenderFlags = renderInfo.RenderFlags,
+                        MixtureRate = renderInfo.MixtureRate,
+                        TMDID = o
+                    };
+                    models.Add(model);
                 }
             }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -102,7 +102,10 @@ namespace PSXPrev
             {
                 var model = (ModelEntity)entityBase;
                 model.TexturePage = VRAMPages.ClampTexturePage(model.TexturePage);
-                model.Texture = _vram[model.TexturePage];
+                if (model.RenderFlags.HasFlag(RenderFlags.Textured))
+                {
+                    model.Texture = _vram[model.TexturePage];
+                }
             }
             entitiesTreeView.BeginUpdate();
             var entityNode = entitiesTreeView.Nodes.Add(entity.EntityName);
@@ -838,7 +841,10 @@ namespace PSXPrev
             if (_selectedModelEntity != null)
             {
                 _selectedModelEntity.TexturePage = VRAMPages.ClampTexturePage(_selectedModelEntity.TexturePage);
-                _selectedModelEntity.Texture = _vram[_selectedModelEntity.TexturePage];
+                if (_selectedModelEntity.RenderFlags.HasFlag(RenderFlags.Textured))
+                {
+                    _selectedModelEntity.Texture = _vram[_selectedModelEntity.TexturePage];
+                }
             }
             var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
             if (selectedEntityBase != null)

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -18,6 +18,7 @@ uniform vec3 lightDirection;
 uniform vec3 maskColor;
 uniform vec3 ambientColor;
 uniform int renderMode;
+uniform int textureMode;
 uniform int semiTransparentMode;
 uniform float lightIntensity;
 uniform sampler2D mainTex;


### PR DESCRIPTION
### Shader changes:
* Add uniform int textureMode. When 1, the surface is untextured, and stp is always set, allowing these surfaces to be semi-transparent (implements #106).
* Switched bool stp back to int, because bool is supposedly less supported.

### Renderer changes:
* Textured/untextured surfaces are now separated into different models.
* Textures are no longer bound unless the mesh has the Textured render flag.

### Exporter changes:
* Textures are no longer exported if the model doesn't have the Textured render flag.

### Parser changes:
* All model readers now use groupedTriangles with RenderInfo. Previously some were just a triangle list, and others just a texture page lookup.
* PMDParser now applies render flags and texture page.

### Refactor changes:
* Moved SupportedFlags out of RenderFlags and into RenderInfo, this way "SupportedFlags" won't show up in the property grid instead of listing each individual flag.
* PMDParser now automatically adds `_offset` in ReadSharedVertices, so `_offset` no longer needs to be passed to functions.
* Cleaned up TriangleFromPrimitive function for PMDParser and BFFModelReader.
* Changed PSXParser triangle flag variable to quad. Mainly to follow consistency, but also because triangle is ambiguous with Triangle variables, that are seen everywhere. (tri would have also worked...)
* Added TotalTriangles properties to RootEntity and ModelEntity, the one in root entity is visible to the property grid (implements #105).