### PR TITLE
VRAM tab tiled UV lines and combo box typing

### DIFF
--- a/Classes/MeshBatch.cs
+++ b/Classes/MeshBatch.cs
@@ -342,7 +342,7 @@ namespace PSXPrev
                 }
                 mesh.SetData(numElements, positionList, normalList, colorList, uvList, tiledAreaList);
             }
-            if (textureBinder != null && modelEntity.Texture != null && modelEntity.RenderFlags.HasFlag(RenderFlags.Textured))
+            if (textureBinder != null && modelEntity.Texture != null && modelEntity.IsTextured)
             {
                 mesh.Texture = textureBinder.GetTexture((int)modelEntity.TexturePage);
             }

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -76,6 +76,9 @@ namespace PSXPrev.Classes
             }
         }
 
+        [Browsable(false)]
+        public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
+
         //[ReadOnly(true)]
         //public uint PrimitiveIndex { get; set; }
 

--- a/Classes/ObjExporter.cs
+++ b/Classes/ObjExporter.cs
@@ -68,7 +68,7 @@ namespace PSXPrev.Classes
 
         private void WriteModel(ModelEntity model)
         {
-            if (model.Texture != null && model.RenderFlags.HasFlag(RenderFlags.Textured))
+            if (model.Texture != null && model.IsTextured)
             {
                 if (_mtlExporter.AddMaterial((int) model.TexturePage))
                 {

--- a/Classes/PlyExporter.cs
+++ b/Classes/PlyExporter.cs
@@ -28,7 +28,7 @@ namespace PSXPrev.Classes
                 {
                     var model = (ModelEntity)entityBase;
                     faceCount += model.Triangles.Count();
-                    if (model.RenderFlags.HasFlag(RenderFlags.Textured))
+                    if (model.IsTextured)
                     {
                         var texturePage = model.TexturePage;
                         if (!materialsDic.ContainsKey((int)texturePage))

--- a/Classes/RenderInfo.cs
+++ b/Classes/RenderInfo.cs
@@ -16,17 +16,17 @@ namespace PSXPrev.Classes
         Subdivision       = (1 << 6),
         AutomaticDivision = (1 << 7),
 
-        // Bits 30 and 31 are reserved for MixtureRate.
+        // Bits 29-31 are reserved for MixtureRate.
     }
 
     // Blending when RenderFlags.SemiTransparent is set.
     public enum MixtureRate
     {
-        None,
-        Back50_Poly50,    //  50% back +  50% poly
-        Back100_Poly100,  // 100% back + 100% poly
-        Back100_PolyM100, // 100% back - 100% poly
-        Back100_Poly25,   // 100% back +  25% poly
+        None             = 0,
+        Back50_Poly50    = 1, //  50% back +  50% poly
+        Back100_Poly100  = 2, // 100% back + 100% poly
+        Back100_PolyM100 = 3, // 100% back - 100% poly
+        Back100_Poly25   = 4, // 100% back +  25% poly
     }
     
     // A named Tuple<uint, RenderFlags, MixtureRate> for render information used to separate models/meshes.
@@ -47,7 +47,7 @@ namespace PSXPrev.Classes
             {
                 return (((ulong)TexturePage <<  0) |
                         ((ulong)RenderFlags << 32) |
-                        ((ulong)MixtureRate << 62));
+                        ((ulong)MixtureRate << 61));
             }
         }
 

--- a/Classes/TiledUV.cs
+++ b/Classes/TiledUV.cs
@@ -5,23 +5,37 @@ namespace PSXPrev.Classes
     public class TiledUV
     {
         public Vector2[] BaseUv { get; set; }
-        public Vector2 Offset { get; set; } // Position added to BaseUv after wrapping.
-        public Vector2 Size { get; set; }   // Denominator of modulus with BaseUv for wrapping.
+        public float X { get; set; } // Position added to BaseUv after wrapping.
+        public float Y { get; set; }
+        public float Width  { get; set; } // Denominator of modulus with BaseUv for wrapping.
+        public float Height { get; set; }
 
-        public Vector4 Area => new Vector4(Offset.X, Offset.Y, Size.X, Size.Y);
+        public Vector2 Offset => new Vector2(X, Y);
+        public Vector2 Size => new Vector2(Width, Height);
+        public Vector4 Area => new Vector4(X, Y, Width, Height);
 
         public TiledUV(Vector2[] baseUv, float x, float y, float width, float height)
         {
             BaseUv = baseUv;
-            Offset = new Vector2(x, y);
-            Size   = new Vector2(width, height);
+            X = x;
+            Y = y;
+            Width  = width;
+            Height = height;
+        }
+
+        public TiledUV(Vector2[] baseUv, Vector2 offset, Vector2 size)
+            : this(baseUv, offset.X, offset.Y, size.X, size.Y)
+        {
+        }
+
+        public TiledUV(Vector2[] baseUv, Vector4 area)
+            : this(baseUv, area.X, area.Y, area.Z, area.W)
+        {
         }
 
         public TiledUV(TiledUV fromTiledUv)
+            : this(fromTiledUv.BaseUv, fromTiledUv.X, fromTiledUv.Y, fromTiledUv.Width, fromTiledUv.Height)
         {
-            BaseUv = fromTiledUv.BaseUv;
-            Offset = fromTiledUv.Offset;
-            Size   = fromTiledUv.Size;
         }
 
         // This function isn't used, since the tiled (display) UV can be calculated with integer math.
@@ -30,12 +44,12 @@ namespace PSXPrev.Classes
             var uv = new Vector2[BaseUv.Length];
             for (var i = 0; i < uv.Length; i++)
             {
-                uv[i] = Convert(BaseUv[i], Offset.X, Offset.Y, Size.X, Size.Y);
+                uv[i] = Convert(BaseUv[i], X, Y, Width, Height);
             }
             return uv;
         }
 
-        public Vector2 Convert(Vector2 uv) => Convert(uv, Offset.X, Offset.Y, Size.X, Size.Y);
+        public Vector2 Convert(Vector2 uv) => Convert(uv, X, Y, Width, Height);
 
 
         public static Vector2 Convert(Vector2 uv, float x, float y, float width, float height)

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -531,7 +531,10 @@
             this.vramComboBox.Size = new System.Drawing.Size(172, 21);
             this.vramComboBox.TabIndex = 10;
             this.vramComboBox.Text = "Select";
-            this.vramComboBox.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            this.vramComboBox.SelectedIndexChanged += new System.EventHandler(this.vramComboBox_SelectedIndexChanged);
+            this.vramComboBox.TextChanged += new System.EventHandler(this.vramComboBox_TextChanged);
+            this.vramComboBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.vramComboBox_KeyDown);
+            this.vramComboBox.Leave += new System.EventHandler(this.vramComboBox_Leave);
             // 
             // vramPagePictureBox
             // 


### PR DESCRIPTION
## VRAM tab changes
* UV lines now draw in the VRAM tab even if a Sub-model is selected.
* UV lines no longer draw for all VRAM pages, only for the current page.
* UV lines in the VRAM tab now draw tiled rectangles (cyan colored), rather than useless tile-converted UV lines.
* VRAM combo box now shows " (drawn to)" text after page numbers for pages that have had textures drawn to them.
* VRAM combo box now accepts typing to instantly change the VRAM page. The page will update as you type, and ignores characters appearing after the digits (to support the " (drawn to)" text of real combo box item names). Pressing Enter, or unfocusing the combo box will fully update the selected index.
* VRAM selected page is now stored as a separate field, and updated as needed. This is because when typing to update the current VRAM page, the combo box's SelectedIndex will be -1.

## Other changes
* Fixed RenderInfo mistakenly losing the MSB of MixtureRate when doing comparisons.
* Added shorthand IsTextured property to ModelEntity, so that we don't need to spam `model.RenderFlags.hasFlag(RenderFlags.Textured)` everywhere.
* Added IsPageUsed function to VRAMPages, which states if any textures have been drawn to a specific page.
* Added ContainsPage function to VRAMPages as a simple bounds test.
* Pluralized VRAMPages private fields.
* TiledUV now stores its area values in 4 floats, rather than 2 Vector2s.

![image](https://github.com/rickomax/psxprev/assets/9752430/fb5b7813-4b80-45a1-98a2-c19f98b85b48)
