### PR TITLE
glTF2 exporter HMD animation WIP support

### DIFF
--- a/Common/Coordinate.cs
+++ b/Common/Coordinate.cs
@@ -71,6 +71,23 @@ namespace PSXPrev.Common
             RotationOrder = OriginalRotationOrder;
         }
 
+        public Coordinate(Coordinate fromCoordinate, Coordinate[] coords)
+        {
+            _originalLocalMatrix = fromCoordinate._originalLocalMatrix;
+            _originalTranslation = fromCoordinate._originalTranslation;
+            _originalRotation = fromCoordinate._originalRotation;
+
+            LocalMatrix = fromCoordinate.LocalMatrix;
+            Translation = fromCoordinate.Translation;
+            Rotation = fromCoordinate.Rotation;
+            RotationOrder = fromCoordinate.RotationOrder;
+
+            ID = fromCoordinate.ID;
+            ParentID = fromCoordinate.ParentID;
+
+            Coords = coords;
+        }
+
         public void ResetTransform()
         {
             LocalMatrix = OriginalLocalMatrix;
@@ -116,6 +133,17 @@ namespace PSXPrev.Common
                 }
             }
             return false; // Safe. No circular references found.
+        }
+
+
+        public static Coordinate[] CloneCoordiantes(Coordinate[] coords)
+        {
+            var newCoords = new Coordinate[coords.Length];
+            for (var i = 0; i < coords.Length; i++)
+            {
+                newCoords[i] = new Coordinate(coords[i], newCoords);
+            }
+            return newCoords;
         }
     }
 }

--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -35,7 +35,7 @@ namespace PSXPrev.Common
             set
             {
                 _translation = value.ExtractTranslation();
-                _rotation = value.ExtractRotation();
+                _rotation = value.ExtractRotationSafe();
                 _scale = value.ExtractScale();
                 _localMatrix = value;
             }

--- a/Common/Exporters/OBJExporter.cs
+++ b/Common/Exporters/OBJExporter.cs
@@ -74,7 +74,8 @@ namespace PSXPrev.Common.Exporters
             // Write vertices and export materials
             foreach (var entity in entities)
             {
-                foreach (var model in _modelPreparer.GetModels(entity))
+                _modelPreparer.GetPreparedRootEntity(entity, out var models);
+                foreach (var model in models)
                 {
                     WriteModel(model);
                 }
@@ -84,7 +85,7 @@ namespace PSXPrev.Common.Exporters
             var baseIndex = 1; // Obj format is 1-indexed I guess...
             foreach (var entity in entities)
             {
-                var models = _modelPreparer.GetModels(entity);
+                _modelPreparer.GetPreparedRootEntity(entity, out var models);
                 // todo: Should we really be restarting j (groupIndex) from 0 for each root entity?
                 for (var j = 0; j < models.Count; j++)
                 {
@@ -102,7 +103,7 @@ namespace PSXPrev.Common.Exporters
         private void WriteModel(ModelEntity model)
         {
             // Export material if we haven't already
-            if (_options.ExportTextures && model.Texture != null && model.IsTextured)
+            if (NeedsTexture(model))
             {
                 if (_mtlExporter.AddMaterial(model.Texture, out var materialId))
                 {
@@ -172,6 +173,11 @@ namespace PSXPrev.Common.Exporters
                 // v/vt/vn
                 _writer.WriteLine("f {2}/{2}/{2} {1}/{1}/{1} {0}/{0}/{0}", baseIndex++, baseIndex++, baseIndex++);
             }
+        }
+
+        private bool NeedsTexture(ModelEntity model)
+        {
+            return _options.ExportTextures && model.HasTexture;
         }
 
         private static string F(float value)

--- a/Common/Exporters/PLYExporter.cs
+++ b/Common/Exporters/PLYExporter.cs
@@ -77,12 +77,13 @@ namespace PSXPrev.Common.Exporters
             Texture singleTexture = null;
             foreach (var entity in entities)
             {
-                foreach (var model in _modelPreparer.GetModels(entity))
+                _modelPreparer.GetPreparedRootEntity(entity, out var models);
+                foreach (var model in models)
                 {
                     faceCount += model.Triangles.Length;
 
                     // Export material if we haven't already
-                    if (_options.ExportTextures && model.Texture != null && model.IsTextured)
+                    if (NeedsTexture(model))
                     {
                         singleTexture = model.Texture;
 
@@ -159,10 +160,11 @@ namespace PSXPrev.Common.Exporters
             // Write vertices
             foreach (var entity in entities)
             {
-                foreach (var model in _modelPreparer.GetModels(entity))
+                _modelPreparer.GetPreparedRootEntity(entity, out var models);
+                foreach (var model in models)
                 {
                     var materialIndex = 0; // Untextured
-                    if (_options.ExportTextures && model.Texture != null && model.IsTextured)
+                    if (NeedsTexture(model))
                     {
                         materialIndex = _materialsDictionary[model.Texture];
                     }
@@ -217,6 +219,11 @@ namespace PSXPrev.Common.Exporters
         private void WriteMaterial()
         {
             _writer.WriteLine("128 128 128 1.00000 128 128 128 1.00000");
+        }
+
+        private bool NeedsTexture(ModelEntity model)
+        {
+            return _options.ExportTextures && model.HasTexture;
         }
 
         private static string F(float value)

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text;
 using OpenTK;
 
@@ -101,6 +102,13 @@ namespace PSXPrev.Common
                 case RotationOrder.ZYX: return xRot * yRot * zRot;
             }
             return Matrix4.Identity; // Invalid rotation order
+        }
+
+        // Avoid getting NaN quaternions when any matrix scale dimension is 0.
+        public static Quaternion ExtractRotationSafe(this Matrix4 matrix)
+        {
+            var rotation = matrix.ExtractRotation();
+            return float.IsNaN(rotation.X) ? Quaternion.Identity : rotation;
         }
 
         public static Vector3 UnProject(this Vector3 position, Matrix4 projection, Matrix4 view, float width, float height)
@@ -324,6 +332,56 @@ namespace PSXPrev.Common
         public static decimal Clamp(decimal n, decimal min, decimal max)
         {
             return Math.Max(Math.Min(n, max), min);
+        }
+
+        public static int RoundUpToPower(int n, int power)
+        {
+            Debug.Assert(power >= 2, "RoundUpToPower must have power greater than or equal to 2");
+            if (n == 0)
+            {
+                return 0;
+            }
+            var value = 1;
+            var nAbs = Math.Abs(n);
+            while (value < nAbs) value *= power;
+            return value * Math.Sign(n);
+        }
+
+        public static uint RoundUpToPower(uint n, uint power)
+        {
+            Debug.Assert(power >= 2, "RoundUpToPower must have power greater than or equal to 2");
+            if (n == 0)
+            {
+                return 0;
+            }
+            uint value = 1;
+            while (value < n) value *= power;
+            return value;
+        }
+
+        public static long RoundUpToPower(long n, long power)
+        {
+            Debug.Assert(power >= 2, "RoundUpToPower must have power greater than or equal to 2");
+            if (n == 0)
+            {
+                return 0;
+            }
+            long value = 1;
+            var nAbs = Math.Abs(n);
+            while (value < nAbs) value *= power;
+            return value * Math.Sign(n);
+        }
+
+        public static ulong RoundUpToPower(ulong n, ulong power)
+        {
+            Debug.Assert(power >= 2, "RoundUpToPower must have power greater than or equal to 2");
+            if (n == 0)
+            {
+                return 0;
+            }
+            ulong value = 1;
+            while (value < n) value *= power;
+            return value;
         }
 
         public static float ConvertFixed12(int value) => value / Fixed12Scalar;

--- a/Common/ModelEntity.cs
+++ b/Common/ModelEntity.cs
@@ -93,6 +93,11 @@ namespace PSXPrev.Common
         [Browsable(false)]
         public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
 
+        // Not to be confused with IsTextured, this signifies a model is textured, and has a texture assigned.
+        // IsTextured is still useful to help assigning Textures in PreviewForm.
+        [Browsable(false)]
+        public bool HasTexture => Texture != null && IsTextured;
+
         //[ReadOnly(true)]
         //public uint PrimitiveIndex { get; set; }
 

--- a/Common/Renderer/MeshBatch.cs
+++ b/Common/Renderer/MeshBatch.cs
@@ -343,7 +343,7 @@ namespace PSXPrev.Common.Renderer
                 mesh.SetData(MeshDataType.Triangle, numElements, positionList, normalList, colorList, uvList, tiledAreaList);
             }
 
-            if (TextureBinder != null && modelEntity.Texture != null && modelEntity.IsTextured)
+            if (TextureBinder != null && modelEntity.HasTexture)
             {
                 mesh.Texture = TextureBinder.GetTexture((int)modelEntity.TexturePage);
             }

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -226,18 +226,30 @@ namespace PSXPrev.Common.Renderer
             }
         }
 
-        public static Bitmap ConvertTiledTexture(Texture texture, Rectangle srcRect, int repeatX, int repeatY, bool semiTransparency)
+        public static Bitmap ConvertTiledTexture(Texture texture, Rectangle srcRect, int repeatX, int repeatY, int? fullWidth, int? fullHeight, bool semiTransparency)
         {
             var stpX = semiTransparency ? PageSemiTransparencyX : 0;
             srcRect.X += stpX;
 
-            var bitmap = new Bitmap(repeatX * srcRect.Width, repeatY * srcRect.Height);
+            if (!fullWidth.HasValue)
+            {
+                fullWidth  = repeatX * srcRect.Width;
+            }
+            if (!fullHeight.HasValue)
+            {
+                fullHeight = repeatY * srcRect.Height;
+            }
+
+            var bitmap = new Bitmap(fullWidth.Value, fullHeight.Value);
             try
             {
                 using (var graphics = Graphics.FromImage(bitmap))
                 {
                     graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
                     graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+
+                    // Full size might be larger than tiled size.
+                    graphics.Clear(DefaultBackgroundColor);
 
                     for (var ry = 0; ry < repeatY; ry++)
                     {

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -40,6 +40,17 @@ namespace PSXPrev.Common
         public WeakReferenceCollection<Animation> OwnedAnimations { get; } = new WeakReferenceCollection<Animation>();
 
 
+        public RootEntity()
+        {
+        }
+
+        public RootEntity(RootEntity fromRootEntity)
+            : base(fromRootEntity)
+        {
+            Coords = fromRootEntity.Coords;
+        }
+
+
         public override void ComputeBounds()
         {
             base.ComputeBounds();
@@ -54,9 +65,8 @@ namespace PSXPrev.Common
         public List<ModelEntity> GetModelsWithTMDID(uint id)
         {
             _groupedModels.Clear();
-            foreach (var entityBase in ChildEntities)
+            foreach (ModelEntity model in ChildEntities)
             {
-                var model = (ModelEntity) entityBase;
                 if (model.TMDID == id)
                 {
                     _groupedModels.Add(model);

--- a/Forms/ExportModelsForm.Designer.cs
+++ b/Forms/ExportModelsForm.Designer.cs
@@ -52,11 +52,11 @@
             this.exportButton = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.animationsGroupBox = new System.Windows.Forms.GroupBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.checkedAnimationsListBox = new System.Windows.Forms.ListBox();
             this.animationsOnRadioButton = new System.Windows.Forms.RadioButton();
             this.animationsOffRadioButton = new System.Windows.Forms.RadioButton();
-            this.label2 = new System.Windows.Forms.Label();
             this.filePathGroupBox.SuspendLayout();
             this.formatGroupBox.SuspendLayout();
             this.texturesGroupBox.SuspendLayout();
@@ -104,7 +104,7 @@
             this.filePathTextBox.Name = "filePathTextBox";
             this.filePathTextBox.Size = new System.Drawing.Size(370, 20);
             this.filePathTextBox.TabIndex = 0;
-            this.filePathTextBox.TextChanged += new System.EventHandler(this.fileNameTextBox_TextChanged);
+            this.filePathTextBox.TextChanged += new System.EventHandler(this.filePathTextBox_TextChanged);
             // 
             // formatGroupBox
             // 
@@ -322,6 +322,15 @@
             this.animationsGroupBox.TabStop = false;
             this.animationsGroupBox.Text = "Animations";
             // 
+            // label2
+            // 
+            this.label2.Location = new System.Drawing.Point(12, 149);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(366, 30);
+            this.label2.TabIndex = 9;
+            this.label2.Text = "Before exporting Animations, please make sure the animations you have checked are" +
+    " playable";
+            // 
             // label1
             // 
             this.label1.AutoSize = true;
@@ -336,13 +345,13 @@
             this.checkedAnimationsListBox.FormattingEnabled = true;
             this.checkedAnimationsListBox.Location = new System.Drawing.Point(12, 74);
             this.checkedAnimationsListBox.Name = "checkedAnimationsListBox";
+            this.checkedAnimationsListBox.SelectionMode = System.Windows.Forms.SelectionMode.None;
             this.checkedAnimationsListBox.Size = new System.Drawing.Size(370, 69);
             this.checkedAnimationsListBox.TabIndex = 7;
             // 
             // animationsOnRadioButton
             // 
             this.animationsOnRadioButton.AutoSize = true;
-            this.animationsOnRadioButton.Enabled = false;
             this.animationsOnRadioButton.Location = new System.Drawing.Point(101, 19);
             this.animationsOnRadioButton.Name = "animationsOnRadioButton";
             this.animationsOnRadioButton.Size = new System.Drawing.Size(101, 17);
@@ -354,7 +363,6 @@
             // 
             this.animationsOffRadioButton.AutoSize = true;
             this.animationsOffRadioButton.Checked = true;
-            this.animationsOffRadioButton.Enabled = false;
             this.animationsOffRadioButton.Location = new System.Drawing.Point(12, 19);
             this.animationsOffRadioButton.Name = "animationsOffRadioButton";
             this.animationsOffRadioButton.Size = new System.Drawing.Size(83, 17);
@@ -362,15 +370,7 @@
             this.animationsOffRadioButton.TabStop = true;
             this.animationsOffRadioButton.Text = "Don\'t Export";
             this.animationsOffRadioButton.UseVisualStyleBackColor = true;
-            // 
-            // label2
-            // 
-            this.label2.Location = new System.Drawing.Point(12, 149);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(366, 30);
-            this.label2.TabIndex = 9;
-            this.label2.Text = "Before exporting Animations, please make sure the animations you have checked are" +
-    " playable";
+            this.animationsOffRadioButton.CheckedChanged += new System.EventHandler(this.animationsRadioButtons_CheckedChanged);
             // 
             // ExportModelsForm
             // 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -181,6 +181,12 @@ namespace PSXPrev.Forms
             animationsTreeView.Nodes.Add(animationNode);
             AddAnimationObject(animation.RootAnimationObject, animationNode);
             animationsTreeView.EndUpdate();
+
+            // Debugging: Quickly export HMD animation on startup.
+            //if (_animations.Count == 1)
+            //{
+            //    ExportModelsForm.Show(this, new[] { _rootEntities[0] }, new[] { _animations[0] }, _scene.AnimationBatch);
+            //}
         }
 
         public void UpdateRootEntities(List<RootEntity> entities)

--- a/Forms/ScannerForm.Designer.cs
+++ b/Forms/ScannerForm.Designer.cs
@@ -116,7 +116,7 @@
             this.filePathTextBox.Name = "filePathTextBox";
             this.filePathTextBox.Size = new System.Drawing.Size(360, 20);
             this.filePathTextBox.TabIndex = 0;
-            this.filePathTextBox.TextChanged += new System.EventHandler(this.fileNameTextBox_TextChanged);
+            this.filePathTextBox.TextChanged += new System.EventHandler(this.filePathTextBox_TextChanged);
             // 
             // groupBox2
             // 

--- a/Forms/ScannerForm.cs
+++ b/Forms/ScannerForm.cs
@@ -94,7 +94,7 @@ namespace PSXPrev.Forms
             Close();
         }
 
-        private void fileNameTextBox_TextChanged(object sender, EventArgs e)
+        private void filePathTextBox_TextChanged(object sender, EventArgs e)
         {
             scanButton.Enabled = File.Exists(filePathTextBox.Text) || Directory.Exists(filePathTextBox.Text);
         }


### PR DESCRIPTION
* Added ModelEntity.HasTexture, which is true if Texture != null and IsTextured is true. I think this is worth having just because of how many places both comparisons are made in.
* Added GeomMath.ExtractRotationSafe extension method, which returns Quaternion.Identity in the scenario that one of the matrix scale components is 0 (which normally results in a NaN Quaternion).
* AnimationBatch functions now have a simulate parameter, which skips updating the models MeshBatch if true.
* Replaced ModelPreparerExporter.GetModels with GetPreparedRootEntity(..., out models). It's an ugly setup right now, but cloned root entities are needed for animations. And having a method to GetRootEntity and GetModels would be confusing with whether you need to pass the original or prepared root entity to GetModels.
* ModelPreparerExporter.AttachLimbs no longer affects the original model.
* ModelPreparerExporter now exports tiled textures with dimensions that are powers of two.
* Added GeomMath.RoundUpToPower to help get rounded up powers of two.
* Added NeedsTexture(model) shorthands to all model exporters. This returns true if ExportTextures option is true, and if model.HasTexture is true.
* glTF2 no longer exports TEXCOORD_0 when model is untextered.
* glTF2 now exports initial model rotation.
* glTF2 now exports initial model WorldMatrix transforms, instead of LocalMatrix transforms.
* Changed glTF2 file prefix from obj to gltf.
* glTF2 now only computes animation frames once per frame (instead of 3 x models.Count per frame), and now stores the resulting transform components for each model at each frame.
* glTF2 bounds calculation now goes off local vertex positions, and also swaps min/max and negates for Y/Z.
* glTF2 now restores animation loop mode when done with the animation batch.