### PR TITLE
Allow performing multiple scans

### DIFF
--- a/Common/Exporters/OBJExporter.cs
+++ b/Common/Exporters/OBJExporter.cs
@@ -17,7 +17,7 @@ namespace PSXPrev.Common.Exporters
         private string _baseTextureName;
         private ExportModelOptions _options;
 
-        public void Export(RootEntity[] entities, string selectedPath, ExportModelOptions options = null)
+        public void Export(RootEntity[] entities, ExportModelOptions options = null)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -26,7 +26,7 @@ namespace PSXPrev.Common.Exporters
             _pngExporter = new PNGExporter();
             _mtlDictionary = new MTLExporter.MaterialDictionary();
             _modelPreparer = new ModelPreparerExporter(_options);
-            _selectedPath = selectedPath;
+            _selectedPath = _options.Path;
 
             // Prepare the shared state for all models being exported (mainly setting up tiled textures).
             _modelPreparer.PrepareAll(entities);

--- a/Common/Exporters/PLYExporter.cs
+++ b/Common/Exporters/PLYExporter.cs
@@ -18,7 +18,7 @@ namespace PSXPrev.Common.Exporters
         private string _baseTextureName;
         private ExportModelOptions _options;
 
-        public void Export(RootEntity[] entities, string selectedPath, ExportModelOptions options = null)
+        public void Export(RootEntity[] entities, ExportModelOptions options = null)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -30,7 +30,7 @@ namespace PSXPrev.Common.Exporters
             _materialsDictionary = new Dictionary<Texture, int>();
             _untexturedMaterialExported = false;
             _modelPreparer = new ModelPreparerExporter(_options);
-            _selectedPath = selectedPath;
+            _selectedPath = _options.Path;
 
             // Prepare the shared state for all models being exported (mainly setting up tiled textures).
             _modelPreparer.PrepareAll(entities);

--- a/Common/Exporters/glTF2Exporter.cs
+++ b/Common/Exporters/glTF2Exporter.cs
@@ -29,7 +29,7 @@ namespace PSXPrev.Common.Exporters
 
         private const string AssetTemplate = " \"asset\" : {\r\n  \"generator\" : \"PSXPREV\",\r\n  \"version\" : \"2.0\"\r\n },";
 
-        public void Export(RootEntity[] entities, Animation[] animations, AnimationBatch animationBatch, string selectedPath, ExportModelOptions options = null)
+        public void Export(RootEntity[] entities, Animation[] animations, AnimationBatch animationBatch, ExportModelOptions options = null)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -38,7 +38,7 @@ namespace PSXPrev.Common.Exporters
 
             _pngExporter = new PNGExporter();
             _modelPreparer = new ModelPreparerExporter(_options);
-            _selectedPath = selectedPath;
+            _selectedPath = _options.Path;
 
             // Prepare the shared state for all models being exported (mainly setting up tiled textures).
             _modelPreparer.PrepareAll(entities);

--- a/Common/Parsers/TMDHelper.cs
+++ b/Common/Parsers/TMDHelper.cs
@@ -473,15 +473,15 @@ namespace PSXPrev.Common.Parsers
                         if (Program.FixUVAlignment)
                         {
                             tuvm = GeomMath.ConvertUV(((((tumValue << 3) ^ 0xff) + 1) & 0xff),
-                                                       ((((tvmValue << 3) ^ 0xff) + 1) & 0xff));
+                                                      ((((tvmValue << 3) ^ 0xff) + 1) & 0xff));
                         }
                         else
                         {
                             tuvm = GeomMath.ConvertUV(((tumValue << 3) ^ 0xff),
-                                                       ((tvmValue << 3) ^ 0xff));
+                                                      ((tvmValue << 3) ^ 0xff));
                         }
                         tuva = GeomMath.ConvertUV((tuaValue << 3),
-                                                   (tvaValue << 3));
+                                                  (tvaValue << 3));
                     }
                 }
 

--- a/Forms/Controls/RootEntitySelectorEditor.cs
+++ b/Forms/Controls/RootEntitySelectorEditor.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing.Design;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
+using PSXPrev.Common;
 using PSXPrev.Forms.Dialogs;
 
 namespace PSXPrev.Forms.Controls
@@ -16,14 +17,11 @@ namespace PSXPrev.Forms.Controls
 
         public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
         {
-            if (Program.IsScanning)
-            {
-                MessageBox.Show("Please wait until the scan finishes.");
-                return null;
-            }
             var svc = provider.GetService(typeof(IWindowsFormsEditorService)) as IWindowsFormsEditorService;
             using (var form = new SelectRootEntityDialog())
             {
+                form.RootEntities = Program.GetEntityResults();
+                form.SelectedRootEntity = value as RootEntity;
                 var result = svc != null ? svc.ShowDialog(form) : form.ShowDialog();
                 if (result == DialogResult.OK)
                 {

--- a/Forms/Dialogs/SelectRootEntityDialog.Designer.cs
+++ b/Forms/Dialogs/SelectRootEntityDialog.Designer.cs
@@ -30,13 +30,15 @@
         {
             this.okButton = new System.Windows.Forms.Button();
             this.mainLabel = new System.Windows.Forms.Label();
-            this.TMDListBox = new System.Windows.Forms.ComboBox();
+            this.entitiesListBox = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // okButton
             // 
+            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Location = new System.Drawing.Point(107, 58);
+            this.okButton.Location = new System.Drawing.Point(107, 67);
             this.okButton.Name = "okButton";
             this.okButton.Size = new System.Drawing.Size(91, 24);
             this.okButton.TabIndex = 3;
@@ -49,24 +51,24 @@
             this.mainLabel.Name = "mainLabel";
             this.mainLabel.Size = new System.Drawing.Size(283, 20);
             this.mainLabel.TabIndex = 5;
-            this.mainLabel.Text = "Select a TMD Model";
+            this.mainLabel.Text = "Select a Model";
             this.mainLabel.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
-            // TMDListBox
+            // entitiesListBox
             // 
-            this.TMDListBox.FormattingEnabled = true;
-            this.TMDListBox.Location = new System.Drawing.Point(12, 35);
-            this.TMDListBox.Name = "TMDListBox";
-            this.TMDListBox.Size = new System.Drawing.Size(280, 21);
-            this.TMDListBox.TabIndex = 6;
+            this.entitiesListBox.FormattingEnabled = true;
+            this.entitiesListBox.Location = new System.Drawing.Point(12, 35);
+            this.entitiesListBox.Name = "entitiesListBox";
+            this.entitiesListBox.Size = new System.Drawing.Size(280, 21);
+            this.entitiesListBox.TabIndex = 6;
             // 
             // SelectRootEntityDialog
             // 
             this.AcceptButton = this.okButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(304, 90);
-            this.Controls.Add(this.TMDListBox);
+            this.ClientSize = new System.Drawing.Size(304, 99);
+            this.Controls.Add(this.entitiesListBox);
             this.Controls.Add(this.mainLabel);
             this.Controls.Add(this.okButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
@@ -75,8 +77,7 @@
             this.Name = "SelectRootEntityDialog";
             this.ShowIcon = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "PSXPrev";
-            this.Load += new System.EventHandler(this.SelectTMDForm_Load);
+            this.Text = "PSXPrev Model Selector";
             this.ResumeLayout(false);
 
         }
@@ -85,6 +86,6 @@
 
         private System.Windows.Forms.Button okButton;
         private System.Windows.Forms.Label mainLabel;
-        private System.Windows.Forms.ComboBox TMDListBox;
+        private System.Windows.Forms.ComboBox entitiesListBox;
     }
 }

--- a/Forms/Dialogs/SelectRootEntityDialog.cs
+++ b/Forms/Dialogs/SelectRootEntityDialog.cs
@@ -6,20 +6,43 @@ namespace PSXPrev.Forms.Dialogs
 {
     public partial class SelectRootEntityDialog : Form
     {
-        public RootEntity SelectedRootEntity => TMDListBox.SelectedItem as RootEntity;
+        private RootEntity[] _rootEntities;
+        public RootEntity[] RootEntities
+        {
+            get => _rootEntities;
+            set
+            {
+                _rootEntities = value;
+                entitiesListBox.Items.Clear();
+                foreach (var entity in _rootEntities)
+                {
+                    entitiesListBox.Items.Add(entity.EntityName ?? nameof(RootEntity));
+                }
+            }
+        }
+
+        public RootEntity SelectedRootEntity
+        {
+            get
+            {
+                if (entitiesListBox.SelectedIndex > -1)
+                {
+                    return _rootEntities[entitiesListBox.SelectedIndex];
+                }
+                return null;
+            }
+            set
+            {
+                if (_rootEntities != null)
+                {
+                    entitiesListBox.SelectedIndex = Array.IndexOf(_rootEntities, value);
+                }
+            }
+        }
 
         public SelectRootEntityDialog()
         {
             InitializeComponent();
-        }
-
-        private void SelectTMDForm_Load(object sender, EventArgs e)
-        {
-            TMDListBox.Items.Clear();
-            foreach (var entity in Program.AllEntities)
-            {
-                TMDListBox.Items.Add(entity);
-            }
         }
     }
 }

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -65,15 +65,6 @@ namespace PSXPrev.Forms
 
             // Use the last export options
             ReadSettings(Settings.Instance.ExportModelOptions);
-
-            // Debugging: Instantly export with specified settings.
-            //{
-            //    filePathTextBox.Text = @"";
-            //    formatGLTF2RadioButton.Checked = true;
-            //    animationsOnRadioButton.Checked = true;
-            //    optionRedrawTexturesCheckBox.Checked = true;
-            //    DialogResult = DialogResult.OK;
-            //}
         }
 
         private void selectFolderButton_Click(object sender, EventArgs e)
@@ -153,12 +144,10 @@ namespace PSXPrev.Forms
                 return;
             }
 
-            var selectedPath = filePathTextBox.Text;
-
             var options = new ExportModelOptions
             {
                 // These settings are only present for loading and saving purposes.
-                Path = selectedPath,
+                Path = filePathTextBox.Text,
                 Format = _format,
 
                 ExportTextures = !texturesOffRadioButton.Checked,
@@ -176,21 +165,7 @@ namespace PSXPrev.Forms
 
             WriteSettings(options);
 
-            switch (_format)
-            {
-                case ExportModelOptions.OBJ:
-                    var objExporter = new OBJExporter();
-                    objExporter.Export(Entities, selectedPath, options);
-                    break;
-                case ExportModelOptions.PLY:
-                    var plyExporter = new PLYExporter();
-                    plyExporter.Export(Entities, selectedPath, options);
-                    break;
-                case ExportModelOptions.GLTF2:
-                    var glTF2Exporter = new glTF2Exporter();
-                    glTF2Exporter.Export(Entities, Animations, AnimationBatch, selectedPath, options);
-                    break;
-            }
+            Export(options, Entities, Animations, AnimationBatch);
         }
 
         private void ReadSettings(ExportModelOptions options)
@@ -232,11 +207,11 @@ namespace PSXPrev.Forms
             {
                 texturesSingleRadioButton.Checked = true;
             }
+            // Force checked changed event in-case this is already the checked radio button.
             foreach (var control in texturesGroupBox.Controls)
             {
                 if (control is RadioButton radioButton && radioButton.Checked)
                 {
-                    // Force checked changed event in-case this is already the checked radio button.
                     texturesRadioButtons_CheckedChanged(radioButton, EventArgs.Empty);
                     break;
                 }
@@ -260,11 +235,11 @@ namespace PSXPrev.Forms
             {
                 animationsOnRadioButton.Checked = true;
             }
+            // Force checked changed event in-case this is already the checked radio button.
             foreach (var control in animationsGroupBox.Controls)
             {
                 if (control is RadioButton radioButton && radioButton.Checked)
                 {
-                    // Force checked changed event in-case this is already the checked radio button.
                     animationsRadioButtons_CheckedChanged(radioButton, EventArgs.Empty);
                     break;
                 }
@@ -276,6 +251,25 @@ namespace PSXPrev.Forms
             Settings.Instance.ExportModelOptions = options.Clone();
         }
 
+
+        public static void Export(ExportModelOptions options, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
+        {
+            switch (options.Format)
+            {
+                case ExportModelOptions.OBJ:
+                    var objExporter = new OBJExporter();
+                    objExporter.Export(entities, options);
+                    break;
+                case ExportModelOptions.PLY:
+                    var plyExporter = new PLYExporter();
+                    plyExporter.Export(entities, options);
+                    break;
+                case ExportModelOptions.GLTF2:
+                    var glTF2Exporter = new glTF2Exporter();
+                    glTF2Exporter.Export(entities, animations, animationBatch, options);
+                    break;
+            }
+        }
 
         public static bool Show(IWin32Window owner, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
         {

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -90,10 +90,15 @@ namespace PSXPrev.Forms
             this.exportAllModelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mainMenuStrip = new System.Windows.Forms.MenuStrip();
             this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.startScanToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.clearScanResultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
             this.pauseScanningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.stopScanningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
             this.defaultSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.loadSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.modelsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -168,8 +173,6 @@ namespace PSXPrev.Forms
             this.label7 = new System.Windows.Forms.Label();
             this.cameraFOVUpDown = new System.Windows.Forms.NumericUpDown();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.loadSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.entitiesTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.modelsSplitContainer)).BeginInit();
             this.modelsSplitContainer.Panel1.SuspendLayout();
@@ -1038,6 +1041,9 @@ namespace PSXPrev.Forms
             // fileToolStripMenuItem
             // 
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.startScanToolStripMenuItem,
+            this.clearScanResultsToolStripMenuItem,
+            this.toolStripSeparator11,
             this.pauseScanningToolStripMenuItem,
             this.stopScanningToolStripMenuItem,
             this.toolStripSeparator10,
@@ -1049,6 +1055,25 @@ namespace PSXPrev.Forms
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "File";
+            // 
+            // startScanToolStripMenuItem
+            // 
+            this.startScanToolStripMenuItem.Name = "startScanToolStripMenuItem";
+            this.startScanToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.startScanToolStripMenuItem.Text = "Start Scan";
+            this.startScanToolStripMenuItem.Click += new System.EventHandler(this.startScanToolStripMenuItem_Click);
+            // 
+            // clearResultsToolStripMenuItem
+            // 
+            this.clearScanResultsToolStripMenuItem.Name = "clearResultsToolStripMenuItem";
+            this.clearScanResultsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.clearScanResultsToolStripMenuItem.Text = "Clear Scan Results";
+            this.clearScanResultsToolStripMenuItem.Click += new System.EventHandler(this.clearScanResultsToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator11
+            // 
+            this.toolStripSeparator11.Name = "toolStripSeparator11";
+            this.toolStripSeparator11.Size = new System.Drawing.Size(204, 6);
             // 
             // pauseScanningToolStripMenuItem
             // 
@@ -1076,6 +1101,20 @@ namespace PSXPrev.Forms
             this.defaultSettingsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
             this.defaultSettingsToolStripMenuItem.Text = "Reset Settings to Defaults";
             this.defaultSettingsToolStripMenuItem.Click += new System.EventHandler(this.defaultSettingsToolStripMenuItem_Click);
+            // 
+            // loadSettingsToolStripMenuItem
+            // 
+            this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.loadSettingsToolStripMenuItem.Text = "Reload Settings";
+            this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
+            // 
+            // saveSettingsToolStripMenuItem
+            // 
+            this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
+            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.saveSettingsToolStripMenuItem.Text = "Save Current Settings";
+            this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
@@ -1259,7 +1298,7 @@ namespace PSXPrev.Forms
             this.exportSelectedTexturesToolStripMenuItem,
             this.exportAllTexturesToolStripMenuItem});
             this.exportTexturesToolStripMenuItem.Name = "exportTexturesToolStripMenuItem";
-            this.exportTexturesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportTexturesToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.exportTexturesToolStripMenuItem.Text = "Export Textures";
             // 
             // exportSelectedTexturesToolStripMenuItem
@@ -1279,59 +1318,59 @@ namespace PSXPrev.Forms
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(173, 6);
             // 
             // drawToVRAMToolStripMenuItem
             // 
             this.drawToVRAMToolStripMenuItem.Name = "drawToVRAMToolStripMenuItem";
-            this.drawToVRAMToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.drawToVRAMToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.drawToVRAMToolStripMenuItem.Text = "Draw to VRAM";
             this.drawToVRAMToolStripMenuItem.Click += new System.EventHandler(this.drawSelectedToVRAM_Click);
             // 
             // drawAllToVRAMToolStripMenuItem
             // 
             this.drawAllToVRAMToolStripMenuItem.Name = "drawAllToVRAMToolStripMenuItem";
-            this.drawAllToVRAMToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.drawAllToVRAMToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.drawAllToVRAMToolStripMenuItem.Text = "Draw All to VRAM";
             this.drawAllToVRAMToolStripMenuItem.Click += new System.EventHandler(this.drawAllToVRAM_Click);
             // 
             // findByPageToolStripMenuItem
             // 
             this.findByPageToolStripMenuItem.Name = "findByPageToolStripMenuItem";
-            this.findByPageToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.findByPageToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.findByPageToolStripMenuItem.Text = "Find by Page";
             this.findByPageToolStripMenuItem.Click += new System.EventHandler(this.findByPageToolStripMenuItem_Click);
             // 
             // clearSearchToolStripMenuItem
             // 
             this.clearSearchToolStripMenuItem.Name = "clearSearchToolStripMenuItem";
-            this.clearSearchToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.clearSearchToolStripMenuItem.Text = "Clear Results";
+            this.clearSearchToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
+            this.clearSearchToolStripMenuItem.Text = "Clear Find Results";
             this.clearSearchToolStripMenuItem.Click += new System.EventHandler(this.clearSearchToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(173, 6);
             // 
             // autoDrawModelTexturesToolStripMenuItem
             // 
             this.autoDrawModelTexturesToolStripMenuItem.CheckOnClick = true;
             this.autoDrawModelTexturesToolStripMenuItem.Name = "autoDrawModelTexturesToolStripMenuItem";
-            this.autoDrawModelTexturesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.autoDrawModelTexturesToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.autoDrawModelTexturesToolStripMenuItem.Text = "Auto Draw Textures";
             this.autoDrawModelTexturesToolStripMenuItem.CheckedChanged += new System.EventHandler(this.autoDrawModelTexturesToolStripMenuItem_CheckedChanged);
             // 
             // toolStripSeparator6
             // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
-            this.toolStripSeparator6.Size = new System.Drawing.Size(177, 6);
+            this.toolStripSeparator6.Size = new System.Drawing.Size(173, 6);
             // 
             // setMaskColorToolStripMenuItem
             // 
             this.setMaskColorToolStripMenuItem.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.setMaskColorToolStripMenuItem.Name = "setMaskColorToolStripMenuItem";
-            this.setMaskColorToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.setMaskColorToolStripMenuItem.Size = new System.Drawing.Size(176, 22);
             this.setMaskColorToolStripMenuItem.Text = "Set Mask Color";
             this.setMaskColorToolStripMenuItem.Click += new System.EventHandler(this.setMaskColorToolStripMenuItem_Click);
             // 
@@ -1407,7 +1446,7 @@ namespace PSXPrev.Forms
             // 
             this.showUVToolStripMenuItem.CheckOnClick = true;
             this.showUVToolStripMenuItem.Name = "showUVToolStripMenuItem";
-            this.showUVToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.showUVToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.showUVToolStripMenuItem.Text = "Show UV";
             this.showUVToolStripMenuItem.Click += new System.EventHandler(this.showUVToolStripMenuItem_Click);
             // 
@@ -1739,20 +1778,6 @@ namespace PSXPrev.Forms
             0});
             this.cameraFOVUpDown.ValueChanged += new System.EventHandler(this.cameraFOVUpDown_ValueChanged);
             // 
-            // loadSettingsToolStripMenuItem
-            // 
-            this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
-            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
-            this.loadSettingsToolStripMenuItem.Text = "Reload Settings";
-            this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
-            // 
-            // saveSettingsToolStripMenuItem
-            // 
-            this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
-            this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
-            this.saveSettingsToolStripMenuItem.Text = "Save Current Settings";
-            this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
-            // 
             // PreviewForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1770,6 +1795,7 @@ namespace PSXPrev.Forms
             this.Text = "PSXPrev";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.previewForm_FormClosing);
             this.Load += new System.EventHandler(this.previewForm_Load);
+            this.Shown += new System.EventHandler(this.previewForm_Shown);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyDown);
             this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.previewForm_KeyUp);
             this.entitiesTabPage.ResumeLayout(false);
@@ -1996,5 +2022,8 @@ namespace PSXPrev.Forms
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
         private System.Windows.Forms.ToolStripMenuItem loadSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveSettingsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem startScanToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem clearScanResultsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
     }
 }

--- a/Forms/ScannerForm.Designer.cs
+++ b/Forms/ScannerForm.Designer.cs
@@ -382,6 +382,7 @@
             // scanButton
             // 
             this.scanButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.scanButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.scanButton.Enabled = false;
             this.scanButton.Location = new System.Drawing.Point(297, 326);
             this.scanButton.Name = "scanButton";
@@ -389,7 +390,6 @@
             this.scanButton.TabIndex = 4;
             this.scanButton.Text = "Scan";
             this.scanButton.UseVisualStyleBackColor = true;
-            this.scanButton.Click += new System.EventHandler(this.scanButton_Click);
             // 
             // toolTip
             // 
@@ -399,6 +399,7 @@
             // 
             // ScannerForm
             // 
+            this.AcceptButton = this.scanButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(384, 356);
@@ -411,8 +412,9 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.Name = "ScannerForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "PSXPrev Launcher";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "PSXPrev Scan Files";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ScannerForm_FormClosed);
             this.Load += new System.EventHandler(this.ScannerForm_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();

--- a/Forms/TMDBindingsForm.cs
+++ b/Forms/TMDBindingsForm.cs
@@ -62,6 +62,14 @@ namespace PSXPrev.Forms
             IsVisible = true;
         }
 
+        public static void CloseTool()
+        {
+            if (_instance != null)
+            {
+                _instance.Close();
+            }
+        }
+
         private void TMDBindingForm_FormClosed(object sender, FormClosedEventArgs e)
         {
             _instance = null;

--- a/ScanOptions.cs
+++ b/ScanOptions.cs
@@ -6,6 +6,7 @@ namespace PSXPrev
     public class ScanOptions
     {
         public const string DefaultFilter = "*.*";
+        public const string EmptyFilter = "*";
 
         // These settings are only present for loading and saving purposes.
         // File path:
@@ -64,12 +65,12 @@ namespace PSXPrev
         public bool LogToFile { get; set; } = false;
         [JsonProperty("logToConsole")]
         public bool LogToConsole { get; set; } = true;
+        [JsonProperty("consoleColor")]
+        public bool UseConsoleColor { get; set; } = true;
         [JsonProperty("debug")]
         public bool Debug { get; set; } = false;
         [JsonProperty("showErrors")]
         public bool ShowErrors { get; set; } = false;
-        [JsonProperty("consoleColor")]
-        public bool ConsoleColor { get; set; } = true;
 
         // Program options:
         [JsonProperty("drawAllToVRAM")]
@@ -77,6 +78,23 @@ namespace PSXPrev
         [JsonProperty("fixUVAlignment")]
         public bool FixUVAlignment { get; set; } = true;
 
+
+        public void Validate()
+        {
+            if (Path == null)
+            {
+                Path = string.Empty;
+            }
+
+            if (Filter == null)
+            {
+                Filter = DefaultFilter;
+            }
+            else if (string.IsNullOrWhiteSpace(Filter))
+            {
+                Filter = EmptyFilter; // When filter is empty, default to matching all files (with or without an extension).
+            }
+        }
 
         public ScanOptions Clone()
         {

--- a/Settings.cs
+++ b/Settings.cs
@@ -17,7 +17,8 @@ namespace PSXPrev
     {
         private static readonly Settings _defaults = new Settings();
 
-        private static string SettingsFilePath => Path.Combine(Application.StartupPath, "PSXPrev.settings.json");
+        // Returns "<path>\\<exename>.settings.json"
+        private static string SettingsFilePath => Path.ChangeExtension(Application.ExecutablePath, ".settings.json");
 
         public static Settings Instance { get; set; } = new Settings();
 
@@ -110,7 +111,7 @@ namespace PSXPrev
         public bool AutoPlayAnimation { get; set; } = false;
 
         [JsonProperty("autoSelectAnimationModel")]
-        public bool AutoSelectAnimationModel { get; set; } = false;
+        public bool AutoSelectAnimationModel { get; set; } = true;
 
         [JsonProperty("animationLoopMode"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
         public AnimationLoopMode AnimationLoopMode { get; set; } = AnimationLoopMode.Loop;
@@ -121,47 +122,63 @@ namespace PSXPrev
         [JsonProperty("animationSpeed")]
         public float AnimationSpeed { get; set; } = 1f;
 
-        [JsonProperty("exportOptions")]
-        public ExportModelOptions ExportModelOptions { get; set; } = new ExportModelOptions();
+        [JsonProperty("logStandardColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ConsoleColor LogStandardColor { get; set; } = ConsoleColor.White;
+
+        [JsonProperty("logPositiveColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ConsoleColor LogPositiveColor { get; set; } = ConsoleColor.Green;
+
+        [JsonProperty("logWarningColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ConsoleColor LogWarningColor { get; set; } = ConsoleColor.Yellow;
+
+        [JsonProperty("logErrorColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ConsoleColor LogErrorColor { get; set; } = ConsoleColor.Red;
+
+        [JsonProperty("logExceptionPrefixColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ConsoleColor LogExceptionPrefixColor { get; set; } = ConsoleColor.DarkGray;
 
         [JsonProperty("scanOptions")]
         public ScanOptions ScanOptions { get; set; } = new ScanOptions();
 
+        [JsonProperty("exportOptions")]
+        public ExportModelOptions ExportModelOptions { get; set; } = new ExportModelOptions();
+
 
         public void Validate()
         {
-            GridSnap        = ValidateMax(  GridSnap,        _defaults.GridSnap, 0f);
-            CameraFOV       = ValidateClamp(CameraFOV,       _defaults.CameraFOV, Scene.CameraMinFOV, Scene.CameraMaxFOV);
-            LightIntensity  = ValidateMax(  LightIntensity,  _defaults.LightIntensity, 0f);
-            LightYaw        = ValidateAngle(LightYaw,        _defaults.LightYaw);
-            LightPitch      = ValidateAngle(LightPitch,      _defaults.LightPitch);
-            WireframeSize   = ValidateMax(  WireframeSize,   _defaults.WireframeSize, 1f);
-            VertexSize      = ValidateMax(  VertexSize,      _defaults.VertexSize,    1f);
-            BackgroundColor = ValidateColor(BackgroundColor, _defaults.BackgroundColor);
-            AmbientColor    = ValidateColor(AmbientColor,    _defaults.AmbientColor);
-            MaskColor       = ValidateColor(MaskColor,       _defaults.MaskColor);
-            AnimationSpeed  = ValidateClamp(AnimationSpeed,  _defaults.AnimationSpeed, 0.01f, 100f);
+            GridSnap          = ValidateMax(  GridSnap,          _defaults.GridSnap, 0f);
+            CameraFOV         = ValidateClamp(CameraFOV,         _defaults.CameraFOV, Scene.CameraMinFOV, Scene.CameraMaxFOV);
+            LightIntensity    = ValidateMax(  LightIntensity,    _defaults.LightIntensity, 0f);
+            LightYaw          = ValidateAngle(LightYaw,          _defaults.LightYaw);
+            LightPitch        = ValidateAngle(LightPitch,        _defaults.LightPitch);
+            WireframeSize     = ValidateMax(  WireframeSize,     _defaults.WireframeSize, 1f);
+            VertexSize        = ValidateMax(  VertexSize,        _defaults.VertexSize,    1f);
+            BackgroundColor   = ValidateColor(BackgroundColor,   _defaults.BackgroundColor);
+            AmbientColor      = ValidateColor(AmbientColor,      _defaults.AmbientColor);
+            MaskColor         = ValidateColor(MaskColor,         _defaults.MaskColor);
+            AnimationLoopMode = ValidateEnum( AnimationLoopMode, _defaults.AnimationLoopMode);
+            AnimationSpeed    = ValidateClamp(AnimationSpeed,    _defaults.AnimationSpeed, 0.01f, 100f);
+            LogStandardColor        = ValidateEnum(LogStandardColor,        _defaults.LogStandardColor);
+            LogPositiveColor        = ValidateEnum(LogPositiveColor,        _defaults.LogPositiveColor);
+            LogWarningColor         = ValidateEnum(LogWarningColor,         _defaults.LogWarningColor);
+            LogErrorColor           = ValidateEnum(LogErrorColor,           _defaults.LogErrorColor);
+            LogExceptionPrefixColor = ValidateEnum(LogExceptionPrefixColor, _defaults.LogExceptionPrefixColor);
 
-            if (!Enum.IsDefined(typeof(AnimationLoopMode), AnimationLoopMode))
-            {
-                AnimationLoopMode = _defaults.AnimationLoopMode;
-            }
-
-            if (ExportModelOptions == null)
-            {
-                ExportModelOptions = new ExportModelOptions();
-            }
             if (ScanOptions == null)
             {
                 ScanOptions = new ScanOptions();
+            }
+            if (ExportModelOptions == null)
+            {
+                ExportModelOptions = new ExportModelOptions();
             }
         }
 
         public Settings Clone()
         {
             var settings = (Settings)MemberwiseClone();
-            settings.ExportModelOptions = settings.ExportModelOptions?.Clone();
             settings.ScanOptions = settings.ScanOptions?.Clone();
+            settings.ExportModelOptions = settings.ExportModelOptions?.Clone();
             return settings;
         }
 
@@ -183,17 +200,29 @@ namespace PSXPrev
             {
                 Instance = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsFilePath));
                 Instance.Validate();
+
+                // Create a settings file if one doesn't already exist.
+                if (!File.Exists(SettingsFilePath))
+                {
+                    Instance.Save();
+                }
             }
             catch
             {
-                Instance = new Settings(); // Load default settings on failure.
+                // Load default settings on failure.
+                LoadDefaults();
             }
-            Instance.Save();
         }
 
         public static void LoadDefaults()
         {
             Instance = new Settings();
+
+            // Create a settings file if one doesn't already exist.
+            if (!File.Exists(SettingsFilePath))
+            {
+                Instance.Save();
+            }
         }
 
 
@@ -220,6 +249,11 @@ namespace PSXPrev
         private static System.Drawing.Color ValidateColor(System.Drawing.Color value, System.Drawing.Color @default)
         {
             return value.A != 255 ? @default : value;
+        }
+
+        private static TEnum ValidateEnum<TEnum>(TEnum value, TEnum @default)
+        {
+            return !Enum.IsDefined(typeof(TEnum), value) ? @default : value;
         }
     }
 }


### PR DESCRIPTION
## Multiple scans changes
* Scanning can now be performed multiple times, and the results can optionally be cleared from the File menu.
* PreviewForm now runs on the main thread (Main now requires STAThread attribute).
* PreviewForm is the form that brings up the ScannerForm or tells Program to start scanning with command line arguments (Program will state if this is necessary with HasCommandLineArguments).
* Passing null arguments to Program.Initialise will no longer show the usage. HOWEVER, calling Initialise again is not expected behavior.
* Program.Logger is never reconstructed. Instead, the Logger's arguments can be changed at the start of ScanAsync. If LogToFile was false before, then it will open a new file to write to if needed.
* PreviewForm's refresh action assigned in program now only passes items that were recently scanned since the last refresh. With this, PreviewForm no longer checks if the items are already in the list, since that should be impossible unless PreviewForm adds items obtained from Program.GetResults.
* Program.All properties are no longer accessible, and instead GetResults should be used to return a new array of the results. This means it's possible to get these while a scan is still in progress. And as such, RootEntitySelectorEditor and SelectRootEntityDialog now allow doing so with a scan in progress.

## Other changes
* Renamed Program.DoScan to ScanAsync. Also Added ScanCommandLineAsync.
* Removed selectedPath argument from ModelExporters, and path/filter arguments from Program.ScanAsync. The options parameter should now specify the path and/or filters.
* Settings file now uses exe name instead of hardcoded "PSXPrev".
* Changed Settings.AutoSelectAnimationModel default to true.
* Added settings for Logger line colors (json only).
* Settings.Load and LoadDefaults now only save the settings file if one doesn't already exist.
* Added Settings.ValidateEnum helper.
* Fix TMDBindingsForm throwing error with null Animation. PreviewForm now makes _curAnimation is non-null before calling ShowTool.
* ScannerForm now uses the same pattern for executing as ExportModelsForm. The scan button has been given a dialog result, and the FormClosed event is now where the Scan action is executed.