### PR TITLE
Fix missing mtl0 for untextured models in exported obj files

### DIFF
--- a/Classes/DaeExporter.cs
+++ b/Classes/DaeExporter.cs
@@ -41,7 +41,7 @@ namespace PSXPrev.Classes
                     var model = (ModelEntity) entity.ChildEntities[j];
                     var modelName = string.Format("model-{0}-lib", j);
                     var materialName = string.Format("{0}-material", modelName);
-                    var triangleCount = model.Triangles.Count();
+                    var triangleCount = model.Triangles.Length;
                     var elementGroupCount = triangleCount * 3;
                     var elementCount = elementGroupCount * 3;
 

--- a/Classes/MtlExporter.cs
+++ b/Classes/MtlExporter.cs
@@ -5,13 +5,28 @@ namespace PSXPrev.Classes
 {
     public class MtlExporter : IDisposable
     {
+        public const string UntexturedID = "none";
+
         private readonly StreamWriter _writer;
         private readonly int _modelIndex;
-        private readonly bool[] _exportedPages = new bool[32];
+        private readonly bool[] _exportedPages = new bool[VRAMPages.PageCount]; // 32
+
+        public string FileName { get; }
 
         public MtlExporter(string selectedPath, int modelIndex)
         {
-            _writer = new StreamWriter($"{selectedPath}/mtl{modelIndex}.mtl");
+            FileName = $"mtl{modelIndex}.mtl";
+            _writer = new StreamWriter($"{selectedPath}/{FileName}");
+            _modelIndex = modelIndex;
+
+            // Add a material without a file for use with untextured models.
+            WriteMaterial(GetMaterialName(null), null);
+        }
+
+        public string GetMaterialName(int? texturePage)
+        {
+            var materialId = texturePage?.ToString() ?? MtlExporter.UntexturedID;
+            return $"mtl{materialId}";
         }
 
         public bool AddMaterial(int texturePage)
@@ -21,14 +36,25 @@ namespace PSXPrev.Classes
                 return false;
             }
             _exportedPages[texturePage] = true;
-            _writer.WriteLine("newmtl mtl{0}", texturePage);
-            _writer.WriteLine("Ka 0.00000 0.00000 0.00000");
-            _writer.WriteLine("Kd 0.50000 0.50000 0.50000");
-            _writer.WriteLine("Ks 0.00000 0.00000 0.00000");
-            _writer.WriteLine("d 1.00000");
-            _writer.WriteLine("illum 0");
-            _writer.WriteLine("map_Kd {0}.png", texturePage);
+
+            WriteMaterial(GetMaterialName(texturePage), texturePage.ToString());
             return true;
+        }
+
+        private void WriteMaterial(string materialName, string fileName)
+        {
+            _writer.WriteLine("newmtl {0}", materialName);
+            _writer.WriteLine("Ka 0.00000 0.00000 0.00000"); // ambient color
+            _writer.WriteLine("Kd 0.50000 0.50000 0.50000"); // diffuse color
+            _writer.WriteLine("Ks 0.00000 0.00000 0.00000"); // specular color
+            _writer.WriteLine("d 1.00000"); // "dissolved" (opaque)
+            _writer.WriteLine("illum 0"); // illumination: 0-color on and ambient off
+            if (fileName != null)
+            {
+                _writer.WriteLine("map_Kd {0}.png", fileName); // diffuse texture map
+                //todo: Output alpha for transparent pixels
+                //_writer.WriteLine("map_d {0}.png", fileName2); // alpha texture map
+            }
         }
 
         public void Dispose()

--- a/Classes/ObjExporter.cs
+++ b/Classes/ObjExporter.cs
@@ -24,16 +24,16 @@ namespace PSXPrev.Classes
                     var entity = entities[i];
                     _mtlExporter = new MtlExporter(selectedPath, i);
                     _streamWriter = new StreamWriter($"{selectedPath}/obj{i}.obj");
-                    _streamWriter.WriteLine("mtllib mtl{0}.mtl", i);
-                    foreach (var childEntity in entity.ChildEntities)
+                    _streamWriter.WriteLine("mtllib {0}", _mtlExporter.FileName);
+                    foreach (ModelEntity model in entity.ChildEntities)
                     {
-                        WriteModel(childEntity as ModelEntity);
+                        WriteModel(model);
                     }
                     var baseIndex = 1;
                     for (var j = 0; j < entity.ChildEntities.Length; j++)
                     {
-                        var childEntity = entity.ChildEntities[j];
-                        WriteGroup(j, ref baseIndex, childEntity as ModelEntity);
+                        var model = (ModelEntity)entity.ChildEntities[j];
+                        WriteGroup(j, ref baseIndex, model);
                     }
                     _streamWriter.Dispose();
                     _mtlExporter.Dispose();
@@ -43,21 +43,21 @@ namespace PSXPrev.Classes
             {
                 _mtlExporter = new MtlExporter(selectedPath, 0);
                 _streamWriter = new StreamWriter($"{selectedPath}/obj0.obj");
-                _streamWriter.WriteLine("mtllib mtl0.mtl");
+                _streamWriter.WriteLine("mtllib {0}", _mtlExporter.FileName);
                 foreach (var entity in entities)
                 {
-                    foreach (EntityBase childEntity in entity.ChildEntities)
+                    foreach (ModelEntity model in entity.ChildEntities)
                     {
-                        WriteModel(childEntity as ModelEntity);
+                        WriteModel(model);
                     }
                 }
                 var baseIndex = 1;
                 foreach (var entity in entities)
                 {
-                    for (int j = 0; j < entity.ChildEntities.Length; j++)
+                    for (var j = 0; j < entity.ChildEntities.Length; j++)
                     {
-                        var childEntity = entity.ChildEntities[j];
-                        WriteGroup(j, ref baseIndex, childEntity as ModelEntity);
+                        var model = (ModelEntity)entity.ChildEntities[j];
+                        WriteGroup(j, ref baseIndex, model);
                     }
                 }
                 _streamWriter.Dispose();
@@ -78,53 +78,69 @@ namespace PSXPrev.Classes
             var worldMatrix = model.WorldMatrix;
             foreach (var triangle in model.Triangles)
             {
-                var vertexColor0 = string.Empty;
-                var vertexColor1 = string.Empty;
-                var vertexColor2 = string.Empty;
-                var c0 = triangle.Colors[0];
-                var c1 = triangle.Colors[1];
-                var c2 = triangle.Colors[2];
-                if (_experimentalVertexColor)
+                for (var j = 0; j < 3; j++)
                 {
-                    vertexColor0 = string.Format(" {0} {1} {2}", (c0.R).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c0.G).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c0.B).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                    vertexColor1 = string.Format(" {0} {1} {2}", (c1.R).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c1.G).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c1.B).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                    vertexColor2 = string.Format(" {0} {1} {2}", (c2.R).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c2.G).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (c2.B).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
+                    var vertex = Vector3.TransformPosition(triangle.Vertices[j], worldMatrix);
+                    WriteVertex(vertex, triangle.Colors[j]);
                 }
-                var v0 = Vector3.TransformPosition(triangle.Vertices[0], worldMatrix);
-                var v1 = Vector3.TransformPosition(triangle.Vertices[1], worldMatrix);
-                var v2 = Vector3.TransformPosition(triangle.Vertices[2], worldMatrix);
-                _streamWriter.WriteLine("v {0} {1} {2} {3}", (v0.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v0.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v0.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), vertexColor0);
-                _streamWriter.WriteLine("v {0} {1} {2} {3}", (v1.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v1.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v1.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), vertexColor1);
-                _streamWriter.WriteLine("v {0} {1} {2} {3}", (v2.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v2.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-v2.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), vertexColor2);
             }
             foreach (var triangle in model.Triangles)
             {
-                var n0 = Vector3.TransformNormal(triangle.Normals[0], worldMatrix);
-                var n1 = Vector3.TransformNormal(triangle.Normals[1], worldMatrix);
-                var n2 = Vector3.TransformNormal(triangle.Normals[2], worldMatrix);
-                _streamWriter.WriteLine("vn {0} {1} {2}", (n0.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n0.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n0.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                _streamWriter.WriteLine("vn {0} {1} {2}", (n1.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n1.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n1.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                _streamWriter.WriteLine("vn {0} {1} {2}", (n2.X).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n2.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (-n2.Z).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
+                for (var j = 0; j < 3; j++)
+                {
+                    var normal = Vector3.TransformNormal(triangle.Normals[j], worldMatrix);
+                    WriteNormal(normal);
+                }
             }
             foreach (var triangle in model.Triangles)
             {
-                var uv0 = triangle.Uv[0];
-                var uv1 = triangle.Uv[1];
-                var uv2 = triangle.Uv[2];
-                _streamWriter.WriteLine("vt {0} {1}", uv0.X.ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (1f - uv0.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                _streamWriter.WriteLine("vt {0} {1}", uv1.X.ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (1f - uv1.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
-                _streamWriter.WriteLine("vt {0} {1}", uv2.X.ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture), (1f - uv2.Y).ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture));
+                for (var j = 0; j < 3; j++)
+                {
+                    WriteUV(triangle.Uv[j]);
+                }
             }
+        }
+
+        private void WriteVertex(Vector3 vertex, Color color)
+        {
+            var vertexColor = string.Empty;
+            if (_experimentalVertexColor)
+            {
+                vertexColor = string.Format(" {0} {1} {2}", F(color.R), F(color.G), F(color.B));
+            }
+            _streamWriter.WriteLine("v {0} {1} {2}{3}", F(vertex.X), F(-vertex.Y), F(-vertex.Z), vertexColor);
+        }
+
+        private void WriteNormal(Vector3 normal)
+        {
+            _streamWriter.WriteLine("vn {0} {1} {2}", F(normal.X), F(-normal.Y), F(-normal.Z));
+        }
+
+        private void WriteUV(Vector2 uv)
+        {
+            _streamWriter.WriteLine("vt {0} {1}", F(uv.X), F(1f - uv.Y));
         }
 
         private void WriteGroup(int groupIndex, ref int baseIndex, ModelEntity model)
         {
-            _streamWriter.WriteLine("g group" + groupIndex);
-            _streamWriter.WriteLine("usemtl mtl{0}", model.TexturePage);
+            var materialName = _mtlExporter.GetMaterialName(model.IsTextured ? (int?)model.TexturePage : null);
+
+            _streamWriter.WriteLine("g group{0}", groupIndex);
+            _streamWriter.WriteLine("usemtl {0}", materialName);
             for (var k = 0; k < model.Triangles.Length; k++)
             {
                 _streamWriter.WriteLine("f {2}/{2}/{2} {1}/{1}/{1} {0}/{0}/{0}", baseIndex++, baseIndex++, baseIndex++);
             }
+        }
+
+        private static string F(float value)
+        {
+            return value.ToString(GeomUtils.FloatFormat, CultureInfo.InvariantCulture);
+        }
+
+        private static string I(float value)
+        {
+            return value.ToString(GeomUtils.IntegerFormat, CultureInfo.InvariantCulture);
         }
     }
 }


### PR DESCRIPTION
* `mtlnone` is now used for untextured models. Importers will no longer give a warning or error for missing `mtl0`, which would be used for untextured models, but not written to the `mtl` file.
* Refactored a lot of the Obj, Ply, and Mtl Exporter code to reduce code duplication (inside and between exporters) and reduce verbosity.