### PR TITLE
Fix FOV ray picking and scene debug visuals

### DIFF
--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -184,10 +184,7 @@ namespace PSXPrev.Common.Animator
             // todo: Is this correct for handling reseting the mesh batch?
             // What if the animation doesn't match the object?
             var objectCount = animation == null ? 0 : (animation.ObjectCount + 1);
-            _scene.MeshBatch.Reset(objectCount);
-            _scene.BoundsBatch.Reset();
-            _scene.TriangleOutlineBatch.Reset();
-            _scene.GizmosMeshBatch.Reset(0);
+            _scene.ResetBatches(objectCount);
             if (_animation != animation)
             {
                 _animation = animation;

--- a/Common/Color.cs
+++ b/Common/Color.cs
@@ -4,8 +4,12 @@
     {
         public const float DefaultColorTone = 0.5f;
         public static readonly Color Red = new Color(1f, 0f, 0f);
+        public static readonly Color Yellow = new Color(1f, 1f, 0f);
         public static readonly Color Green = new Color(0f, 1f, 0f);
+        public static readonly Color Cyan = new Color(0f, 1f, 1f);
         public static readonly Color Blue = new Color(0f, 0f, 1f);
+        public static readonly Color Magenta = new Color(1f, 0f, 1f);
+        public static readonly Color Black = new Color(0f, 0f, 0f);
         public static readonly Color White = new Color(1f, 1f, 1f);
         public static readonly Color Grey = new Color(DefaultColorTone, DefaultColorTone, DefaultColorTone);
 
@@ -18,6 +22,11 @@
             R = r;
             G = g;
             B = b;
+        }
+
+        public Color(System.Drawing.Color color)
+            : this(color.R / 255f, color.G / 255f, color.B / 255f)
+        {
         }
 
         public override string ToString()

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -105,16 +105,21 @@ namespace PSXPrev.Common
 
         public static Vector3 UnProject(this Vector3 position, Matrix4 projection, Matrix4 view, float width, float height)
         {
+            // OpenTK version:
+            //var viewProjInv = Matrix4.Invert(view * projection);
+            //position.Y = height - position.Y;
+            //return Vector3.Unproject(position, 0f, 0f, width, height, 0f, 1f, viewProjInv);
+
             Vector4 vec;
             vec.X = 2.0f * position.X / width - 1;
-            vec.Y = -(2.0f * position.Y / height - 1);
-            vec.Z = position.Z;
+            vec.Y = 2.0f * (height - position.Y) / height - 1;
+            vec.Z = 2.0f * position.Z - 1; // 2.0f * position.Z / depth - 1; // Where depth=1
             vec.W = 1.0f;
             var viewInv = Matrix4.Invert(view);
             var projInv = Matrix4.Invert(projection);
             Vector4.Transform(ref vec, ref projInv, out vec);
             Vector4.Transform(ref vec, ref viewInv, out vec);
-            if (Math.Abs(vec.W) > 0.000001f)
+            if (Math.Abs(vec.W) > 0.0000000001f) //0.000001f)
             {
                 vec.X /= vec.W;
                 vec.Y /= vec.W;
@@ -180,7 +185,7 @@ namespace PSXPrev.Common
             var diff = rayOrigin - vertex0;
             var prod1 = Vector3.Dot(diff, planeNormal);
             var prod2 = Vector3.Dot(rayDirection, planeNormal);
-            if (Math.Abs(prod2) <= 0.000001f)
+            if (Math.Abs(prod2) <= 0.0000000001f) //0.000001f)
             {
                 return -1f; // Ray and plane are parallel.
             }

--- a/Common/Renderer/LineBatch.cs
+++ b/Common/Renderer/LineBatch.cs
@@ -109,35 +109,47 @@ namespace PSXPrev.Common.Renderer
             line.Draw(width);
         }
 
-        public void SetupEntityBounds(EntityBase entity)
+        public void SetupEntityBounds(EntityBase entity, Color color = null)
         {
             if (entity == null)
             {
                 return;
             }
+            if (color == null)
+            {
+                color = Color.White;
+            }
             var corners = entity.Bounds3D.Corners;
-            AddLine(corners[0], corners[2], Color.White);
-            AddLine(corners[2], corners[4], Color.White);
-            AddLine(corners[4], corners[1], Color.White);
-            AddLine(corners[1], corners[0], Color.White);
-            AddLine(corners[6], corners[7], Color.White);
-            AddLine(corners[7], corners[5], Color.White);
-            AddLine(corners[5], corners[3], Color.White);
-            AddLine(corners[3], corners[6], Color.White);
-            AddLine(corners[4], corners[7], Color.White);
-            AddLine(corners[6], corners[2], Color.White);
-            AddLine(corners[1], corners[5], Color.White);
-            AddLine(corners[3], corners[0], Color.White);
+            AddLine(corners[0], corners[2], color);
+            AddLine(corners[2], corners[4], color);
+            AddLine(corners[4], corners[1], color);
+            AddLine(corners[1], corners[0], color);
+            AddLine(corners[6], corners[7], color);
+            AddLine(corners[7], corners[5], color);
+            AddLine(corners[5], corners[3], color);
+            AddLine(corners[3], corners[6], color);
+            AddLine(corners[4], corners[7], color);
+            AddLine(corners[6], corners[2], color);
+            AddLine(corners[1], corners[5], color);
+            AddLine(corners[3], corners[0], color);
         }
 
-        public void SetupTriangleOutline(Triangle triangle, Matrix4 worldMatrix)
+        public void SetupTriangleOutline(Triangle triangle, Matrix4 worldMatrix, Color color = null)
         {
+            if (triangle == null)
+            {
+                return;
+            }
+            if (color == null)
+            {
+                color = Color.White;
+            }
             var vertex0 = Vector3.TransformPosition(triangle.Vertices[0], worldMatrix);
             var vertex1 = Vector3.TransformPosition(triangle.Vertices[1], worldMatrix);
             var vertex2 = Vector3.TransformPosition(triangle.Vertices[2], worldMatrix);
-            AddLine(vertex0, vertex1, Color.White);
-            AddLine(vertex1, vertex2, Color.White);
-            AddLine(vertex2, vertex0, Color.White);
+            AddLine(vertex0, vertex1, color);
+            AddLine(vertex1, vertex2, color);
+            AddLine(vertex2, vertex0, color);
         }
     }
 }

--- a/Common/Renderer/MeshBatch.cs
+++ b/Common/Renderer/MeshBatch.cs
@@ -107,13 +107,15 @@ namespace PSXPrev.Common.Renderer
             BindMesh(modelEntity, matrix, textureBinder, finalVertices != null || finalNormals != null, initialVertices, initialNormals, finalVertices, finalNormals, interpolator);
         }
 
-        public void BindCube(Matrix4 matrix, Color color, Vector3 center, Vector3 size, int index, TextureBinder textureBinder = null, bool updateMeshData = true)
+        public void BindCube(Matrix4 matrix, Color color, Vector3 center, Vector3 size, int index, TextureBinder textureBinder = null, bool updateMeshData = true, RenderFlags renderFlags = RenderFlags.DoubleSided, MixtureRate mixtureRate = MixtureRate.None)
         {
             var mesh = GetMesh(index);
             if (mesh == null)
             {
                 return;
             }
+            mesh.RenderFlags = renderFlags;
+            mesh.MixtureRate = mixtureRate;
             if (updateMeshData)
             {
                 const int numTriangles = 12;


### PR DESCRIPTION
* Scene.CameraYaw is now wrapped between 0 and PI*2, so that the value won't lose precision as it gets excessively large.
* Scene.Initialize now just calls Resize instead of SetupMatrices.
* Resize now assigns ViewportWidth and ViewportHeight, which are used in calculations in-place of passing the width/height every time.
* SetupMatrices no longer takes any arguments, as they are always the same.
* MeshBatch.BindCube now takes options render flags and mixture rate options.
* Added Scene.ShowVisuals which is enables or disables the ability for all non-geometry visuals to be displayed. Aka, it overrides ShowBounds and ShowGizmos. This is used when in the animation tab to force-disable other visuals.
* Add debug visuals to Scene.
    * ShowDebugVisuals - enables debug visuals similarly to ShowVisuals (however it's affected by ShowVisuals too).
    * ShowDebugPickedRay - when R is pressed, the current pick ray will be frozen in place and visible.
    * ShowIntersections - when clicking on an entity or triangle, all intersecting items will be highlighted. holding I will constantly update the visible intersections without having the click.
* Pressing Enter in the PreviewForm while a numeric up/down is selected will remove focus from the control.
* Made epsilon in GeomMath smaller to account for extremely low FOV levels.
* Some fixes to GeomMath.UnProject to match how it's done in OpenTK.
* Added Scene.ResetBatches, so that we don't need to Reset every new added batch in AnimationBatch.
* Added more Common.Color constants.

![image](https://github.com/rickomax/psxprev/assets/9752430/849d6be9-eda0-41b1-abed-6257b14569bb)
