### PR TITLE
Tiled texture and Ply texture exporting

### DIFF
--- a/Classes/Animation.cs
+++ b/Classes/Animation.cs
@@ -75,6 +75,12 @@ namespace PSXPrev.Classes
             }
         }
 
+        public override string ToString()
+        {
+            var name = AnimationName ?? nameof(Animation);
+            return $"{name} Frames={FrameCount} Objects={ObjectCount}";
+        }
+
 
         // Assign a flat collection of objects and setup parenting and hierarchy.
         public void AssignObjects(Dictionary<uint, AnimationObject> animationObjects, bool calcObjectFrameCounts, bool calcFrameDurations)

--- a/Classes/EntityBase.cs
+++ b/Classes/EntityBase.cs
@@ -166,11 +166,26 @@ namespace PSXPrev.Classes
         [Browsable(false)]
         public Matrix4 TempWorldMatrix => TempMatrix * WorldMatrix;
 
+
         protected EntityBase()
         {
             // Also assigns LocalMatrix, Translation, Rotation, and Scale.
             OriginalLocalMatrix = Matrix4.Identity;
         }
+
+        protected EntityBase(EntityBase fromEntity)
+        {
+            EntityName = fromEntity.EntityName;
+            ParentEntity = fromEntity.ParentEntity;
+            Bounds3D = fromEntity.Bounds3D;
+            TempMatrix = fromEntity.TempMatrix;
+            _originalLocalMatrix = fromEntity._originalLocalMatrix;
+            _localMatrix = fromEntity._localMatrix;
+            _translation = fromEntity._translation;
+            _scale = fromEntity._scale;
+            _rotation = fromEntity._rotation;
+        }
+
 
         public virtual void ComputeBounds()
         {
@@ -235,7 +250,8 @@ namespace PSXPrev.Classes
 
         public override string ToString()
         {
-            return EntityName;
+            var name = EntityName ?? GetType().Name;
+            return $"{name} Children={ChildCount}";
         }
 
         public virtual void FixConnections()

--- a/Classes/ModelEntity.cs
+++ b/Classes/ModelEntity.cs
@@ -77,6 +77,20 @@ namespace PSXPrev.Classes
         }
 
         [Browsable(false)]
+        public bool NeedsTiled
+        {
+            get
+            {
+                foreach (var triangle in Triangles)
+                {
+                    if (triangle.NeedsTiled)
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        [Browsable(false)]
         public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
 
         //[ReadOnly(true)]
@@ -107,6 +121,36 @@ namespace PSXPrev.Classes
         public Dictionary<uint, Vector3> AttachableVertices { get; set; }
         [Browsable(false)]
         public Dictionary<uint, Vector3> AttachableNormals { get; set; }
+
+
+        public ModelEntity()
+        {
+        }
+
+        public ModelEntity(ModelEntity fromModel, Triangle[] triangles)
+            : base(fromModel)
+        {
+            Triangles = triangles;
+            TexturePage = fromModel.TexturePage;
+            RenderFlags = fromModel.RenderFlags;
+            MixtureRate = fromModel.MixtureRate;
+            Texture = fromModel.Texture;
+            TMDID = fromModel.TMDID;
+            Visible = fromModel.Visible;
+            SharedID = fromModel.SharedID;
+            AttachableVertices = fromModel.AttachableVertices;
+            AttachableNormals = fromModel.AttachableNormals;
+            //AttachableVertices = new Dictionary<uint, Vector3>(fromModel.AttachableVertices);
+            //AttachableNormals = new Dictionary<uint, Vector3>(fromModel.AttachableNormals);
+        }
+
+
+        public override string ToString()
+        {
+            var name = EntityName ?? GetType().Name;
+            var page = IsTextured ? TexturePage.ToString() : "null";
+            return $"{name} Triangles={TrianglesCount} TexturePage={page}";
+        }
 
         public override void ComputeBounds()
         {

--- a/Classes/ModelPreparerExporter.cs
+++ b/Classes/ModelPreparerExporter.cs
@@ -1,0 +1,571 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using OpenTK;
+
+namespace PSXPrev.Classes
+{
+    // Class to split up and reconfigure models into a format that can be exported.
+    // Currently this just separates models with tiled textures and assigns tiled textures to the models.
+    public class ModelPreparerExporter : IDisposable
+    {
+        private readonly Dictionary<Tuple<uint, Vector4>, TiledTextureInfo> _groupedModels = new Dictionary<Tuple<uint, Vector4>, TiledTextureInfo>();
+        private readonly Dictionary<RootEntity, List<ModelEntity>> _rootEntityModels = new Dictionary<RootEntity, List<ModelEntity>>();
+        private readonly bool _tiledTextures;
+        private readonly bool _singleTexture; // Should all texture pages/tiled textures be merged into one bitmap?
+        private SingleTextureInfo _currentSingleInfo;
+
+        public ModelPreparerExporter(bool tiledTextures = true, bool singleTexture = false)
+        {
+            _tiledTextures = tiledTextures;
+            _singleTexture = singleTexture;
+        }
+
+
+        public void AddRootEntity(RootEntity rootEntity)
+        {
+            // todo: Maybe make this optional later. But for now we should
+            // fix connections even if we haven't viewed the model yet.
+            rootEntity.FixConnections();
+
+            foreach (ModelEntity model in rootEntity.ChildEntities)
+            {
+                SeparateModel(rootEntity, model);
+            }
+        }
+
+        public List<ModelEntity> GetModels(RootEntity rootEntity)
+        {
+            return _rootEntityModels[rootEntity];
+        }
+
+        // Call this after AddRootEntity has been called for all root entities that plan to be exported.
+        public void PrepareAll()
+        {
+            foreach (var tiledInfo in _groupedModels.Values)
+            {
+                if (tiledInfo.IsTiled)
+                {
+                    PrepareTiledTexture(tiledInfo); // Only need to prepare tiled textures
+                }
+            }
+        }
+
+        // Call this when preparing to export the current set of root entities.
+        // NOTE: This assumes that PrepareCurrent will NEVER be called with the same RootEntity twice!
+        public void PrepareCurrent(params RootEntity[] rootEntities)
+        {
+            if (_currentSingleInfo != null)
+            {
+                // Cleanup previous singleInfo
+                _currentSingleInfo.Dispose();
+                _currentSingleInfo = null;
+            }
+            if (_singleTexture)
+            {
+                // Add models and textures to singleInfo
+                _currentSingleInfo = new SingleTextureInfo();
+                var addedTextures = new HashSet<Texture>();
+                foreach (var rootEntity in rootEntities)
+                {
+                    var models = GetModels(rootEntity);
+                    foreach (var model in models)
+                    {
+                        if (model.Texture != null && model.IsTextured && addedTextures.Add(model.Texture))
+                        {
+                            _currentSingleInfo.OriginalTextures.Add(model.Texture);
+                        }
+                    }
+                    _currentSingleInfo.Models.AddRange(models);
+                }
+
+                PrepareSingleTexture(_currentSingleInfo);
+            }
+        }
+
+
+        private void PrepareTiledTexture(TiledTextureInfo tiledInfo)
+        {
+            // Find how many times the texture needs to repeat in the X and Y directions.
+            var maxUv = Vector2.Zero;
+            foreach (var model in tiledInfo.Models)
+            {
+                foreach (var triangle in model.Triangles)
+                {
+                    var baseUv = triangle.TiledBaseUv;
+                    if (baseUv != null)
+                    {
+                        for (var j = 0; j < 3; j++)
+                        {
+                            maxUv = Vector2.ComponentMax(maxUv, baseUv[j]);
+                        }
+                    }
+                }
+            }
+
+            // Create a new tiled texture that repeats the needed amount of times.
+            tiledInfo.SetupTiledTexture(maxUv);
+
+            // Assign new tiled texture to models.
+            foreach (var model in tiledInfo.Models)
+            {
+                model.Texture = tiledInfo.TiledTexture;
+
+                // Convert triangle UVs to new tiled texture UVs (we're no longer 256x256).
+                foreach (var triangle in model.Triangles)
+                {
+                    var baseUv = triangle.TiledBaseUv;
+                    if (baseUv != null)
+                    {
+                        // Create a new array because we don't own triangle.Uv's array.
+                        var uvs = new Vector2[3];
+                        for (var j = 0; j < 3; j++)
+                        {
+                            uvs[j] = tiledInfo.Convert(baseUv[j]);
+                        }
+                        triangle.Uv = uvs;
+                        triangle.TiledUv = null; // We're not tiled anymore.
+                    }
+                }
+            }
+        }
+
+        private void PrepareSingleTexture(SingleTextureInfo singleInfo)
+        {
+            // Compute packing and create a new single texture that contains all other textures.
+            singleInfo.SetupSingleTexture(true, true, true);
+
+            // Assign new single texture to models.
+            foreach (var model in singleInfo.Models)
+            {
+                if (model.Texture != null && model.IsTextured)
+                {
+                    var uvConverter = singleInfo.GetUVConverter(model.Texture);
+                    model.Texture = singleInfo.SingleTexture;
+
+                    // Convert triangle UVs to new single texture UVs (we're no longer 256x256).
+                    foreach (var triangle in model.Triangles)
+                    {
+                        var origUv = triangle.Uv;
+                        // Create a new array because we don't own triangle.Uv's array.
+                        var uvs = new Vector2[3];
+                        for (var j = 0; j < 3; j++)
+                        {
+                            uvs[j] = uvConverter.Convert(origUv[j]);
+                        }
+                        triangle.Uv = uvs;
+                        triangle.TiledUv = null; // We're not tiled anymore.
+                    }
+                }
+            }
+        }
+
+        private void SeparateModel(RootEntity rootEntity, ModelEntity model)
+        {
+            if (!_singleTexture && (!_tiledTextures || model.Texture == null || !model.IsTextured || !model.NeedsTiled))
+            {
+                // No changes to the model.
+                AddModel(rootEntity, model, Vector4.Zero);
+            }
+            else if (_singleTexture && !_tiledTextures)
+            {
+                // Create copies for every model with copies of each triangle.
+                var triangles = model.Triangles;
+                var newTriangles = new Triangle[triangles.Length];
+                for (var i = 0; i < triangles.Length; i++)
+                {
+                    newTriangles[i] = new Triangle(triangles[i]);
+                }
+                var newModel = new ModelEntity(model, newTriangles);
+                AddModel(rootEntity, newModel, Vector4.Zero);
+            }
+            else
+            {
+                // Separate models by tiled area, and force-create copies if we're creating a single texture.
+                var groupedTriangles = new Dictionary<Vector4, List<Triangle>>();
+
+                foreach (var triangle in model.Triangles)
+                {
+                    var needsTiled = _tiledTextures && triangle.NeedsTiled;
+                    var needsCopy = _singleTexture || needsTiled;
+                    var tiledArea = needsTiled ? triangle.TiledArea.Value : Vector4.Zero;
+                    if (!groupedTriangles.TryGetValue(tiledArea, out var triangles))
+                    {
+                        triangles = new List<Triangle>();
+                        groupedTriangles.Add(tiledArea, triangles);
+                    }
+                    // We only need to create a copy for tiled triangles, since we'll be modifying those.
+                    triangles.Add(needsCopy ? new Triangle(triangle) : triangle);
+                }
+
+                foreach (var kvp in groupedTriangles)
+                {
+                    var tiledArea = kvp.Key;
+                    var triangles = kvp.Value;
+                    var newModel = new ModelEntity(model, triangles.ToArray());
+                    AddModel(rootEntity, newModel, tiledArea);
+                }
+            }
+        }
+
+        private void AddModel(RootEntity rootEntity, ModelEntity model, Vector4 tiledArea)
+        {
+            var tuple = new Tuple<uint, Vector4>(model.TexturePage, tiledArea);
+            if (!_groupedModels.TryGetValue(tuple, out var tiledInfo))
+            {
+                tiledInfo = new TiledTextureInfo(model.Texture, tiledArea);
+                _groupedModels.Add(tuple, tiledInfo);
+            }
+            tiledInfo.Models.Add(model);
+
+            if (!_rootEntityModels.TryGetValue(rootEntity, out var childModels))
+            {
+                childModels = new List<ModelEntity>();
+                _rootEntityModels.Add(rootEntity, childModels);
+            }
+            childModels.Add(model);
+        }
+
+        public void Dispose()
+        {
+            if (_currentSingleInfo != null)
+            {
+                _currentSingleInfo.Dispose();
+                _currentSingleInfo = null;
+            }
+            foreach (var tiledInfo in _groupedModels.Values)
+            {
+                tiledInfo.Dispose();
+            }
+            _groupedModels.Clear();
+            _rootEntityModels.Clear();
+        }
+
+
+        private class SingleTextureInfo : IDisposable
+        {
+            // Use this as an alignment since texture tiling is always in units of 8.
+            private const int PACKED_ALIGN = 8;
+
+            public class PackedTextureInfo
+            {
+                //public Texture Texture;
+                public float OffsetX;
+                public float OffsetY;
+                public float ScalarX;
+                public float ScalarY;
+
+                public Vector2 Convert(Vector2 origUv)
+                {
+                    return new Vector2(OffsetX + origUv.X * ScalarX, OffsetY + origUv.Y * ScalarY);
+                }
+            }
+
+            public List<Texture> OriginalTextures { get; } = new List<Texture>();
+            public List<ModelEntity> Models { get; } = new List<ModelEntity>();
+
+            public Texture SingleTexture { get; private set; }
+
+            private readonly List<List<Texture>> _packedTextures = new List<List<Texture>>();
+            private readonly Dictionary<Texture, PackedTextureInfo> _packedTextureInfos = new Dictionary<Texture, PackedTextureInfo>();
+
+            private int _countX = 1;
+            private int _countY = 1;
+
+
+            public PackedTextureInfo GetUVConverter(Texture oldTexture)
+            {
+                return _packedTextureInfos[oldTexture];
+            }
+
+            public void SetupSingleTexture(bool powerOfTwo, bool sort, bool pack)
+            {
+                // Sort textures.
+                if (sort || pack) // Sorting is required when packing using greedy method
+                {
+                    // Order by:
+                    // 1. Texture pages:
+                    //     i. Page:   lowest to highest
+                    // 2. Loose textures:
+                    //     i. Width:  highest to lowest
+                    //    ii. Height: highest to lowest
+                    //   iii. Page:   lowest to highest
+                    OriginalTextures.Sort((a, b) => {
+                        if (!a.IsVRAMPage || !b.IsVRAMPage)
+                        {
+                            if (a.IsVRAMPage != b.IsVRAMPage)
+                            {
+                                return -a.IsVRAMPage.CompareTo(b.IsVRAMPage);
+                            }
+                            else if (a.Width != b.Width)
+                            {
+                                return -a.Width.CompareTo(b.Width);
+                            }
+                            else if (a.Height != b.Height)
+                            {
+                                return -a.Height.CompareTo(b.Height);
+                            }
+                        }
+                        return a.TexturePage.CompareTo(b.TexturePage);
+                    });
+                }
+
+                // Pack multiple loose textures into single cells to reduce required space.
+                if (pack)
+                {
+                    PackTextures();
+                }
+                else
+                {
+                    // Add each texture to its own cell.
+                    foreach (var texture in OriginalTextures)
+                    {
+                        _packedTextures.Add(new List<Texture> { texture });
+                    }
+                }
+
+                // Find a column/row count with the smallest max dimension (closest to a square).
+                // todo: This calculation can be simplified/optimized by a lot, but it works for now...
+                var total = _packedTextures.Count;
+                _countX = total;
+                _countY = 1;
+                var w = 1;
+                while (w <= total)
+                {
+                    // Round height up to account for partially-used rows.
+                    var h = (total + w - 1) / w;
+
+                    if (powerOfTwo)
+                    {
+                        // Find a power of two for the height.
+                        var h2 = 1;
+                        while (h2 < h)
+                        {
+                            h2 *= 2;
+                        }
+                        h = h2;
+                    }
+
+                    // Use <= to prefer larger widths over larger heights.
+                    if (Math.Max(w, h) <= Math.Max(_countX, _countY))
+                    {
+                        _countX = w;
+                        _countY = h;
+                    }
+
+                    // Loop increment
+                    if (powerOfTwo)
+                    {
+                        w *= 2;
+                    }
+                    else
+                    {
+                        w++;
+                    }
+                }
+
+                // Create packed texture info to help convert texture UVs later.
+                var cellIndex = 0;
+                foreach (var cellTextures in _packedTextures)
+                {
+                    var column = cellIndex % _countX;
+                    var row    = cellIndex / _countX;
+                    foreach (var texture in cellTextures)
+                    {
+                        var width  = !texture.IsVRAMPage ? texture.Width  : 255; //(VRAMPages.PageSize - 1);
+                        var height = !texture.IsVRAMPage ? texture.Height : 255; //(VRAMPages.PageSize - 1);
+                        var packedInfo = new PackedTextureInfo
+                        {
+                            //Texture = texture,
+                            OffsetX = (texture.X / 255f + column) / _countX,
+                            OffsetY = (texture.Y / 255f + row)    / _countY,
+                            ScalarX = (width  > 0 ? ((float)(width  - 0) / (255 * _countX)) : (1f / _countX)),
+                            ScalarY = (height > 0 ? ((float)(height - 0) / (255 * _countY)) : (1f / _countY)),
+                        };
+                        _packedTextureInfos.Add(texture, packedInfo);
+                    }
+                    cellIndex++;
+                }
+
+                if (SingleTexture == null)
+                {
+                    var bitmap = VRAMPages.ConvertSingleTexture(_packedTextures, _countX, _countY, false);
+                    try
+                    {
+                        SingleTexture = new Texture(bitmap, 0, 0, 32, 0);
+                        SingleTexture.TextureName = $"Single[{_countX}x{_countY}]";
+                        //SingleTexture.SemiTransparentMap = VRAMPages.ConvertSingleTexture(_packedTextures, _countX, _countY, true);
+                    }
+                    catch
+                    {
+                        bitmap.Dispose();
+                        throw;
+                    }
+                }
+            }
+
+            private void PackTextures()
+            {
+                // Add VRAM texture pages as their own cells, no other textures can be placed in them.
+                foreach (var texture in OriginalTextures)
+                {
+                    if (texture.IsVRAMPage)
+                    {
+                        _packedTextures.Add(new List<Texture> { texture });
+                    }
+                }
+
+                // Greedy rectangle packing: <https://stackoverflow.com/a/1213571/7517185>
+                var packedRects = new List<List<Rectangle>>();
+
+                var vramCellCount = _packedTextures.Count; // Now many indices to skip when adding to _packedTextures.
+                foreach (var texture in OriginalTextures)
+                {
+                    if (texture.IsVRAMPage)
+                    {
+                        continue;
+                    }
+
+                    var rect = new Rectangle(0, 0, texture.Width, texture.Height);
+
+                    var cellFound = false;
+                    var cellIndex = 0;
+                    foreach (var cellRects in packedRects)
+                    {
+                        for (var x = 0; x + rect.Width <= VRAMPages.PageSize && !cellFound; x += PACKED_ALIGN)
+                        {
+                            rect.X = x;
+                            for (var y = 0; y + rect.Height <= VRAMPages.PageSize && !cellFound; y += PACKED_ALIGN)
+                            {
+                                rect.Y = y;
+
+                                cellFound = true; // Assume a space is found in the cell unless we intersect.
+                                foreach (var otherRect in cellRects)
+                                {
+                                    if (rect.IntersectsWith(otherRect))
+                                    {
+                                        cellFound = false;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (cellFound)
+                        {
+                            // Add to existing cell
+                            texture.X = rect.X;
+                            texture.Y = rect.Y;
+                            cellRects.Add(rect);
+                            _packedTextures[cellIndex + vramCellCount].Add(texture);
+                            break;
+                        }
+                        cellIndex++;
+                    }
+                    if (!cellFound)
+                    {
+                        // Start a new cell
+                        rect.X = 0; // Reset rect position used during intersection checks
+                        rect.Y = 0;
+                        packedRects.Add(new List<Rectangle> { rect });
+                        _packedTextures.Add(new List<Texture> { texture });
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (SingleTexture != null)
+                {
+                    SingleTexture.Dispose();
+                    SingleTexture = null;
+                }
+                // Clear texture X,Y coordinates assigned during PackTextures.
+                foreach (var texture in OriginalTextures)
+                {
+                    texture.X = 0;
+                    texture.Y = 0;
+                }
+            }
+        }
+
+
+        private class TiledTextureInfo : IDisposable
+        {
+            public Texture OriginalTexture { get; }
+            public float X { get; } // Position added to BaseUv after wrapping.
+            public float Y { get; }
+            public float Width { get; } // Denominator of modulus with BaseUv for wrapping.
+            public float Height { get; }
+
+            public List<ModelEntity> Models { get; } = new List<ModelEntity>();
+
+            public Texture TiledTexture { get; private set; }
+
+            private int _repeatX = 1;
+            private int _repeatY = 1;
+            private float _scalarX = 1f; // Cached scalars to convert base UVs to tiled texture UVs.
+            private float _scalarY = 1f;
+
+            public int TexturePage => OriginalTexture.TexturePage;
+
+            public bool IsTiled => Width != 0f && Height != 0f;
+
+            public TiledTextureInfo(Texture originalTexture, Vector4 tiledArea)
+            {
+                OriginalTexture = originalTexture;
+                X = tiledArea.X;
+                Y = tiledArea.Y;
+                Width  = tiledArea.Z;
+                Height = tiledArea.W;
+            }
+
+
+            public Vector2 Convert(Vector2 baseUv)
+            {
+                return new Vector2(baseUv.X * _scalarX, baseUv.Y * _scalarY);
+            }
+
+            public void SetupTiledTexture(Vector2 maxUv)
+            {
+                // Make sure repeat is at least one or higher.
+                _repeatX = (int)Math.Max(1, Width  != 0f ? Math.Ceiling(maxUv.X / Width)  : 1f);
+                _repeatY = (int)Math.Max(1, Height != 0f ? Math.Ceiling(maxUv.Y / Height) : 1f);
+
+                _scalarX = (Width  != 0f ? 1f / (Width  * _repeatX) : 1f);
+                _scalarY = (Height != 0f ? 1f / (Height * _repeatY) : 1f);
+
+                if (TiledTexture == null)
+                {
+                    var srcX = (int)(X * 255f);
+                    var srcY = (int)(Y * 255f);
+                    var srcWidth  = Width  != 0f ? (int)(Width  * 255f) : VRAMPages.PageSize;
+                    var srcHeight = Height != 0f ? (int)(Height * 255f) : VRAMPages.PageSize;
+                    var srcRect = new Rectangle(srcX, srcY, srcWidth, srcHeight);
+
+                    var bitmap = VRAMPages.ConvertTiledTexture(OriginalTexture, srcRect, _repeatX, _repeatY, false);
+                    try
+                    {
+                        TiledTexture = new Texture(bitmap, 0, 0, 32, TexturePage);
+                        //TiledTexture.TextureName = $"Tiled[{srcX},{srcY} {srcWidth}x{srcHeight}]";
+                        TiledTexture.TextureName = $"Tiled[{_repeatX}x{_repeatY}]";
+                        //TiledTexture.SemiTransparentMap = VRAMPages.ConvertTiledTexture(OriginalTexture, srcRect, _repeatX, _repeatY, true);
+                    }
+                    catch
+                    {
+                        bitmap.Dispose();
+                        throw;
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                if (TiledTexture != null)
+                {
+                    TiledTexture.Dispose();
+                    TiledTexture = null;
+                }
+            }
+        }
+    }
+}

--- a/Classes/MtlExporter.cs
+++ b/Classes/MtlExporter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace PSXPrev.Classes
@@ -8,58 +9,179 @@ namespace PSXPrev.Classes
         public const string UntexturedID = "none";
 
         private readonly StreamWriter _writer;
+        private readonly string _selectedPath;
         private readonly int _modelIndex;
-        private readonly bool[] _exportedPages = new bool[VRAMPages.PageCount]; // 32
+        private readonly MaterialDictionary _materialIds;
+        private readonly HashSet<Texture> _writtenMaterials = new HashSet<Texture>();
 
         public string FileName { get; }
 
-        public MtlExporter(string selectedPath, int modelIndex)
+        public MtlExporter(string selectedPath, int modelIndex, MaterialDictionary materialIds = null)
         {
             FileName = $"mtl{modelIndex}.mtl";
             _writer = new StreamWriter($"{selectedPath}/{FileName}");
+            _selectedPath = selectedPath;
             _modelIndex = modelIndex;
+            _materialIds = materialIds ?? new MaterialDictionary();
 
             // Add a material without a file for use with untextured models.
-            WriteMaterial(GetMaterialName(null), null);
+            WriteMaterial(null);
         }
 
-        public string GetMaterialName(int? texturePage)
+        public string GetMaterialName(Texture texture)
         {
-            var materialId = texturePage?.ToString() ?? MtlExporter.UntexturedID;
-            return $"mtl{materialId}";
+            return GetMaterialName(_materialIds.Get(texture));
         }
 
-        public bool AddMaterial(int texturePage)
+        public string GetMaterialName(int? materialId)
         {
-            if (_exportedPages[texturePage])
+            return $"mtl{materialId?.ToString() ?? MtlExporter.UntexturedID}";
+        }
+
+        public bool AddMaterial(Texture texture, out int materialId)
+        {
+            if (texture == null)
             {
+                materialId = -1;
                 return false;
             }
-            _exportedPages[texturePage] = true;
-
-            WriteMaterial(GetMaterialName(texturePage), texturePage.ToString());
-            return true;
+            // We may have already exported this material for another model,
+            // but we may still need to write it to the mtl file for this model.
+            var exported = !_materialIds.Add(texture, out materialId);
+            if (_writtenMaterials.Add(texture))
+            {
+                WriteMaterial(materialId);
+            }
+            return !exported;
         }
 
-        private void WriteMaterial(string materialName, string fileName)
+        private void WriteMaterial(int? materialId)
         {
-            _writer.WriteLine("newmtl {0}", materialName);
+            _writer.WriteLine("newmtl {0}", GetMaterialName(materialId));
             _writer.WriteLine("Ka 0.00000 0.00000 0.00000"); // ambient color
             _writer.WriteLine("Kd 0.50000 0.50000 0.50000"); // diffuse color
             _writer.WriteLine("Ks 0.00000 0.00000 0.00000"); // specular color
             _writer.WriteLine("d 1.00000"); // "dissolved" (opaque)
             _writer.WriteLine("illum 0"); // illumination: 0-color on and ambient off
-            if (fileName != null)
+            if (materialId.HasValue)
             {
-                _writer.WriteLine("map_Kd {0}.png", fileName); // diffuse texture map
+                _writer.WriteLine("map_Kd {0}.png", materialId); // diffuse texture map
                 //todo: Output alpha for transparent pixels
-                //_writer.WriteLine("map_d {0}.png", fileName2); // alpha texture map
+                //_writer.WriteLine("map_d {0}a.png", materialId); // alpha texture map
             }
         }
 
         public void Dispose()
         {
             _writer.Close();
+        }
+
+
+        public class MaterialDictionary
+        {
+            private readonly bool[] _exportedPages = new bool[VRAMPages.PageCount]; // 32
+            private readonly Dictionary<Texture, int> _exportedTextures = new Dictionary<Texture, int>();
+
+            public bool Add(Texture texture, out int materialId)
+            {
+                if (texture == null)
+                {
+                    materialId = -1;
+                    return false;
+                }
+                else if (texture.IsVRAMPage)
+                {
+                    materialId = texture.TexturePage;
+                    if (_exportedPages[texture.TexturePage])
+                    {
+                        return false;
+                    }
+                    _exportedPages[texture.TexturePage] = true;
+                }
+                else
+                {
+                    if (_exportedTextures.TryGetValue(texture, out materialId))
+                    {
+                        return false;
+                    }
+                    materialId = _exportedPages.Length + _exportedTextures.Count;
+                    _exportedTextures.Add(texture, materialId);
+                }
+
+                return true; // Material added
+            }
+
+            public bool Contains(Texture texture)
+            {
+                if (texture == null)
+                {
+                    return true;
+                }
+                else if (texture.IsVRAMPage)
+                {
+                    return _exportedPages[texture.TexturePage];
+                }
+                else
+                {
+                    return _exportedTextures.ContainsKey(texture);
+                }
+            }
+
+            public int? Get(Texture texture)
+            {
+                if (texture == null)
+                {
+                    return null;
+                }
+                else if (texture.IsVRAMPage)
+                {
+                    if (!_exportedPages[texture.TexturePage])
+                    {
+                        throw new KeyNotFoundException();
+                    }
+                    return texture.TexturePage;
+                }
+                else
+                {
+                    return _exportedTextures[texture];
+                }
+            }
+
+            public bool TryGetValue(Texture texture, out int? materialId)
+            {
+                if (texture == null)
+                {
+                    materialId = null;
+                    return true;
+                }
+                else if (texture.IsVRAMPage)
+                {
+                    if (_exportedPages[texture.TexturePage])
+                    {
+                        materialId = texture.TexturePage;
+                        return true;
+                    }
+                }
+                else
+                {
+                    if (_exportedTextures.TryGetValue(texture, out var materialIdValue))
+                    {
+                        materialId = materialIdValue;
+                        return true;
+                    }
+                }
+                materialId = null;
+                return false;
+            }
+
+            public void Clear()
+            {
+                for (var i = 0; i < _exportedPages.Length; i++)
+                {
+                    _exportedPages[i] = false;
+                }
+                _exportedTextures.Clear();
+            }
         }
     }
 }

--- a/Classes/ObjExporter.cs
+++ b/Classes/ObjExporter.cs
@@ -6,84 +6,115 @@ namespace PSXPrev.Classes
 {
     public class ObjExporter
     {
-        private StreamWriter _streamWriter;
+        private StreamWriter _writer;
         private PngExporter _pngExporter;
         private MtlExporter _mtlExporter;
+        private MtlExporter.MaterialDictionary _mtlDictionary;
+        private ModelPreparerExporter _modelPreparer;
         private string _selectedPath;
         private bool _experimentalVertexColor;
+        private bool _exportTextures;
 
-        public void Export(RootEntity[] entities, string selectedPath, bool experimentalVertexColor = false, bool joinEntities = false)
+        public void Export(RootEntity[] entities, string selectedPath, bool joinEntities = false, bool experimentalVertexColor = false, bool exportTextures = true)
         {
             _pngExporter = new PngExporter();
+            _mtlDictionary = new MtlExporter.MaterialDictionary();
+            _modelPreparer = new ModelPreparerExporter(tiledTextures: true, singleTexture: false);
             _selectedPath = selectedPath;
             _experimentalVertexColor = experimentalVertexColor;
+            _exportTextures = exportTextures;
+
+            // Prepare the shared state for all models being exported (mainly setting up tiled textures).
+            foreach (var entity in entities)
+            {
+                _modelPreparer.AddRootEntity(entity);
+            }
+            _modelPreparer.PrepareAll();
+
             if (!joinEntities)
             {
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var entity = entities[i];
-                    _mtlExporter = new MtlExporter(selectedPath, i);
-                    _streamWriter = new StreamWriter($"{selectedPath}/obj{i}.obj");
-                    _streamWriter.WriteLine("mtllib {0}", _mtlExporter.FileName);
-                    foreach (ModelEntity model in entity.ChildEntities)
-                    {
-                        WriteModel(model);
-                    }
-                    var baseIndex = 1;
-                    for (var j = 0; j < entity.ChildEntities.Length; j++)
-                    {
-                        var model = (ModelEntity)entity.ChildEntities[j];
-                        WriteGroup(j, ref baseIndex, model);
-                    }
-                    _streamWriter.Dispose();
-                    _mtlExporter.Dispose();
+                    ExportEntities(i, entities[i]);
                 }
             }
             else
             {
-                _mtlExporter = new MtlExporter(selectedPath, 0);
-                _streamWriter = new StreamWriter($"{selectedPath}/obj0.obj");
-                _streamWriter.WriteLine("mtllib {0}", _mtlExporter.FileName);
-                foreach (var entity in entities)
-                {
-                    foreach (ModelEntity model in entity.ChildEntities)
-                    {
-                        WriteModel(model);
-                    }
-                }
-                var baseIndex = 1;
-                foreach (var entity in entities)
-                {
-                    for (var j = 0; j < entity.ChildEntities.Length; j++)
-                    {
-                        var model = (ModelEntity)entity.ChildEntities[j];
-                        WriteGroup(j, ref baseIndex, model);
-                    }
-                }
-                _streamWriter.Dispose();
-                _mtlExporter.Dispose();
+                ExportEntities(0, entities);
             }
+
+            //_pngExporter.Dispose();
+            _pngExporter = null;
+            //_mtlDictionary.Clear();
+            _mtlDictionary = null;
+            _modelPreparer.Dispose();
+            _modelPreparer = null;
+        }
+
+        private void ExportEntities(int index, params RootEntity[] entities)
+        {
+            // Re-use the dictionary of materials so that we only export them once,
+            // and so that different textures aren't assigned the same ID.
+            // We're using a separate mtl file for each model so that unused materials aren't added.
+            _mtlExporter = new MtlExporter(_selectedPath, index, _mtlDictionary);
+            _writer = new StreamWriter($"{_selectedPath}/obj{index}.obj");
+
+            // Prepare the state for the current model being exported.
+            _modelPreparer.PrepareCurrent(entities);
+
+            // Write mtl file reference
+            _writer.WriteLine("mtllib {0}", _mtlExporter.FileName);
+
+            // Write vertices and export materials
+            foreach (var entity in entities)
+            {
+                foreach (var model in _modelPreparer.GetModels(entity))
+                {
+                    WriteModel(model);
+                }
+            }
+
+            // Write groups and their faces
+            var baseIndex = 1; // Obj format is 1-indexed I guess...
+            foreach (var entity in entities)
+            {
+                var models = _modelPreparer.GetModels(entity);
+                // todo: Should we really be restarting j (groupIndex) from 0 for each root entity?
+                for (var j = 0; j < models.Count; j++)
+                {
+                    var model = models[j];
+                    WriteGroup(j, ref baseIndex, model);
+                }
+            }
+
             _mtlExporter.Dispose();
+            _mtlExporter = null;
+            _writer.Dispose();
+            _writer = null;
         }
 
         private void WriteModel(ModelEntity model)
         {
-            if (model.Texture != null && model.IsTextured)
+            // Export material if we haven't already
+            if (_exportTextures && model.Texture != null && model.IsTextured)
             {
-                if (_mtlExporter.AddMaterial((int) model.TexturePage))
+                if (_mtlExporter.AddMaterial(model.Texture, out var materialId))
                 {
-                    _pngExporter.Export(model.Texture, (int) model.TexturePage, _selectedPath);
+                    _pngExporter.Export(model.Texture, materialId, _selectedPath);
                 }
             }
+
             var worldMatrix = model.WorldMatrix;
+            // Write vertex positions (and colors if experimental)
             foreach (var triangle in model.Triangles)
             {
                 for (var j = 0; j < 3; j++)
                 {
                     var vertex = Vector3.TransformPosition(triangle.Vertices[j], worldMatrix);
-                    WriteVertex(vertex, triangle.Colors[j]);
+                    WriteVertexPosition(vertex, triangle.Colors[j]);
                 }
             }
+            // Write vertex normals
             foreach (var triangle in model.Triangles)
             {
                 for (var j = 0; j < 3; j++)
@@ -92,6 +123,7 @@ namespace PSXPrev.Classes
                     WriteNormal(normal);
                 }
             }
+            // Write vertex UVs
             foreach (var triangle in model.Triangles)
             {
                 for (var j = 0; j < 3; j++)
@@ -101,35 +133,38 @@ namespace PSXPrev.Classes
             }
         }
 
-        private void WriteVertex(Vector3 vertex, Color color)
+        private void WriteVertexPosition(Vector3 vertex, Color color)
         {
             var vertexColor = string.Empty;
             if (_experimentalVertexColor)
             {
                 vertexColor = string.Format(" {0} {1} {2}", F(color.R), F(color.G), F(color.B));
             }
-            _streamWriter.WriteLine("v {0} {1} {2}{3}", F(vertex.X), F(-vertex.Y), F(-vertex.Z), vertexColor);
+            _writer.WriteLine("v {0} {1} {2}{3}", F(vertex.X), F(-vertex.Y), F(-vertex.Z), vertexColor);
         }
 
         private void WriteNormal(Vector3 normal)
         {
-            _streamWriter.WriteLine("vn {0} {1} {2}", F(normal.X), F(-normal.Y), F(-normal.Z));
+            _writer.WriteLine("vn {0} {1} {2}", F(normal.X), F(-normal.Y), F(-normal.Z));
         }
 
         private void WriteUV(Vector2 uv)
         {
-            _streamWriter.WriteLine("vt {0} {1}", F(uv.X), F(1f - uv.Y));
+            _writer.WriteLine("vt {0} {1}", F(uv.X), F(1f - uv.Y));
         }
 
         private void WriteGroup(int groupIndex, ref int baseIndex, ModelEntity model)
         {
-            var materialName = _mtlExporter.GetMaterialName(model.IsTextured ? (int?)model.TexturePage : null);
+            var materialName = _mtlExporter.GetMaterialName(_exportTextures ? model.Texture : null);
 
-            _streamWriter.WriteLine("g group{0}", groupIndex);
-            _streamWriter.WriteLine("usemtl {0}", materialName);
+            // Write group header
+            _writer.WriteLine("g group{0}", groupIndex);
+            _writer.WriteLine("usemtl {0}", materialName);
+            // Write group faces
             for (var k = 0; k < model.Triangles.Length; k++)
             {
-                _streamWriter.WriteLine("f {2}/{2}/{2} {1}/{1}/{1} {0}/{0}/{0}", baseIndex++, baseIndex++, baseIndex++);
+                // v/vt/vn
+                _writer.WriteLine("f {2}/{2}/{2} {1}/{1}/{1} {0}/{0}/{0}", baseIndex++, baseIndex++, baseIndex++);
             }
         }
 

--- a/Classes/PlyExporter.cs
+++ b/Classes/PlyExporter.cs
@@ -1,107 +1,216 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using OpenTK;
 
 namespace PSXPrev.Classes
 {
     public class PlyExporter
     {
-        public PlyExporter()
-        {
+        private StreamWriter _writer;
+        private PngExporter _pngExporter;
+        private Dictionary<Texture, int> _materialsDictionary;
+        private bool _untexturedMaterialExported;
+        private ModelPreparerExporter _modelPreparer;
+        private string _selectedPath;
+        private bool _exportTextures;
 
+        public void Export(RootEntity[] entities, string selectedPath, bool joinEntities = false, bool exportTextures = true)
+        {
+            // todo: Different material IDs aren't handled for different root entities.
+            _pngExporter = new PngExporter();
+            _materialsDictionary = new Dictionary<Texture, int>();
+            _untexturedMaterialExported = false;
+            _modelPreparer = new ModelPreparerExporter(tiledTextures: exportTextures, singleTexture: exportTextures);
+            _selectedPath = selectedPath;
+            _exportTextures = exportTextures;
+
+            // Prepare the shared state for all models being exported (mainly setting up tiled textures).
+            foreach (var entity in entities)
+            {
+                _modelPreparer.AddRootEntity(entity);
+            }
+            _modelPreparer.PrepareAll();
+
+            if (!joinEntities)
+            {
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    if (i == 27)
+                    {
+                        var x = 0;
+                    }
+                    ExportEntities(i, entities[i]);
+                }
+            }
+            else
+            {
+                ExportEntities(0, entities);
+            }
+
+            //_pngExporter.Dispose();
+            _pngExporter = null;
+            //_materialsDictionary.Clear();
+            _materialsDictionary = null;
+            _modelPreparer.Dispose();
+            _modelPreparer = null;
         }
 
-        public void Export(RootEntity[] entities, string selectedPath)
+        private void ExportEntities(int index, params RootEntity[] entities)
         {
-            var pngExporter = new PngExporter();
-            for (var i = 0; i < entities.Length; i++)
+            _writer = new StreamWriter($"{_selectedPath}/ply{index}.ply");
+
+            // Prepare the state for the current model being exported.
+            _modelPreparer.PrepareCurrent(entities);
+
+            // Count faces and export materials
+            // Note that the standard Ply format does not support listing
+            // texture files, even though it supports texture UVs...
+            var faceCount = 0;
+            var materialCount = 1; // change: Start at 1 because 0 is untextured
+            Texture singleTexture = null;
+            foreach (var entity in entities)
             {
-                var entity = entities[i];
-                var writer = new StreamWriter($"{selectedPath}/ply{i}.ply");
-                writer.WriteLine("ply");
-                writer.WriteLine("format ascii 1.0");
-                var materialsDic = new Dictionary<int, int>();
-                var faceCount = 0;
-                var numMaterials = 0;
-                foreach (ModelEntity model in entity.ChildEntities)
+                foreach (var model in _modelPreparer.GetModels(entity))
                 {
                     faceCount += model.Triangles.Length;
-                    if (model.IsTextured)
+
+                    // Export material if we haven't already
+                    if (_exportTextures && model.Texture != null && model.IsTextured)
                     {
-                        // todo: Handle untextured material index...
-                        var texturePage = model.TexturePage;
-                        if (!materialsDic.ContainsKey((int)texturePage))
+                        if (!_materialsDictionary.TryGetValue(model.Texture, out var materialIndex))
                         {
-                            materialsDic.Add((int)texturePage, numMaterials++);
-                            pngExporter.Export(model.Texture, (int)texturePage, selectedPath);
+                            // Using singleTexture, materialIndex is always 0.
+                            materialIndex = 0;// _materialsDictionary.Count + 1; // 1-indexed because 0 is untextured
+                            _materialsDictionary.Add(model.Texture, materialIndex);
+
+                            singleTexture = model.Texture;
+                            //_pngExporter.Export(model.Texture, materialIndex, _selectedPath);
                         }
+                        // For each later model we write, there may be more materials defined that are unused.
+                        materialCount = Math.Max(materialCount, materialIndex + 1);
                     }
                 }
-                var vertexCount = faceCount * 3;
-                writer.WriteLine("element vertex {0}", vertexCount);
-                writer.WriteLine("property float32 x");
-                writer.WriteLine("property float32 y");
-                writer.WriteLine("property float32 z");
-                writer.WriteLine("property float32 nx");
-                writer.WriteLine("property float32 ny");
-                writer.WriteLine("property float32 nz");
-                writer.WriteLine("property float32 u");
-                writer.WriteLine("property float32 v");
-                writer.WriteLine("property uchar red");
-                writer.WriteLine("property uchar green");
-                writer.WriteLine("property uchar blue");
-                writer.WriteLine("property int32 material_index");
-                writer.WriteLine("element face {0}", faceCount);
-                writer.WriteLine("property list uint8 int32 vertex_indices");
-                writer.WriteLine("element material {0}", numMaterials);
-                writer.WriteLine("property uchar ambient_red");
-                writer.WriteLine("property uchar ambient_green");
-                writer.WriteLine("property uchar ambient_blue");
-                writer.WriteLine("property float32 ambient_coeff");
-                writer.WriteLine("property uchar diffuse_red");
-                writer.WriteLine("property uchar diffuse_green");
-                writer.WriteLine("property uchar diffuse_blue");
-                writer.WriteLine("property float32 diffuse_coeff");
-                writer.WriteLine("end_header");
+            }
 
-                foreach (ModelEntity model in entity.ChildEntities)
+            // Export untextured material
+            if (_exportTextures && !_untexturedMaterialExported)
+            {
+                // We always need to export the untextured material, because we're 1-indexing other materials.
+                _untexturedMaterialExported = true;
+                // It's pointless to export an empty material, if the importer isn't going to use it.
+                //_pngExporter.ExportEmpty(System.Drawing.Color.White, 0, _selectedPath);
+            }
+
+            // Write header
+            _writer.WriteLine("ply");
+            _writer.WriteLine("format ascii 1.0");
+
+            // Export single texture material
+            // Note: Some formats allow defining ONE texture file, like so.
+            if (_exportTextures && singleTexture != null)
+            {
+                _pngExporter.Export(singleTexture, index, _selectedPath);
+
+                _writer.WriteLine("comment TextureFile {0}.png", index);
+            }
+
+            // Write header vertex structure
+            var vertexCount = faceCount * 3;
+            _writer.WriteLine("element vertex {0}", vertexCount);
+            _writer.WriteLine("property float32 x");
+            _writer.WriteLine("property float32 y");
+            _writer.WriteLine("property float32 z");
+            _writer.WriteLine("property float32 nx");
+            _writer.WriteLine("property float32 ny");
+            _writer.WriteLine("property float32 nz");
+            // Support two different names for UVs: texture_u/v, and s/t
+            _writer.WriteLine("property float32 texture_u"); // MeshLab reads texture_u/v
+            _writer.WriteLine("property float32 texture_v");
+            _writer.WriteLine("property float32 s"); // Blender reads s/t
+            _writer.WriteLine("property float32 t");
+            _writer.WriteLine("property uchar red");
+            _writer.WriteLine("property uchar green");
+            _writer.WriteLine("property uchar blue");
+            _writer.WriteLine("property int32 material_index");
+            // Write header face structure
+            _writer.WriteLine("element face {0}", faceCount);
+            _writer.WriteLine("property list uint8 int32 vertex_indices");
+            // Write header material structure
+            _writer.WriteLine("element material {0}", materialCount);
+            _writer.WriteLine("property uchar ambient_red");
+            _writer.WriteLine("property uchar ambient_green");
+            _writer.WriteLine("property uchar ambient_blue");
+            _writer.WriteLine("property float32 ambient_coeff");
+            _writer.WriteLine("property uchar diffuse_red");
+            _writer.WriteLine("property uchar diffuse_green");
+            _writer.WriteLine("property uchar diffuse_blue");
+            _writer.WriteLine("property float32 diffuse_coeff");
+            // End header
+            _writer.WriteLine("end_header");
+
+            // Write vertices
+            foreach (var entity in entities)
+            {
+                foreach (var model in _modelPreparer.GetModels(entity))
                 {
-                    var materialIndex = materialsDic[(int) model.TexturePage];
+                    var materialIndex = 0; // Untextured
+                    if (_exportTextures && model.Texture != null && model.IsTextured)
+                    {
+                        materialIndex = _materialsDictionary[model.Texture];
+                    }
+
                     var worldMatrix = model.WorldMatrix;
                     foreach (var triangle in model.Triangles)
                     {
-                        // todo: Handle untextured material index...
                         for (var j = 0; j < 3; j++)
                         {
                             var vertex = Vector3.TransformPosition(triangle.Vertices[j], worldMatrix);
                             var normal = Vector3.TransformNormal(triangle.Normals[j], worldMatrix);
-                            WriteVertex(writer, vertex, normal, triangle.Uv[j], triangle.Colors[j], materialIndex);
+                            WriteVertex(vertex, normal, triangle.Uv[j], triangle.Colors[j], materialIndex);
                         }
                     }
                 }
-                for (var j = 0; j < faceCount; j++)
-                {
-                    var faceIndex = j * 3;
-                    writer.WriteLine("3 {2} {1} {0}", faceIndex, faceIndex + 1, faceIndex + 2);
-                }
-                for (var j = 0; j < numMaterials; j++)
-                {
-                    writer.WriteLine("128 128 128 1.00000 128 128 128 1.00000");
-                }
-                writer.Close();
             }
+            // Write faces
+            for (var i = 0; i < faceCount; i++)
+            {
+                WriteFace(i);
+            }
+            // Write materials
+            for (var i = 0; i < materialCount; i++)
+            {
+                WriteMaterial();
+            }
+
+            _writer.Close();
+            _writer = null;
         }
 
-        private void WriteVertex(StreamWriter writer, Vector3 vertex, Vector3 normal, Vector2 uv, Color color, int materialIndex)
+        private void WriteVertex(Vector3 vertex, Vector3 normal, Vector2 uv, Color color, int materialIndex)
         {
-            writer.WriteLine("{0} {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11}",
-                            F(-vertex.X), F(-vertex.Y), F(-vertex.Z),
-                            F(-normal.X), F(-normal.Y), F(-normal.Z),
-                            F(uv.X), F(1f - uv.Y),
-                            I(color.R * 255), I(color.G * 255), I(color.B * 255),
-                            materialIndex);
+            // Output UV (6 and 7) twice, since we're supporting two different names for it.
+            _writer.WriteLine("{0} {1} {2} {3} {4} {5} {6} {7} {6} {7} {8} {9} {10} {11}",
+                              //F(-vertex.X), F(-vertex.Y), F(-vertex.Z),
+                              //F(-normal.X), F(-normal.Y), F(-normal.Z),
+                              F(vertex.X), F(-vertex.Y), F(-vertex.Z),
+                              F(normal.X), F(-normal.Y), F(-normal.Z),
+                              F(uv.X), F(1f - uv.Y),
+                              I(color.R * 255), I(color.G * 255), I(color.B * 255),
+                              materialIndex);
+        }
+
+        private void WriteFace(int faceIndex)
+        {
+            var vertexIndex = faceIndex * 3;
+            //_writer.WriteLine("3 {0} {1} {2}", vertexIndex, vertexIndex + 1, vertexIndex + 2);
+            _writer.WriteLine("3 {2} {1} {0}", vertexIndex, vertexIndex + 1, vertexIndex + 2);
+        }
+
+        private void WriteMaterial()
+        {
+            _writer.WriteLine("128 128 128 1.00000 128 128 128 1.00000");
         }
 
         private static string F(float value)

--- a/Classes/PngExporter.cs
+++ b/Classes/PngExporter.cs
@@ -1,33 +1,60 @@
-﻿using System.Drawing.Imaging;
+﻿using System.Drawing;
+using System.Drawing.Imaging;
 
 namespace PSXPrev.Classes
 {
     public class PngExporter
     {
-        public void Export(Texture selectedTexture, int textureIndex, string selectedPath)
+        public void Export(Texture texture, int textureId, string selectedPath)
         {
-            var filePath = $"{selectedPath}/{textureIndex}.png";
-            if (selectedTexture.IsVRAMPage)
+            Export(texture, textureId.ToString(), selectedPath);
+        }
+
+        public void Export(Texture texture, string name, string selectedPath)
+        {
+            if (texture.IsVRAMPage)
             {
                 // Remove the semi-transparency section from the exported bitmap.
-                using (var bitmap = VRAMPages.GetTextureOnly(selectedTexture))
+                using (var bitmap = VRAMPages.ConvertTexture(texture, false))
                 {
-                    bitmap.Save(filePath, ImageFormat.Png);
+                    ExportBitmap(bitmap, name, selectedPath);
                 }
             }
             else
             {
-                selectedTexture.Bitmap.Save(filePath, ImageFormat.Png);
+                ExportBitmap(texture.Bitmap, name, selectedPath);
             }
         }
 
-        public void Export(Texture[] selectedTextures, string selectedPath)
+        public void ExportEmpty(System.Drawing.Color color, int textureId, string selectedPath, int width = 1, int height = 1)
         {
-            for (var i = 0; i < selectedTextures.Length; i++)
+            ExportEmpty(color, textureId.ToString(), selectedPath, width, height);
+        }
+
+        public void ExportEmpty(System.Drawing.Color color, string name, string selectedPath, int width = 1, int height = 1)
+        {
+            using (var bitmap = new Bitmap(width, height))
             {
-                var selectedTexture = selectedTextures[i];
-                Export(selectedTexture, i, selectedPath);  
+                using (var graphics = Graphics.FromImage(bitmap))
+                {
+                    graphics.Clear(color);
+                }
+                ExportBitmap(bitmap, name, selectedPath);
             }
+        }
+
+        public void Export(Texture[] textures, string selectedPath)
+        {
+            for (var i = 0; i < textures.Length; i++)
+            {
+                Export(textures[i], i, selectedPath);
+            }
+        }
+
+        private void ExportBitmap(Bitmap bitmap, string name, string selectedPath)
+        {
+            var filePath = $"{selectedPath}/{name}.png";
+            bitmap.Save(filePath, ImageFormat.Png);
         }
     }
 }

--- a/Classes/TMDHelper.cs
+++ b/Classes/TMDHelper.cs
@@ -456,9 +456,8 @@ namespace PSXPrev.Classes
                 var tva = 0f;
                 var isTiled = false;
                 // Confirm that tiled information is non-zero, otherwise we can just ignore it.
-                if (primitiveData.TryGetValue(m, PrimitiveDataType.TILE, out var tile) && (tile & 0xfffff) != 0)
+                if (primitiveData.TryGetValue(m, PrimitiveDataType.TILE, out var tile)) //&& (tile & 0xfffff) != 0)
                 {
-                    isTiled = true;
                     tumValue = (tile >>  0) & 0x1f;
                     tvmValue = (tile >>  5) & 0x1f;
                     tuaValue = (tile >> 10) & 0x1f;
@@ -471,18 +470,23 @@ namespace PSXPrev.Classes
                     // This is because all four values are required to be multiples of 8.
                     // So to recover tum and tvm, we need to unshift, negate, and then (realistically) add 1 to get the original value.
                     // However, adding 1 right now produces gaps in the textures. We can only add 1 when UV_DIV == 256f.
-                    if (UV_DIV == 256f)
+
+                    if (tumValue != 0 || tvmValue != 0) // We're not tiled if there's no wrap size.
                     {
-                        tum = (((tumValue << 3) ^ 0xff) + 1) / UV_DIV;
-                        tvm = (((tvmValue << 3) ^ 0xff) + 1) / UV_DIV;
+                        isTiled = true;
+                        if (UV_DIV == 256f)
+                        {
+                            tum = ((((tumValue << 3) ^ 0xff) + 1) & 0xff) / UV_DIV;
+                            tvm = ((((tvmValue << 3) ^ 0xff) + 1) & 0xff) / UV_DIV;
+                        }
+                        else
+                        {
+                            tum = ((tumValue << 3) ^ 0xff) / UV_DIV;
+                            tvm = ((tvmValue << 3) ^ 0xff) / UV_DIV;
+                        }
+                        tua = (tuaValue << 3) / UV_DIV;
+                        tva = (tvaValue << 3) / UV_DIV;
                     }
-                    else
-                    {
-                        tum = ((tumValue << 3) ^ 0xff) / UV_DIV;
-                        tvm = ((tvmValue << 3) ^ 0xff) / UV_DIV;
-                    }
-                    tua = (tuaValue << 3) / UV_DIV;
-                    tva = (tvaValue << 3) / UV_DIV;
                 }
 
                 // Converts UV base coordinates to tiled UV coordinates (for use with display/exporter).

--- a/Classes/Texture.cs
+++ b/Classes/Texture.cs
@@ -11,14 +11,19 @@ namespace PSXPrev.Classes
 
         private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
 
-        public Texture(int width, int height, int x, int y, int bpp, int texturePage, bool isVRAMPage = false)
+        public Texture(Bitmap bitmap, int x, int y, int bpp, int texturePage, bool isVRAMPage = false)
         {
-            Bitmap = new Bitmap(width, height);
+            Bitmap = bitmap;
             X = x;
             Y = y;
             Bpp = bpp;
             TexturePage = texturePage;
             IsVRAMPage = isVRAMPage;
+        }
+
+        public Texture(int width, int height, int x, int y, int bpp, int texturePage, bool isVRAMPage = false)
+            : this(new Bitmap(width, height), x, y, bpp, texturePage, isVRAMPage)
+        {
         }
 
         [DisplayName("Name")]
@@ -57,6 +62,12 @@ namespace PSXPrev.Classes
         {
             get => _ownerEntity.TryGetTarget(out var owner) ? owner : null;
             set => _ownerEntity.SetTarget(value);
+        }
+
+        public override string ToString()
+        {
+            var name = TextureName ?? nameof(Texture);
+            return $"{name} {X},{Y} {Width}x{Height} {Bpp}bpp";
         }
 
 

--- a/Classes/TiledUV.cs
+++ b/Classes/TiledUV.cs
@@ -14,6 +14,22 @@ namespace PSXPrev.Classes
         public Vector2 Size => new Vector2(Width, Height);
         public Vector4 Area => new Vector4(X, Y, Width, Height);
 
+        // Tests if any of the base UVs extend outside of the base tiled area.
+        public bool NeedsTiled
+        {
+            get
+            {
+                foreach (var uv in BaseUv)
+                {
+                    if ((Width != 0f && uv.X > Width) || (Height != 0f && uv.Y > Height))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
         public TiledUV(Vector2[] baseUv, float x, float y, float width, float height)
         {
             BaseUv = baseUv;

--- a/Classes/Triangle.cs
+++ b/Classes/Triangle.cs
@@ -74,6 +74,9 @@ namespace PSXPrev.Classes
         [ReadOnly(true), DisplayName("Is Tiled Texture")]
         public bool IsTiled => TiledUv != null;
 
+        [Browsable(false)]
+        public bool NeedsTiled => TiledUv?.NeedsTiled ?? false;
+
         [ReadOnly(true)]
         public Color[] Colors { get; set; }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Printing;
+using System.IO;
 using System.Reflection;
 using System.Timers;
 using System.Windows.Forms;
@@ -1072,6 +1073,8 @@ namespace PSXPrev
         private void cmsModelExport_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             var checkedEntities = GetCheckedEntities();
+            // Uncomment this line to test exporting all loaded models (so we don't need to check them).
+            //checkedEntities = _rootEntities.ToArray();
             if (checkedEntities == null)
             {
                 MessageBox.Show(this, "Check the models to export first");
@@ -1084,21 +1087,40 @@ namespace PSXPrev
                 if (OutputFolderSelect(out var path))
                 {
                     var objExporter = new ObjExporter();
+
+                    // Set to true to debug the PlyExporter by writing to the `ply/` subdirectory.
+                    const bool PLY_DEBUG = false;
+                    PlyExporter plyExporter = null;
+                    string plyPath = null;
+                    if (PLY_DEBUG)
+                    {
+                        plyExporter = new PlyExporter();
+                        plyPath = Path.Combine(path, "ply");
+                        if (!Directory.Exists(plyPath))
+                        {
+                            Directory.CreateDirectory(plyPath);
+                        }
+                    }
+
                     if (e.ClickedItem == miOBJ)
                     {
-                        objExporter.Export(checkedEntities, path);
+                        objExporter.Export(checkedEntities, path, joinEntities: false, experimentalVertexColor: false);
+                        if (PLY_DEBUG) plyExporter.Export(checkedEntities, plyPath, joinEntities: false);
                     }
                     else if (e.ClickedItem == miOBJVC)
                     {
-                        objExporter.Export(checkedEntities, path, true);
+                        objExporter.Export(checkedEntities, path, joinEntities: false, experimentalVertexColor: true);
+                        if (PLY_DEBUG) plyExporter.Export(checkedEntities, plyPath, joinEntities: false);
                     }
                     else if (e.ClickedItem == miOBJMerged)
                     {
-                        objExporter.Export(checkedEntities, path, false, true);
+                        objExporter.Export(checkedEntities, path, joinEntities: true, experimentalVertexColor: false);
+                        if (PLY_DEBUG) plyExporter.Export(checkedEntities, plyPath, joinEntities: true);
                     }
                     else if (e.ClickedItem == miOBJVCMerged)
                     {
-                        objExporter.Export(checkedEntities, path, true, true);
+                        objExporter.Export(checkedEntities, path, joinEntities: true, experimentalVertexColor: true);
+                        if (PLY_DEBUG) plyExporter.Export(checkedEntities, plyPath, joinEntities: true);
                     }
                     MessageBox.Show(this, "Models exported");
                 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Classes\PngExporter.cs" />
     <Compile Include="Classes\PXLParser.cs" />
     <Compile Include="Classes\TextureBinder.cs" />
+    <Compile Include="Classes\ModelPreparerExporter.cs" />
     <Compile Include="Classes\TiledUV.cs" />
     <Compile Include="Classes\TMDHelper.cs" />
     <Compile Include="Classes\TMDParser.cs" />


### PR DESCRIPTION
* Added ModelPreparerExporter, which is a tool now used by ObjExporter and PlyExporter to create tiled textures, and a single texture for Ply, since the format only allows one.
* Fixed PlyExporter outputting a horizontally flipped model, also fixed culling.
* Added ToString to Texture, Animation, and ModelEntity, and added more info to EntityBase's ToString.
* VRAMPages now assigns names to VRAM textures.
* TMDHelper now ensures tiling size is non-zero before setting isTiled to true.
* MtlExporter now supports preserving what textures have already been exported, while still rewritting materials needed for the current Obj's Mtl file.
* Added commented-out/disabled debug lines for testing PlyExporter, and automatically using all loaded models for exporting (in PreviewForm).

**Example of a packed single Ply texture:**
![0](https://github.com/rickomax/psxprev/assets/9752430/d1cd7ad2-71ff-4968-8b69-72b64be4df50)
