### PR TITLE
Scanner rewrite, refactoring, and command line options

### DIFF
--- a/Classes/FileOffsetScanner.cs
+++ b/Classes/FileOffsetScanner.cs
@@ -8,12 +8,18 @@ namespace PSXPrev.Classes
     public delegate void AnimationAddedAction(Animation animation, long offset);
     public delegate void TextureAddedAction(Texture texture, long offset);
 
-    public abstract class FileOffsetScanner
+    public abstract class FileOffsetScanner : IDisposable
     {
-        protected long _offset;
         private readonly EntityAddedAction _entityAddedAction;
         private readonly AnimationAddedAction _animationAddedAction;
         private readonly TextureAddedAction _textureAddedAction;
+
+        protected long _offset;
+
+        public long? StartOffset { get; set; }
+        public long? StopOffset { get; set; }
+        // Next stream offset will be at the end of the last-read file.
+        public bool NextOffset { get; set; }
 
         public FileOffsetScanner(EntityAddedAction entityAdded = null, AnimationAddedAction animationAdded = null, TextureAddedAction textureAdded = null)
         {
@@ -31,11 +37,18 @@ namespace PSXPrev.Classes
 
             Program.Logger.WriteLine($"Scanning for {FormatName} at file: {fileTitle}");
 
+            // Assume this is a read-only stream, and that the length won't change.
+            _offset = StartOffset ?? 0;
+            var length = Math.Max(_offset + 1, Math.Min(reader.BaseStream.Length, StopOffset ?? long.MaxValue));
 
-            _offset = 0;
 
-            while (reader.BaseStream.CanRead)
+            while (reader.BaseStream.CanRead && _offset < length)
             {
+                if (Program.WaitOnScanState())
+                {
+                    break; // Canceled
+                }
+
                 reader.BaseStream.Seek(_offset, SeekOrigin.Begin);
 
                 var passed = false;
@@ -88,7 +101,7 @@ namespace PSXPrev.Classes
                             texture.TextureName = name;
                             _textureAddedAction(texture, _offset);
 
-                            Program.Logger.WritePositiveLine($"Found {FormatName} Image {AtOffsetString}");
+                            Program.Logger.WritePositiveLine($"Found {FormatName} Texture {AtOffsetString}");
                         }
                     }
                 }
@@ -101,18 +114,32 @@ namespace PSXPrev.Classes
                 }
 
                 _offset++; // Always increment by at least one.
-                if (passed)
+                if (passed && NextOffset)
                 {
-                    _offset = Math.Max(_offset, reader.BaseStream.Position);
-                }
-
-                if (Program.NoOffset || _offset > reader.BaseStream.Length)
-                {
-                    Program.Logger.WriteLine($"{FormatName} - Reached file end: {fileTitle}");
-                    return;
+                    var endPosition = reader.BaseStream.Position;
+                    // Don't use this for now, because reading rogue matching data
+                    // can cause large jumps in offset that skip real files.
+                    //if (reader.BaseStream is FileOffsetStream fileOffsetStream)
+                    //{
+                    //    endPosition = fileOffsetStream.FarthestPosition;
+                    //}
+                    _offset = Math.Max(_offset, endPosition);
                 }
             }
+
+            Program.Logger.WriteLine($"{FormatName} - Reached file end: {fileTitle}");
         }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+
 
         protected string AtOffsetString => $"at offset {_offset:X}";
 

--- a/Classes/FileOffsetStream.cs
+++ b/Classes/FileOffsetStream.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+
+namespace PSXPrev.Classes
+{
+    // Stream wrapper for tracking the farthest position visited in the file.
+    public sealed class FileOffsetStream : Stream
+    {
+        private readonly Stream _stream;
+        private long _maxPosition;
+
+        public FileOffsetStream(Stream stream)
+        {
+            _stream = stream;
+            _maxPosition = stream.Position;
+        }
+
+
+        public long FarthestPosition
+        {
+            get
+            {
+                _maxPosition = Math.Max(_maxPosition, _stream.Position);
+                return _maxPosition;
+            }
+        }
+
+        public override long Position
+        {
+            get => _stream.Position;
+            set => Seek(value, SeekOrigin.Begin);
+        }
+
+        public override long Length => _stream.Length;
+
+        public override bool CanRead => _stream.CanRead;
+
+        public override bool CanSeek => _stream.CanSeek;
+
+        public override bool CanWrite => _stream.CanWrite;
+
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            _maxPosition = Math.Max(_maxPosition, _stream.Position);
+            var newPosition = _stream.Seek(offset, origin);
+            _maxPosition = Math.Max(_maxPosition, newPosition);
+            return newPosition;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _maxPosition = Math.Max(_maxPosition, _stream.Position);
+            }
+            base.Dispose(disposing);
+        }
+
+        public override int ReadByte() => _stream.ReadByte();
+
+        public override void WriteByte(byte value) => _stream.WriteByte(value);
+
+        public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+
+        public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
+
+        public override void Flush() => _stream.Flush();
+
+        public override void SetLength(long value) => _stream.SetLength(value);
+    }
+}

--- a/Classes/FileReader.cs
+++ b/Classes/FileReader.cs
@@ -19,7 +19,7 @@ namespace PSXPrev.Classes
             {
                 return;
             }
-            var file = File.Open(filename, FileMode.Open);
+            var file = File.OpenRead(filename);
             Reader = new BinaryReader(file, Encoding.ASCII);
         }
     }

--- a/Classes/RootEntitySelectorEditor.cs
+++ b/Classes/RootEntitySelectorEditor.cs
@@ -16,30 +16,18 @@ namespace PSXPrev.Classes
 
         public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            if (Program.Scanning)
+            if (Program.IsScanning)
             {
                 MessageBox.Show("Please wait until the scan finishes.");
                 return null;
             }
             var svc = provider.GetService(typeof(IWindowsFormsEditorService)) as IWindowsFormsEditorService;
-            if (svc != null)
+            using (var form = new SelectTMDForm())
             {
-                using (var form = new SelectTMDForm())
+                var result = svc != null ? svc.ShowDialog(form) : form.ShowDialog();
+                if (result == DialogResult.OK)
                 {
-                    if (svc.ShowDialog(form) == DialogResult.OK)
-                    {
-                        return form.SelectedTMD;
-                    }
-                }
-            }
-            else
-            {
-                using (var form = new SelectTMDForm())
-                {
-                    if (form.ShowDialog() == DialogResult.OK)
-                    {
-                        return form.SelectedTMD;
-                    }
+                    return form.SelectedTMD;
                 }
             }
             return base.EditValue(context, provider, value);

--- a/Classes/Utils.cs
+++ b/Classes/Utils.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Text;
-using PSXPrev.Forms;
 
 namespace PSXPrev.Classes
 {
@@ -10,20 +9,12 @@ namespace PSXPrev.Classes
         {
             var sb = new StringBuilder();
 
-            for (int i = 0; i < bits.Count; i++)
+            for (var i = 0; i < bits.Count; i++)
             {
-                char c = bits[i] ? '1' : '0';
-                sb.Append(c);
+                sb.Append(bits[i] ? '1' : '0');
             }
 
             return sb.ToString();
-        }
-
-        public static string ShowDialog(string caption, string text)
-        {
-            var prompt = new DialogForm {Text = caption, LabelText = text};
-            prompt.ShowDialog();
-            return prompt.ResultText;
         }
     }
 }

--- a/Forms/DialogForm.cs
+++ b/Forms/DialogForm.cs
@@ -1,25 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace PSXPrev.Forms
 {
     public partial class DialogForm : Form
     {
-        public String ResultText
-        {
-            get { return mainTextBox.Text; }
-        }
+        public string ResultText => mainTextBox.Text;
 
-        public String LabelText
+        public string LabelText
         {
-            set { mainLabel.Text = value; }
+            get => mainLabel.Text;
+            set => mainLabel.Text = value;
         }
 
         public DialogForm()
@@ -30,6 +21,17 @@ namespace PSXPrev.Forms
         private void okButton_Click(object sender, EventArgs e)
         {
             Close();
+        }
+
+        public static string Show(string text, string caption) => Show(null, text, caption);
+
+        public static string Show(IWin32Window owner, string text, string caption)
+        {
+            using (var prompt = new DialogForm { LabelText = text, Text = caption })
+            {
+                prompt.ShowDialog(owner);
+                return prompt.ResultText;
+            }
         }
     }
 }

--- a/Forms/LauncherForm.cs
+++ b/Forms/LauncherForm.cs
@@ -67,21 +67,27 @@ namespace PSXPrev.Forms
                 CheckTOD = scanTODCheckBox.Checked,
                 CheckVDF = scanVDFCheckBox.Checked,
 
-                IgnoreTMDVersion = optionIgnoreTMDVersionCheckBox.Checked,
                 IgnoreHMDVersion = optionIgnoreHMDVersionCheckBox.Checked,
                 IgnoreTIMVersion = optionIgnoreTIMVersionCheckBox.Checked,
+                IgnoreTMDVersion = optionIgnoreTMDVersionCheckBox.Checked,
+
+                StartOffset = optionNoOffsetCheckBox.Checked ? (long?)0 : null,
+                StopOffset = optionNoOffsetCheckBox.Checked ? (long?)1 : null,
+                //NextOffset = false, //todo
+
+                //DepthFirstFileSearch = true, //todo
+                //AsyncFileScan = true, //todo
 
                 LogToFile = optionLogToFileCheckBox.Checked,
-                NoVerbose = optionNoVerboseCheckBox.Checked,
+                LogToConsole = !optionNoVerboseCheckBox.Checked,
                 Debug = optionDebugCheckBox.Checked,
                 ShowErrors = optionShowErrorsCheckBox.Checked,
-                NoConsoleColor = false, //todo
+                //ConsoleColor = true, //todo
 
                 DrawAllToVRAM = optionDrawAllToVRAMCheckBox.Checked,
-                NoOffset = optionNoOffsetCheckBox.Checked,
                 AutoAttachLimbs = optionAutoAttachLimbsCheckBox.Checked,
-                AutoPlayAnimations = false, //todo
-                AutoSelect = false, //todo
+                //AutoPlayAnimations = false, //todo
+                //AutoSelect = false, //todo
             });
 
             Close();

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -87,6 +87,7 @@ namespace PSXPrev
             this.mainMenuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pauseScanningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.stopScanningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.modelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -925,6 +926,7 @@ namespace PSXPrev
             // 
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.pauseScanningToolStripMenuItem,
+            this.stopScanningToolStripMenuItem,
             this.toolStripMenuItem1,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
@@ -938,6 +940,13 @@ namespace PSXPrev
             this.pauseScanningToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
             this.pauseScanningToolStripMenuItem.Text = "Pause Scanning";
             this.pauseScanningToolStripMenuItem.CheckedChanged += new System.EventHandler(this.pauseScanningToolStripMenuItem_CheckedChanged);
+            // 
+            // stopScanningToolStripMenuItem
+            // 
+            this.stopScanningToolStripMenuItem.Name = "stopScanningToolStripMenuItem";
+            this.stopScanningToolStripMenuItem.Size = new System.Drawing.Size(157, 22);
+            this.stopScanningToolStripMenuItem.Text = "Stop Scanning";
+            this.stopScanningToolStripMenuItem.Click += new System.EventHandler(this.stopScanningToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
@@ -1498,6 +1507,7 @@ namespace PSXPrev
             this.Name = "PreviewForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "PSXPrev";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.previewForm_FormClosing);
             this.Load += new System.EventHandler(this.previewForm_Load);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyDown);
             this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyUp);
@@ -1687,5 +1697,6 @@ namespace PSXPrev
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel6;
         private System.Windows.Forms.Label animationProgressLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+        private System.Windows.Forms.ToolStripMenuItem stopScanningToolStripMenuItem;
     }
 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Classes\CoordUnit.cs" />
     <Compile Include="Classes\DaeExporter.cs" />
     <Compile Include="Classes\EntityBase.cs" />
+    <Compile Include="Classes\FileOffsetStream.cs" />
     <Compile Include="Classes\FInt.cs" />
     <Compile Include="Classes\HMDHelper.cs" />
     <Compile Include="Classes\HMDParser.cs" />


### PR DESCRIPTION
## Command line options
* -range [START],[STOP] (or -range [OFFSET] for a single offset). These values are always taken in hex.
* -nextoffset : File scanners will move offset based on the position of the reader after successfully parsing a file. The default behavior has now been changed to always incrementing offset by one.
* -syncscan : Disables multi-threaded parsing of individual files.
* Unknown/invalid command line arguments are now printed to the console as a warning.
* PressAnyKeyToContinue when path isn't found now only triggers if LogToConsole is true.

## Scanning changes
* A lot of refactoring in Program.
* Parsers are now stored as `Func<FileOffsetScanner>`.
* Parsers are now populated in alphabetical order.
* ISO and invalid file extensions are now checked using a shared function.
* Added ProcessISO function.
* Renamed ProcessFile to ScanFile.
* Added ProcessFile function, which processes a file for each scanner (can't be used in ProcessISO).
* ProcessFiles is no longer a recursive function.
* Fixed handling of file progress.
* Renamed Program.UpdateProgress to UpdateFileProgress.
* Added Program.ResetFileProgress, which is called before the start of a file, or at the start of a new parser when not async (with true parameter).
* Renamed Program.WaitWhileHalted to WaitOnScanState. This function now sleeps for 1ms to give priority to other threads while waiting to unpause.
* Scan can now be canceled. WaitOnScanState returns true if cancellation has been requested, in which case, the function calling this should return/break and cleanup.
* Made more variables virtual that should be virtual.
* Added dedicated functions CancelScan and PauseScan, rather than changing Program fields/properties.
* CancelScan is now called when PreviewForm is closing.
* Added (unused) FileOffsetStream, which is a wrapper around another stream used to track the farthest position a file was read at. This is not setup yet during Program.ScanFile, and is not handled yet in FileOffsetScanner.ScanFile (however uncommented code is ready).
* Pausing a scan will now pause FileOffsetScanners in-between parse attempts.

## Other changes
* Utils.ShowDialog has been moved to DialogForm.Show, to follow the same convention used by MessageBox.Show. The order of text/caption parameters has also been switched to match MessageBox.
* Minor refactoring/cleanup in RootEntitySelectorEditor.
* Rewrote some of the HMD debug output information, like changing primitive type to hex, because it's easier to read.
* Fixed HMD developerId being parsed one bit too low (at 27 when it should be 28).
* Fixed PreviewForm sometimes erroring while closing in the middle of the scan. A new field _closing is now set during the Closing event, and this is now checked together with IsDisposed before invoking functions that may be called by Program.
* PreviewForm timers are now stopped during the Closing event.
* Added menu item to stop current scan. When pressed, a message box will first ask the user to confirm they want to cancel.
* When a scan is canceled or finishes, the Pause/Stop Scanning menu items will be unchecked/disabled.
* The status text label is changed to "Scan Paused"/"Scan Resumed" when pressing the Pause Scanning menu item.