### PR TITLE
Animation sanity checks and fix VRAM/Texture tab rendering

### DIFF
--- a/Classes/AnimationBatch.cs
+++ b/Classes/AnimationBatch.cs
@@ -132,7 +132,11 @@ namespace PSXPrev.Classes
         // Total number of frames in animation and frames to wait between restarting loops.
         public double TotalFrameCount => FrameCount + LoopDelayFrameCount;
         // Real time in frames (including looping and delayed time). (Time x FPS)
-        public double FrameTime => Time * FPS;
+        public double FrameTime
+        {
+            get => Time * FPS;
+            set => Time = (FPS == 0 ? 0 : value / FPS);
+        }
         // Looped, capped, and mirrored playback time in frames.
         public double CurrentFrameTime => Math.Max(0, Math.Min(FrameCount, LoopFrameTime()));
 
@@ -753,6 +757,11 @@ namespace PSXPrev.Classes
         // Useful for when Modulus calculations prevent the animation from displaying in its end state.
         private static double CloseToFrameCount(bool start, double frameTime, double frameCount, double timeMultiplier)
         {
+            if (timeMultiplier == 0)
+            {
+                return 0d;
+            }
+
             //const double EPSILON = 0.0001d;
             var frameEpsilon = EPSILON / timeMultiplier;
 

--- a/Forms/TMDBindingsForm.cs
+++ b/Forms/TMDBindingsForm.cs
@@ -50,14 +50,14 @@ namespace PSXPrev.Forms
             bindingPropertyGrid.SelectedObject = new DictionaryPropertyGridAdapter(_currentAnimation.TMDBindings);
         }
 
-        public static void ShowTool(Animation currentAnimation)
+        public static void ShowTool(IWin32Window owner, Animation currentAnimation)
         {
             if (_instance == null)
             {
                 _instance = new TMDBindingsForm();
             }
             _instance.Reload(currentAnimation);
-            _instance.Show();
+            _instance.Show(owner);
             IsVisible = true;
         }
 


### PR DESCRIPTION
* AnimationBatch.FrameTime now has a setter, with safety checks for 0 FPS.
* VRAM picture box no longer has image assigned, instead the image is entirely dependent on being rendered during the Paint function (which requires calls to Invalidate). The reason we can't assign the image is because it would include the semi-transparent zone, and that zone would show behind transparent sections of the correctly rendered VRAM page.
* Fixed VRAM and texture images rendering half a pixel back. Unfortunately this changes the smoothing effect you see around textures, but I hope to bring it back manually later on.
* Added IWin32Window owner argument to all newly added MessageBox.Show calls, and added owner argument to TMDBindingsForm.ShowTool.