### PR TITLE
Add command line options: -croc, -nocolor, -autoplay, -autoselect

### DIFF
--- a/Classes/Animation.cs
+++ b/Classes/Animation.cs
@@ -18,6 +18,8 @@ namespace PSXPrev.Classes
 
     public class Animation
     {
+        private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
+
         [DisplayName("Animation Name")]
         public string AnimationName { get; set; }
 
@@ -36,6 +38,14 @@ namespace PSXPrev.Classes
 
         [DisplayName("Animation Type")]
         public AnimationType AnimationType { get; set; }
+
+        // The owner model that created this animation (if any).
+        [Browsable(false)]
+        public RootEntity OwnerEntity
+        {
+            get => _ownerEntity.TryGetTarget(out var owner) ? owner : null;
+            set => _ownerEntity.SetTarget(value);
+        }
 
 
         // When animation objects have their own frame counts/speeds, they will become unsynced as the animation loops.

--- a/Classes/HMDHelper.cs
+++ b/Classes/HMDHelper.cs
@@ -362,13 +362,11 @@ namespace PSXPrev.Classes
             // Print starting Index#StreamID's for each TMDID object.
             if (tmdidStarts != null)
             {
-                Console.ForegroundColor = ConsoleColor.White;
                 foreach (var pair in tmdidStarts.OrderBy(p => p.Key))
                 {
                     var arrayStr = string.Join(", ", pair.Value.Select(t => $"{t.Item1}#{t.Item2}"));
-                    Console.WriteLine($"TMDID {pair.Key,2}: [{arrayStr}]");
+                    Program.Logger.WriteColorLine(ConsoleColor.White, $"TMDID {pair.Key,2}: [{arrayStr}]");
                 }
-                Console.ResetColor();
             }
 
             // Format padding information.
@@ -389,9 +387,7 @@ namespace PSXPrev.Classes
                     {
                         text = (padLeft ? text.PadLeft(pad) : text.PadRight(pad));
                     }
-                    Console.ForegroundColor = color;
-                    Console.Write(text);
-                    Console.ResetColor();
+                    Program.Logger.WriteColor(color, text);
                     lineLength += text.Length;
                 }
 
@@ -502,7 +498,7 @@ namespace PSXPrev.Classes
                         Write(ConsoleColor.DarkCyan, $" [{xref}]");
                     }
                 }
-                Console.WriteLine();
+                Program.Logger.WriteLine();
             }
         }
     }

--- a/Classes/Logger.cs
+++ b/Classes/Logger.cs
@@ -9,7 +9,8 @@ namespace PSXPrev.Classes
     {
         private readonly StreamWriter _writer;
         private readonly bool _writeToFile;
-        private readonly bool _noVerbose;
+        private readonly bool _writeToConsole;
+        private readonly bool _useColor;
 
         public ConsoleColor StandardColor { get; set; } = ConsoleColor.White;
         public ConsoleColor PositiveColor { get; set; } = ConsoleColor.Green;
@@ -17,7 +18,7 @@ namespace PSXPrev.Classes
         public ConsoleColor ErrorColor { get; set; } = ConsoleColor.Red;
         public ConsoleColor ExceptionPrefixColor { get; set; } = ConsoleColor.DarkGray;
 
-        public Logger(bool writeToFile, bool noVerbose)
+        public Logger(bool writeToFile = false, bool writeToConsole = true, bool useColor = true)
         {
             if (writeToFile)
             {
@@ -25,7 +26,8 @@ namespace PSXPrev.Classes
                 _writer = new StreamWriter(Path.Combine(Application.StartupPath, $"{time}.log"));
             }
             _writeToFile = writeToFile;
-            _noVerbose = noVerbose;
+            _writeToConsole = writeToConsole;
+            _useColor = useColor;
         }
 
         private void WriteInternal(ConsoleColor? color, bool newLine, string text)
@@ -34,11 +36,15 @@ namespace PSXPrev.Classes
             {
                 text = string.Empty;
             }
-            if (!_noVerbose)
+            if (_writeToConsole)
             {
-                if (color.HasValue)
+                if (_useColor && color.HasValue)
                 {
                     Console.ForegroundColor = color.Value;
+                }
+                else
+                {
+                    Console.ResetColor();
                 }
                 // Write whole message to WriteLine instead of appending WriteLine(), because it'll be faster.
                 if (newLine)

--- a/Classes/RootEntity.cs
+++ b/Classes/RootEntity.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using OpenTK;
 
 namespace PSXPrev.Classes
@@ -7,6 +10,8 @@ namespace PSXPrev.Classes
     public class RootEntity : EntityBase
     {
         private readonly List<ModelEntity> _groupedModels = new List<ModelEntity>();
+        private WeakReferenceCollection<Texture> _ownedTextures;
+        private WeakReferenceCollection<Animation> _ownedAnimations;
 
         [Browsable(false)]
         public CoordUnit[] Coords { get; set; }
@@ -27,6 +32,21 @@ namespace PSXPrev.Classes
                 return count;
             }
         }
+
+        [Browsable(false)]
+        public IEnumerable<Texture> OwnedTextures
+        {
+            get => _ownedTextures ?? Enumerable.Empty<Texture>();
+            set => _ownedTextures = new WeakReferenceCollection<Texture>(value);
+        }
+
+        [Browsable(false)]
+        public IEnumerable<Animation> OwnedAnimations
+        {
+            get => _ownedAnimations ?? Enumerable.Empty<Animation>();
+            set => _ownedAnimations = new WeakReferenceCollection<Animation>(value);
+        }
+
 
         public override void ComputeBounds()
         {

--- a/Classes/Texture.cs
+++ b/Classes/Texture.cs
@@ -9,6 +9,8 @@ namespace PSXPrev.Classes
         public static readonly System.Drawing.Color NoSemiTransparentFlag = System.Drawing.Color.FromArgb(255, 0, 0, 0);
         public static readonly System.Drawing.Color SemiTransparentFlag = System.Drawing.Color.FromArgb(255, 255, 255, 255);
 
+        private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
+
         public Texture(int width, int height, int x, int y, int bpp, int texturePage, bool isVRAMPage = false)
         {
             Bitmap = new Bitmap(width, height);
@@ -48,6 +50,15 @@ namespace PSXPrev.Classes
 
         [Browsable(false)]
         public Bitmap SemiTransparentMap { get; set; }
+
+        // The owner model that created this texture (if any).
+        [Browsable(false)]
+        public RootEntity OwnerEntity
+        {
+            get => _ownerEntity.TryGetTarget(out var owner) ? owner : null;
+            set => _ownerEntity.SetTarget(value);
+        }
+
 
         public Bitmap SetupSemiTransparentMap()
         {

--- a/Classes/WeakReferenceCollection.cs
+++ b/Classes/WeakReferenceCollection.cs
@@ -1,0 +1,156 @@
+﻿#define WEAKREFCOLLECTION_AUTO_CLEANUP_DEAD
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PSXPrev.Classes
+{
+    // A collection for WeakReferences to objects without exposing the WeakReference class itself.
+    public class WeakReferenceCollection<T> : ICollection<T> where T : class
+    {
+        private readonly List<WeakReference<T>> _references = new List<WeakReference<T>>();
+
+        public WeakReferenceCollection()
+        {
+        }
+
+        public WeakReferenceCollection(IEnumerable<T> items)
+        {
+            AddRange(items);
+        }
+
+
+        public void CleanupDeadReferences()
+        {
+            for (var i = 0; i < _references.Count; i++)
+            {
+                if (!_references[i].TryGetTarget(out _))
+                {
+                    _references.RemoveAt(i); // Remove dead references from the list.
+                    i--;
+                }
+            }
+        }
+
+        // ICollection<T> implementation:
+
+        // Not accessible because Count can change whenever dead references are automatically removed.
+        int ICollection<T>.Count => _references.Count;
+
+        bool ICollection<T>.IsReadOnly => false;
+
+
+        public void Add(T item)
+        {
+            if (item != null)
+            {
+                _references.Add(new WeakReference<T>(item));
+            }
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            if (items != null)
+            {
+                foreach (var item in items)
+                {
+                    Add(item);
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            _references.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            for (var i = 0; i < _references.Count; i++)
+            {
+                if (_references[i].TryGetTarget(out var value))
+                {
+                    if (value == item)
+                    {
+                        return true;
+                    }
+                }
+#if WEAKREFCOLLECTION_AUTO_CLEANUP_DEAD
+                else
+                {
+                    _references.RemoveAt(i); // Remove dead references from the list.
+                    i--;
+                }
+#endif
+            }
+            return false;
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            for (var i = 0; i < _references.Count; i++)
+            {
+                if (_references[i].TryGetTarget(out var value))
+                {
+                    array[arrayIndex + i] = value;
+                }
+#if WEAKREFCOLLECTION_AUTO_CLEANUP_DEAD
+                else
+                {
+                    _references.RemoveAt(i); // Remove dead references from the list.
+                    i--;
+                }
+#endif
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            var removed = true;
+            for (var i = 0; i < _references.Count; i++)
+            {
+                if (_references[i].TryGetTarget(out var value))
+                {
+                    if (value == item)
+                    {
+                        removed = true;
+                        _references.RemoveAt(i);
+                        i--;
+                    }
+                }
+#if WEAKREFCOLLECTION_AUTO_CLEANUP_DEAD
+                else
+                {
+                    _references.RemoveAt(i); // Remove dead references from the list.
+                    i--;
+                }
+#endif
+            }
+            return removed;
+        }
+
+        // IEnumerator<T> implementation:
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (var i = 0; i < _references.Count; i++)
+            {
+                if (_references[i].TryGetTarget(out var value))
+                {
+                    yield return value;
+                }
+#if WEAKREFCOLLECTION_AUTO_CLEANUP_DEAD
+                else
+                {
+                    _references.RemoveAt(i); // Remove dead references from the list.
+                    i--;
+                }
+#endif
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/Forms/LauncherForm.cs
+++ b/Forms/LauncherForm.cs
@@ -73,10 +73,13 @@ namespace PSXPrev.Forms
                 NoVerbose = optionNoVerboseCheckBox.Checked,
                 Debug = optionDebugCheckBox.Checked,
                 ShowErrors = optionShowErrorsCheckBox.Checked,
+                NoConsoleColor = false, //todo
 
                 DrawAllToVRAM = optionDrawAllToVRAMCheckBox.Checked,
-                AutoAttachLimbs = optionAutoAttachLimbsCheckBox.Checked,
                 NoOffset = optionNoOffsetCheckBox.Checked,
+                AutoAttachLimbs = optionAutoAttachLimbsCheckBox.Checked,
+                AutoPlayAnimations = false, //todo
+                AutoSelect = false, //todo
             });
 
             Close();

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -99,6 +99,8 @@
             this.findByPageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.clearSearchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.autoDrawModelTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator6 = new System.Windows.Forms.ToolStripSeparator();
             this.setMaskColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.vRAMToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.clearPageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -107,6 +109,7 @@
             this.showUVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.animationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showSkeletonToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.autoSelectAnimationModelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.videoTutorialToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.compatibilityListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -135,6 +138,7 @@
             this.vertexSizeUpDown = new System.Windows.Forms.NumericUpDown();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.pauseScanningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.autoPlayAnimationsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.entitiesTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.modelsSplitContainer)).BeginInit();
             this.modelsSplitContainer.Panel1.SuspendLayout();
@@ -895,6 +899,8 @@
             this.findByPageToolStripMenuItem,
             this.clearSearchToolStripMenuItem,
             this.toolStripSeparator1,
+            this.autoDrawModelTexturesToolStripMenuItem,
+            this.toolStripSeparator6,
             this.setMaskColorToolStripMenuItem});
             this.texturesToolStripMenuItem.Name = "texturesToolStripMenuItem";
             this.texturesToolStripMenuItem.Size = new System.Drawing.Size(62, 20);
@@ -937,6 +943,19 @@
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(152, 6);
+            // 
+            // autoDrawModelTexturesToolStripMenuItem
+            // 
+            this.autoDrawModelTexturesToolStripMenuItem.CheckOnClick = true;
+            this.autoDrawModelTexturesToolStripMenuItem.Name = "autoDrawModelTexturesToolStripMenuItem";
+            this.autoDrawModelTexturesToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
+            this.autoDrawModelTexturesToolStripMenuItem.Text = "Auto Draw Textures";
+            this.autoDrawModelTexturesToolStripMenuItem.Click += new System.EventHandler(this.autoDrawModelTexturesToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator6
+            // 
+            this.toolStripSeparator6.Name = "toolStripSeparator6";
+            this.toolStripSeparator6.Size = new System.Drawing.Size(173, 6);
             // 
             // setMaskColorToolStripMenuItem
             // 
@@ -989,7 +1008,9 @@
             // animationsToolStripMenuItem
             // 
             this.animationsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.showSkeletonToolStripMenuItem});
+            this.showSkeletonToolStripMenuItem,
+            this.autoPlayAnimationsToolStripMenuItem,
+            this.autoSelectAnimationModelToolStripMenuItem});
             this.animationsToolStripMenuItem.Name = "animationsToolStripMenuItem";
             this.animationsToolStripMenuItem.Size = new System.Drawing.Size(80, 20);
             this.animationsToolStripMenuItem.Text = "Animations";
@@ -1001,6 +1022,14 @@
             this.showSkeletonToolStripMenuItem.Size = new System.Drawing.Size(151, 22);
             this.showSkeletonToolStripMenuItem.Text = "Show Skeleton";
             this.showSkeletonToolStripMenuItem.CheckedChanged += new System.EventHandler(this.showSkeletonToolStripMenuItem_CheckedChanged);
+            // 
+            // autoSelectAnimationModelToolStripMenuItem
+            // 
+            this.autoSelectAnimationModelToolStripMenuItem.CheckOnClick = true;
+            this.autoSelectAnimationModelToolStripMenuItem.Name = "autoSelectAnimationModelToolStripMenuItem";
+            this.autoSelectAnimationModelToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.autoSelectAnimationModelToolStripMenuItem.Text = "Auto Select Model";
+            this.autoSelectAnimationModelToolStripMenuItem.Click += new System.EventHandler(this.autoSelectAnimationModelToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
@@ -1338,6 +1367,14 @@
             this.pauseScanningToolStripMenuItem.Text = "Pause Scanning";
             this.pauseScanningToolStripMenuItem.CheckedChanged += new System.EventHandler(this.pauseScanningToolStripMenuItem_CheckedChanged);
             // 
+            // autoPlayAnimationsToolStripMenuItem
+            // 
+            this.autoPlayAnimationsToolStripMenuItem.CheckOnClick = true;
+            this.autoPlayAnimationsToolStripMenuItem.Name = "autoPlayAnimationsToolStripMenuItem";
+            this.autoPlayAnimationsToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.autoPlayAnimationsToolStripMenuItem.Text = "Auto Play Animation";
+            this.autoPlayAnimationsToolStripMenuItem.Click += new System.EventHandler(this.autoPlayAnimationsToolStripMenuItem_Click);
+            // 
             // PreviewForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1525,5 +1562,9 @@
         private System.Windows.Forms.NumericUpDown vertexSizeUpDown;
         private System.Windows.Forms.ToolStripMenuItem pauseScanningToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem autoDrawModelTexturesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator6;
+        private System.Windows.Forms.ToolStripMenuItem autoSelectAnimationModelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem autoPlayAnimationsToolStripMenuItem;
     }
 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Classes\Utils.cs" />
     <Compile Include="Classes\VDFParser.cs" />
     <Compile Include="Classes\VRAMPages.cs" />
+    <Compile Include="Classes\WeakReferenceCollection.cs" />
     <Compile Include="Forms\DialogForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/README.md
+++ b/README.md
@@ -38,35 +38,40 @@ PSXPrev only find files conformant to the file formats it's looking for. PSXPrev
 
 Command line usage:
 ```
-usage: PSXPrev <PATH> [FILTER="*.*"] [-help] [-an] [-bff] [-hmd]
-               [-mod] [-pmd] [-psx] [-tim] [-tmd] [-tod] [-vdf]
-               [-ignoretmdversion] [-log] [-noverbose] [-debug]
-               [-error] [-drawvram] [-attachlimbs] [-nooffset]
+usage: PSXPrev <PATH> [FILTER="*.*"] [-help] [-an] [-bff] [-croc]
+               [-hmd] [-mod] [-pmd] [-psx] [-tim] [-tmd] [-tod]
+               [-vdf] [-ignoretmdversion] [-log] [-noverbose]
+               [-debug] [-error] [-nocolor] [-drawvram] [-nooffset]
+               [-attachlimbs] [-autoplay] [-autoselect]
 
 arguments:
   PATH   : folder or file path to scan
   FILTER : wildcard filter for files to include (default: "*.*")
 
 scanner options: (default: all formats)
-  -an    : scan for AN animations
-  -bff   : scan for BFF models
-  -hmd   : scan for HMD models, textures, and animations
-  -mod   : scan for MOD models
-  -pmd   : scan for PMD models
-  -psx   : scan for PSX models
-  -tim   : scan for TIM textures
-  -tmd   : scan for TMD models
-  -tod   : scan for TOD animations
-  -vdf   : scan for VDF animations
+  -an        : scan for AN animations
+  -bff       : scan for BFF models
+  -hmd       : scan for HMD models, textures, and animations
+  -mod/-croc : scan for MOD (Croc) models
+  -pmd       : scan for PMD models
+  -psx       : scan for PSX models (just another format)
+  -tim       : scan for TIM textures
+  -tmd       : scan for TMD models
+  -tod       : scan for TOD animations
+  -vdf       : scan for VDF animations
   -ignoretmdversion : reduce strictness when scanning TMD models
 
 log options:
   -log       : write output to log file
-  -noverbose : reduce output to console and file
+  -noverbose : don't write output to console
   -debug     : output file format details and other information
+  -error     : show error (exception) messages when reading files
+  -nocolor   : disable colored console output
 
 program options:
-  -drawvram    : draw all loaded textures to VRAM (not advised when scanning a lot of files)
-  -attachlimbs : enable Auto Attach Limbs by default
+  -drawvram    : draw all loaded textures to VRAM (not advised when scanning many files)
   -nooffset    : only scan files at offset 0
+  -attachlimbs : enable Auto Attach Limbs by default
+  -autoplay    : automatically play selected animations
+  -autoselect  : select animation's model and draw selected model's textures (HMD only)
 ```


### PR DESCRIPTION
## Command line changes
* Re-added `-croc` command line option as an alias for `-mod`. The help message for `-mod` now has "(Croc)" in parenthesis.
* Added `-nocolor` command line option (no GUI option yet) to disable changing the console color when logging.
* Added `-autoselect` command line option (menu items under Textures and Animations) that enables automatically selecting an animation's owner model, or automatically drawing the textures of a selected model to VRAM (only supports HMD for obvious reasons).
* Added `-autoplay` command line option (menu item under Animations) that automatically starts playing an animation when selected.
* Passing an empty string as the program filter will now default to `"*"` for all files.
* When `-debug` is used, PSXPrev will pause with a `"Press any key to continue..."` message (only if the program returns either due to `-help` or the file path not being found).


## Fix changes
* Fix Textured flag not being applied for HMD Ground triangles.
* HMDHelper now uses Program.Logger instead of Console for printing animation instructions.
* Program.HaltRequested is now volatile, since it can be accessed from multiple threads.

## Refactor changes
* Added WaitWhileHalted function to replace all `while (HaltRequested)` loops.
* Added WeakReferenceCollection class, which acts like an `ICollection<T>`, but stores a `List<WeakReference<T>>`.
* RootEntity now has properties to assign owned textures and animations (using weak references).
* Texture and Animation now have a property to assign the owner root entity (using a weak reference).
* Changed logger noVerbose argument to the opposite: writeToConsole. True should now be passed to produce console output.
* Logger now has default values for all constructor arguments, which defaults to the program's standard settings (no log, write to console, use color).