### PR TITLE
Camera FOV up/down and gizmo fixes

### DIFF
--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -148,6 +148,8 @@ namespace PSXPrev.Forms
             this.vertexSizeUpDown = new System.Windows.Forms.NumericUpDown();
             this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
             this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.cameraFOVUpDown = new System.Windows.Forms.NumericUpDown();
+            this.label7 = new System.Windows.Forms.Label();
             this.entitiesTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.modelsSplitContainer)).BeginInit();
             this.modelsSplitContainer.Panel1.SuspendLayout();
@@ -208,6 +210,7 @@ namespace PSXPrev.Forms
             ((System.ComponentModel.ISupportInitialize)(this.lightIntensityNumericUpDown)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.vertexSizeUpDown)).BeginInit();
             this.flowLayoutPanel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cameraFOVUpDown)).BeginInit();
             this.SuspendLayout();
             // 
             // entitiesTabPage
@@ -1513,6 +1516,8 @@ namespace PSXPrev.Forms
             this.flowLayoutPanel2.Controls.Add(this.label4);
             this.flowLayoutPanel2.Controls.Add(this.vertexSizeUpDown);
             this.flowLayoutPanel2.Controls.Add(this.label5);
+            this.flowLayoutPanel2.Controls.Add(this.cameraFOVUpDown);
+            this.flowLayoutPanel2.Controls.Add(this.label7);
             this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.flowLayoutPanel2.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
             this.flowLayoutPanel2.Location = new System.Drawing.Point(0, 623);
@@ -1525,6 +1530,40 @@ namespace PSXPrev.Forms
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
             this.toolStripMenuItem2.Size = new System.Drawing.Size(181, 6);
+            // 
+            // cameraFOVUpDown
+            // 
+            this.cameraFOVUpDown.Location = new System.Drawing.Point(384, 3);
+            this.cameraFOVUpDown.Maximum = new decimal(new int[] {
+            160,
+            0,
+            0,
+            0});
+            this.cameraFOVUpDown.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.cameraFOVUpDown.Name = "cameraFOVUpDown";
+            this.cameraFOVUpDown.Size = new System.Drawing.Size(43, 20);
+            this.cameraFOVUpDown.TabIndex = 22;
+            this.cameraFOVUpDown.Value = new decimal(new int[] {
+            60,
+            0,
+            0,
+            0});
+            this.cameraFOVUpDown.ValueChanged += new System.EventHandler(this.cameraFOVUpDown_ValueChanged);
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Dock = System.Windows.Forms.DockStyle.Left;
+            this.label7.Location = new System.Drawing.Point(347, 0);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(31, 26);
+            this.label7.TabIndex = 23;
+            this.label7.Text = "FOV:";
+            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PreviewForm
             // 
@@ -1612,6 +1651,7 @@ namespace PSXPrev.Forms
             ((System.ComponentModel.ISupportInitialize)(this.vertexSizeUpDown)).EndInit();
             this.flowLayoutPanel2.ResumeLayout(false);
             this.flowLayoutPanel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.cameraFOVUpDown)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1733,5 +1773,7 @@ namespace PSXPrev.Forms
         private System.Windows.Forms.ToolStripMenuItem showTMDBindingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewOnGitHubToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+        private System.Windows.Forms.NumericUpDown cameraFOVUpDown;
+        private System.Windows.Forms.Label label7;
     }
 }

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -901,23 +901,13 @@ namespace PSXPrev.Forms
 
         private void UpdateGizmos(Scene.GizmoId selectedGizmo = Scene.GizmoId.None, Scene.GizmoId hoveredGizmo = Scene.GizmoId.None, bool updateMeshData = true)
         {
-            if (updateMeshData)
-            {
-                _scene.GizmosMeshBatch.Reset(3);
-            }
             var selectedEntityBase = (EntityBase)_selectedRootEntity ?? _selectedModelEntity;
-            if (selectedEntityBase == null)
+            _scene.UpdateGizmos(selectedEntityBase, hoveredGizmo, selectedGizmo, updateMeshData);
+            if (selectedEntityBase != null)
             {
-                return;
+                _selectedGizmo = selectedGizmo;
+                _hoveredGizmo = hoveredGizmo;
             }
-            var matrix = Matrix4.CreateTranslation(selectedEntityBase.Bounds3D.Center);
-            var scaleMatrix = _scene.GetGizmoScaleMatrix(matrix.ExtractTranslation());
-            var finalMatrix = scaleMatrix * matrix;
-            _scene.GizmosMeshBatch.BindCube(finalMatrix, hoveredGizmo == Scene.GizmoId.XMover || selectedGizmo == Scene.GizmoId.XMover ? Common.Color.White : Common.Color.Red, Scene.XGizmoDimensions, Scene.XGizmoDimensions, 0, null, updateMeshData);
-            _scene.GizmosMeshBatch.BindCube(finalMatrix, hoveredGizmo == Scene.GizmoId.YMover || selectedGizmo == Scene.GizmoId.YMover ? Common.Color.White : Common.Color.Green, Scene.YGizmoDimensions, Scene.YGizmoDimensions, 1, null, updateMeshData);
-            _scene.GizmosMeshBatch.BindCube(finalMatrix, hoveredGizmo == Scene.GizmoId.ZMover || selectedGizmo == Scene.GizmoId.ZMover ? Common.Color.White : Common.Color.Blue, Scene.ZGizmoDimensions, Scene.ZGizmoDimensions, 2, null, updateMeshData);
-            _selectedGizmo = selectedGizmo;
-            _hoveredGizmo = hoveredGizmo;
         }
 
         private void UpdateSelectedEntity(bool updateMeshData = true)
@@ -1841,6 +1831,13 @@ namespace PSXPrev.Forms
         private void vertexSizeUpDown_ValueChanged(object sender, EventArgs e)
         {
             _scene.VertexSize = vertexSizeUpDown.Value;
+        }
+
+        private void cameraFOVUpDown_ValueChanged(object sender, EventArgs e)
+        {
+            _scene.CameraFOV = (float)cameraFOVUpDown.Value;
+            cameraFOVUpDown.Refresh(); // Too slow to refresh number normally if using the arrow keys
+            UpdateGizmos(_selectedGizmo, _hoveredGizmo, false);
         }
 
         private void pauseScanningToolStripMenuItem_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
* Added FOV numeric up/down at the bottom with the other scene controls. Range is from 1-160 degrees (anything higher looks unintelligible).
* Changed max camera pitch to 89 degrees (we can't go to 90 degrees because the view will flip at that point).
* Inverted YMover gizmo so it points upwards instead of downwards.
* Fixed Z-fighting with Gizmos. X now occupies the center where all gizmos used to intersect.
* Moved UpdateGizmos logic to Scene, as it fits there better than PreviewForm determining how to draw them.
* Gizmo constants are now stored in a dictionary with classes containing their center, size, and color.
* Gizmo under mouse now finds the closest gizmo, rather than the first to intersect (X, Y, then Z).
* Camera distance calculations now need to apply _cameraFOVDistanceScalar.