### PR TITLE
FileOffsetScanner change to results and texture disposal

### DIFF
--- a/Common/Parsers/ANParser.cs
+++ b/Common/Parsers/ANParser.cs
@@ -15,19 +15,15 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "AN";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
             var magic = reader.ReadUInt16();
             if (magic == 0xAAAA)
             {
                 var animation = ParseAN(reader);
                 if (animation != null)
                 {
-                    animations = new List<Animation> { animation };
+                    AnimationResults.Add(animation);
                 }
             }
         }

--- a/Common/Parsers/BFFParser.cs
+++ b/Common/Parsers/BFFParser.cs
@@ -18,16 +18,12 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "BFF";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
-            var model = ReadModels(reader);
-            if (model != null)
+            var rootEntity = ReadModels(reader);
+            if (rootEntity != null)
             {
-                entities = new List<RootEntity> { model };
+                EntityResults.Add(rootEntity);
             }
         }
 

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -15,16 +15,12 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "MOD";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
-            var model = ReadModels(reader);
-            if (model != null)
+            var rootEntity = ReadModels(reader);
+            if (rootEntity != null)
             {
-                entities = new List<RootEntity> { model };
+                EntityResults.Add(rootEntity);
             }
         }
 

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -15,19 +15,15 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "PMD";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
             var version = reader.ReadUInt32();
             if (version == 0x00000042)
             {
-                var entity = ParsePMD(reader);
-                if (entity != null)
+                var rootEntity = ParsePMD(reader);
+                if (rootEntity != null)
                 {
-                    entities = new List<RootEntity> { entity };
+                    EntityResults.Add(rootEntity);
                 }
             }
         }

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -21,16 +21,12 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "PSX";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-            
-            var model = ReadModels(reader);
-            if (model != null)
+            var rootEntity = ReadModels(reader);
+            if (rootEntity != null)
             {
-                entities = new List<RootEntity> { model };
+                EntityResults.Add(rootEntity);
             }
         }
 

--- a/Common/Parsers/TIMParser.cs
+++ b/Common/Parsers/TIMParser.cs
@@ -15,12 +15,8 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "TIM";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
             var id = reader.ReadUInt16();
             if (id == 0x10)
             {
@@ -30,7 +26,7 @@ namespace PSXPrev.Common.Parsers
                     var texture = ParseTim(reader);
                     if (texture != null)
                     {
-                        textures = new List<Texture> { texture };
+                        TextureResults.Add(texture);
                     }
                 }
             }
@@ -158,23 +154,23 @@ namespace PSXPrev.Common.Parsers
                 return null;
             }
 
-            int texturePage = imgDx / 64;
+            var texturePage = imgDx / 64;
             if (texturePage > 16)
             {
                 return null;
             }
 
-            int textureOffset = texturePage * 64;
+            var textureOffset = texturePage * 64;
 
-            int texturePageY = imgDy / 255;
+            var texturePageY = imgDy / 255;
             if (texturePageY > 2)
             {
                 return null;
             }
 
-            int textureOffsetY = texturePageY * 256;
+            var textureOffsetY = texturePageY * 256;
 
-            int finalTexturePage = (texturePageY * 16) + texturePage;
+            var finalTexturePage = (texturePageY * 16) + texturePage;
 
             int textureX;
             int textureY;

--- a/Common/Parsers/TMDParser.cs
+++ b/Common/Parsers/TMDParser.cs
@@ -15,24 +15,20 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "TMD";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
             var version = reader.ReadUInt32();
             if (Program.IgnoreTmdVersion || version == 0x00000041)
             {
-                var entity = ParseTmd(reader, fileTitle);
-                if (entity != null)
+                var rootEntity = ParseTmd(reader);
+                if (rootEntity != null)
                 {
-                    entities = new List<RootEntity> { entity };
+                    EntityResults.Add(rootEntity);
                 }
             }
         }
 
-        private RootEntity ParseTmd(BinaryReader reader, string fileTitle)
+        private RootEntity ParseTmd(BinaryReader reader)
         {
             var flags = reader.ReadUInt32();
             if (flags != 0 && flags != 1)
@@ -156,7 +152,7 @@ namespace PSXPrev.Common.Parsers
 
                 if (Program.Debug)
                 {
-                    Program.Logger.WriteLine($"Primitive count:{objBlock.NPrimitive} {fileTitle}");
+                    Program.Logger.WriteLine($"Primitive count:{objBlock.NPrimitive} {_fileTitle}");
                 }
                 for (var p = 0; p < objBlock.NPrimitive; p++)
                 {
@@ -183,9 +179,9 @@ namespace PSXPrev.Common.Parsers
                                             }
                                             if (!Program.ShowErrors)
                                             {
-                                                Program.Logger.WriteErrorLine($"Vertex index error: {fileTitle}");
+                                                Program.Logger.WriteErrorLine($"Vertex index error: {_fileTitle}");
                                             }
-                                            throw new Exception($"Vertex index error: {fileTitle}");
+                                            throw new Exception($"Vertex index error: {_fileTitle}");
                                         }
                                         return vertices[index];
                                     },
@@ -199,9 +195,9 @@ namespace PSXPrev.Common.Parsers
                                             }
                                             if (!Program.ShowErrors)
                                             {
-                                                Program.Logger.WriteErrorLine($"Normal index error: {fileTitle}");
+                                                Program.Logger.WriteErrorLine($"Normal index error: {_fileTitle}");
                                             }
-                                            throw new Exception($"Normal index error: {fileTitle}");
+                                            throw new Exception($"Normal index error: {_fileTitle}");
                                         }
                                         return normals[index];
                                     });

--- a/Common/Parsers/TODParser.cs
+++ b/Common/Parsers/TODParser.cs
@@ -15,19 +15,15 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "TOD";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-
             var fileID = reader.ReadByte();
             if (fileID == 0x50)
             {
                 var animation = ParseTOD(reader);
                 if (animation != null)
                 {
-                    animations = new List<Animation> { animation };
+                    AnimationResults.Add(animation);
                 }
             }
         }

--- a/Common/Parsers/VDFParser.cs
+++ b/Common/Parsers/VDFParser.cs
@@ -15,16 +15,12 @@ namespace PSXPrev.Common.Parsers
 
         public override string FormatName => "VDF";
 
-        protected override void Parse(BinaryReader reader, string fileTitle, out List<RootEntity> entities, out List<Animation> animations, out List<Texture> textures)
+        protected override void Parse(BinaryReader reader)
         {
-            entities = null;
-            animations = null;
-            textures = null;
-            
             var animation = ParseVDF(reader);
             if (animation != null)
             {
-                animations = new List<Animation> { animation };
+                AnimationResults.Add(animation);
             }
         }
 

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -12,8 +12,6 @@ namespace PSXPrev.Common
     public class RootEntity : EntityBase
     {
         private readonly List<ModelEntity> _groupedModels = new List<ModelEntity>();
-        private WeakReferenceCollection<Texture> _ownedTextures;
-        private WeakReferenceCollection<Animation> _ownedAnimations;
 
         [Browsable(false)]
         public Coordinate[] Coords { get; set; }
@@ -36,18 +34,10 @@ namespace PSXPrev.Common
         }
 
         [Browsable(false)]
-        public IEnumerable<Texture> OwnedTextures
-        {
-            get => _ownedTextures ?? Enumerable.Empty<Texture>();
-            set => _ownedTextures = new WeakReferenceCollection<Texture>(value);
-        }
+        public WeakReferenceCollection<Texture> OwnedTextures { get; } = new WeakReferenceCollection<Texture>();
 
         [Browsable(false)]
-        public IEnumerable<Animation> OwnedAnimations
-        {
-            get => _ownedAnimations ?? Enumerable.Empty<Animation>();
-            set => _ownedAnimations = new WeakReferenceCollection<Animation>(value);
-        }
+        public WeakReferenceCollection<Animation> OwnedAnimations { get; } = new WeakReferenceCollection<Animation>();
 
 
         public override void ComputeBounds()


### PR DESCRIPTION
This fixes the remainder of issue #76.

* FileOffsetScanner no longer passes `fileTitle` or asks for output lists of results.
* To add results during Parse, use the `EntityResults`, `TextureResults`, and `AnimationResults` lists.
* FileTitle can now be gotten through the protected field `_fileTitle`.
* TextureResults are now disposed of upon failure. Textures should immediately be added to `TextureResults` upon loading, so that they can always be disposed of during failure. Disposed of textures are automatically removed from `EntityResults[...].OwnedTextures`.
* Changed RootEntity Owned collections to not have bad property design with the setter. The WeakReferenceCollections are exposed instead.