### PR TITLE
DAE support, glTF2 DOM-based exporting, OBJ vertex index reuse

### DIFF
--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -138,7 +138,7 @@ namespace PSXPrev.Common
         }
 
         [ReadOnly(true), DisplayName("Sub-Models")]
-        public string ChildCount => ChildEntities == null ? "0" : ChildEntities.Length.ToString(CultureInfo.InvariantCulture);
+        public string ChildCount => ChildEntities == null ? "0" : ChildEntities.Length.ToString(NumberFormatInfo.InvariantInfo);
 
         [Browsable(false)]
         public EntityBase[] ChildEntities

--- a/Common/Exporters/DAEExporter.cs
+++ b/Common/Exporters/DAEExporter.cs
@@ -1,24 +1,134 @@
 ﻿using System;
-using System.Linq;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
 using Collada141;
+using OpenTK;
 
 namespace PSXPrev.Common.Exporters
 {
     public class DAEExporter
     {
-        public void Export(RootEntity[] entities, string selectedPath)
+        private PNGExporter _pngExporter;
+        private Dictionary<Texture, int> _exportedTextures;
+        private ModelPreparerExporter _modelPreparer;
+        private ExportModelOptions _options;
+        private string _baseName;
+
+        public void Export(ExportModelOptions options, RootEntity[] entities)
         {
-            for (var i = 0; i < entities.Length; i++)
+            _options = options?.Clone() ?? new ExportModelOptions();
+            // Force any required options for this format here, before calling Validate.
+            _options.MergeEntities = false; // Not supported yet
+            // When testing in MeshLab, only the first mesh of a given image index will
+            // use the correct image, all future meshes will just use images[0].
+            _options.SingleTexture = true;
+            _options.Validate("dae");
+
+            _pngExporter = new PNGExporter();
+            _exportedTextures = new Dictionary<Texture, int>();
+            _modelPreparer = new ModelPreparerExporter(_options);
+
+            // Prepare the shared state for all models being exported (mainly setting up tiled textures).
+            _modelPreparer.PrepareAll(entities);
+
+            if (!_options.MergeEntities)
             {
-                var entity = entities[i];
-                var modelCount = entity.ChildEntities.Length;
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    // Prepare the state for the current model being exported.
+                    _modelPreparer.PrepareCurrent(entities);
+
+                    ExportEntities(i, entities[i]);
+                }
+            }
+            else // Not supported yet, disabled before Validate
+            {
+                // Prepare the state for the current model being exported.
+                _modelPreparer.PrepareCurrent(entities);
+
+                ExportEntities(0, entities);
+            }
+
+            //_pngExporter.Dispose();
+            _pngExporter = null;
+            _exportedTextures = null;
+            _modelPreparer.Dispose();
+            _modelPreparer = null;
+        }
+
+        private void ExportEntities(int index, params RootEntity[] entities)
+        {
+            for (var entityIndex = 0; entityIndex < entities.Length; entityIndex++)
+            {
+                // If shared, reuse the dictionary of textures so that we only export them once.
+                if (!_options.ShareTextures)
+                {
+                    _exportedTextures.Clear();
+                }
+
+                _baseName = _options.GetBaseName(index, entityIndex);
+                var filePath = Path.Combine(_options.Path, $"{_baseName}.dae");
+
+                var entity = _modelPreparer.GetPreparedRootEntity(entities[entityIndex], out var models);
+
+
+                // Find and export all textures used by this entity
+                var imagesDictionary = new Dictionary<Texture, int>();
+                foreach (var model in models)
+                {
+                    var texture = model.Texture;
+                    if (NeedsTexture(model) && !imagesDictionary.ContainsKey(texture))
+                    {
+                        imagesDictionary.Add(texture, imagesDictionary.Count);
+
+                        if (!_exportedTextures.TryGetValue(texture, out var exportedTextureId))
+                        {
+                            exportedTextureId = _exportedTextures.Count;
+                            _exportedTextures.Add(texture, exportedTextureId);
+
+                            var textureName = _options.GetTextureName(_baseName, exportedTextureId);
+                            _pngExporter.Export(texture, textureName, _options.Path);
+                        }
+                    }
+                }
+
+
+                // The schema always includes dates if we define an asset, so may as well give it the right one.
+                var now = DateTime.Now; // Dates have no time zone info (and no Z for UTC).
+                var asset = new asset
+                {
+                    contributor = new[]
+                    {
+                        new assetContributor
+                        {
+                            authoring_tool = "PSXPREV",
+                        },
+                    },
+                    created = now,
+                    modified = now,
+                };
+                var images = new library_images
+                {
+                    image = new image[imagesDictionary.Count],
+                };
+                var materials = new library_materials
+                {
+                    material = new material[imagesDictionary.Count + 1], // +1 for untextured (last index)
+                };
+                var effects = new library_effects
+                {
+                    effect = new effect[imagesDictionary.Count + 1], // +1 for untextured (last index)
+                };
                 var geometries = new library_geometries
                 {
-                    geometry = new geometry[modelCount]
+                    geometry = new geometry[models.Count],
                 };
-                var visualSceneNodes = new node[modelCount];
                 const string visualSceneName = "visual-scene";
+                var visualSceneNodes = new node[models.Count];
                 var visualScenes = new library_visual_scenes
                 {
                     visual_scene = new[]
@@ -26,222 +136,582 @@ namespace PSXPrev.Common.Exporters
                         new visual_scene
                         {
                             id = visualSceneName,
-                            name = visualSceneName,
-                            node = visualSceneNodes
+                            node = visualSceneNodes,
+                        }
+                    },
+                };
+
+                #region Images, Materials, Effects Library
+                const string untexturedMaterialName = "matnone";
+                const string untexturedEffectName = untexturedMaterialName + "fx";
+
+                materials.material[imagesDictionary.Count] = new material
+                {
+                    id = untexturedMaterialName,
+                    instance_effect = new instance_effect
+                    {
+                        url = $"#{untexturedEffectName}",
+                    },
+                };
+                effects.effect[imagesDictionary.Count] = new effect
+                {
+                    id = untexturedEffectName,
+                };
+
+                foreach (var kvp in imagesDictionary)
+                {
+                    var texture = kvp.Key;
+                    var imageId = kvp.Value;
+                    var imageName = $"image{imageId}";
+
+                    var exportedTextureId = _exportedTextures[texture];
+                    var textureName = _options.GetTextureName(_baseName, exportedTextureId);
+
+                    images.image[imageId] = new image
+                    {
+                        id = imageName,
+                        Item = $"{textureName}.png",
+                    };
+
+                    var imageSurfaceName = $"{imageName}-surface";
+                    var imageSamplerName = $"{imageName}-sampler";
+                    var materialName = $"mat{imageId}";
+                    var effectName = $"{materialName}fx";
+
+                    materials.material[imageId] = new material
+                    {
+                        id = materialName,
+                        instance_effect = new instance_effect
+                        {
+                            url = $"#{effectName}",
+                        },
+                    };
+
+                    effects.effect[imageId] = new effect
+                    {
+                        id = effectName,
+                        Items = new[]
+                        {
+                            new effectFx_profile_abstractProfile_COMMON
+                            {
+                                Items = new[]
+                                {
+                                    new common_newparam_type
+                                    {
+                                        sid = imageSurfaceName,
+                                        ItemElementName = ItemChoiceType.surface,
+                                        Item = new fx_surface_common
+                                        {
+                                            type = fx_surface_type_enum.Item2D,
+                                            init_from = new[]
+                                            {
+                                                new fx_surface_init_from_common
+                                                {
+                                                    Value = imageName,
+                                                }
+                                            },
+                                            format = "A8R8G8B8",
+                                        },
+                                    },
+                                    new common_newparam_type
+                                    {
+                                        sid = imageSamplerName,
+                                        ItemElementName = ItemChoiceType.sampler2D,
+                                        Item = new fx_sampler2D_common
+                                        {
+                                            source = imageSurfaceName,
+                                            minfilter = fx_sampler_filter_common.NEAREST,
+                                            magfilter = fx_sampler_filter_common.NEAREST,
+                                            wrap_s = fx_sampler_wrap_common.WRAP,
+                                            wrap_t = fx_sampler_wrap_common.WRAP,
+                                        },
+                                    },
+                                },
+                                technique = new effectFx_profile_abstractProfile_COMMONTechnique
+                                {
+                                    sid = "common",
+                                    Item = new effectFx_profile_abstractProfile_COMMONTechniqueBlinn
+                                    {
+                                        diffuse = new common_color_or_texture_type
+                                        {
+                                            Item = new common_color_or_texture_typeTexture
+                                            {
+                                                texture = imageSamplerName,
+                                                texcoord = $"UVSET0",
+                                            },
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                    };
+                }
+                #endregion
+
+
+                for (var i = 0; i < models.Count; i++)
+                {
+                    var model = models[i];
+                    var modelName = $"mesh{i}";
+                    var vertexCount = model.Triangles.Length * 3;
+                    var needsTexture = NeedsTexture(model);
+                    var normalInVertices = !_options.VertexIndexReuse;
+                    var colorInVertices = !_options.VertexIndexReuse;
+
+                    var materialName = untexturedMaterialName;
+                    var imageId = -1;
+                    if (needsTexture && imagesDictionary.TryGetValue(model.Texture, out imageId))
+                    {
+                        materialName = materials.material[imageId].id;
+                    }
+                    var materialInstanceName = materialName;
+
+                    // Parameter names (like all names) are optional, save space and don't include them.
+                    var acessorParams3d = new[]
+                    {
+                        new param { type = "float" }, // name = "X"
+                        new param { type = "float" }, // name = "Y"
+                        new param { type = "float" }, // name = "Z"
+                    };
+                    var acessorParamsUv = new[]
+                    {
+                        new param { type = "float" }, // name = "S"
+                        new param { type = "float" }, // name = "T"
+                    };
+
+                    #region Processing
+                    var triangleIndices = new StringBuilder();
+                    var positionIndices = new Dictionary<Vector3, int>();
+                    var normalIndices = new Dictionary<Vector3, int>();
+                    var colorIndices = new Dictionary<Vector3, int>();
+                    var uvIndices = new Dictionary<Vector2, int>();
+                    var positionValues = new List<double>();
+                    var normalValues = new List<double>();
+                    var colorValues = new List<double>();
+                    var uvValues = new List<double>();
+                    var baseIndex = 0;
+                    foreach (var triangle in model.Triangles)
+                    {
+                        for (var j = 2; j >= 0; j--, baseIndex++)
+                        {
+                            var vertex = triangle.Vertices[j];
+                            var normal = triangle.Normals[j];
+                            var color = triangle.Colors[j];
+                            var uv = triangle.Uv[j];
+
+                            // Position
+                            if (!_options.VertexIndexReuse || !positionIndices.TryGetValue(vertex, out var positionIndex))
+                            {
+                                if (_options.VertexIndexReuse)
+                                {
+                                    positionIndex = positionIndices.Count;
+                                    positionIndices.Add(vertex, positionIndex);
+                                }
+                                else
+                                {
+                                    positionIndex = baseIndex;
+                                }
+
+                                positionValues.Add(vertex.X);
+                                positionValues.Add(-vertex.Y);
+                                positionValues.Add(-vertex.Z);
+                            }
+                            triangleIndices.Append($"{positionIndex} ");
+
+                            // Normal
+                            if (!_options.VertexIndexReuse || !normalIndices.TryGetValue(normal, out var normalIndex))
+                            {
+                                if (_options.VertexIndexReuse)
+                                {
+                                    normalIndex = normalIndices.Count;
+                                    normalIndices.Add(normal, normalIndex);
+                                }
+                                else
+                                {
+                                    normalIndex = baseIndex;
+                                }
+
+                                normalValues.Add(normal.X);
+                                normalValues.Add(-normal.Y);
+                                normalValues.Add(-normal.Z);
+                            }
+                            if (!normalInVertices)
+                            {
+                                triangleIndices.Append($"{normalIndex} ");
+                            }
+
+                            // Color
+                            if (!_options.VertexIndexReuse || !colorIndices.TryGetValue(color.Vector, out var colorIndex))
+                            {
+                                if (_options.VertexIndexReuse)
+                                {
+                                    colorIndex = colorIndices.Count;
+                                    colorIndices.Add(color.Vector, colorIndex);
+                                }
+                                else
+                                {
+                                    colorIndex = baseIndex;
+                                }
+
+                                colorValues.Add(color.R);
+                                colorValues.Add(color.G);
+                                colorValues.Add(color.B);
+                            }
+                            if (!colorInVertices)
+                            {
+                                triangleIndices.Append($"{colorIndex} ");
+                            }
+
+                            // UV
+                            if (needsTexture)
+                            {
+                                if (!_options.VertexIndexReuse || !uvIndices.TryGetValue(uv, out var uvIndex))
+                                {
+                                    if (_options.VertexIndexReuse)
+                                    {
+                                        uvIndex = uvIndices.Count;
+                                        uvIndices.Add(uv, uvIndex);
+                                    }
+                                    else
+                                    {
+                                        uvIndex = baseIndex;
+                                    }
+
+                                    uvValues.Add(uv.X);
+                                    uvValues.Add(1f - uv.Y);
+                                }
+                                triangleIndices.Append($"{uvIndex} ");
+                            }
                         }
                     }
-                };
-                for (var j = 0; j < modelCount; j++)
-                {
-                    var model = (ModelEntity) entity.ChildEntities[j];
-                    var modelName = string.Format("model-{0}-lib", j);
-                    var materialName = string.Format("{0}-material", modelName);
-                    var triangleCount = model.Triangles.Length;
-                    var elementGroupCount = triangleCount * 3;
-                    var elementCount = elementGroupCount * 3;
 
-                    var acessorParams = new[]
-                    {
-                        new param
-                        {
-                            name = "X",
-                            type = "float"
-                        },
-                        new param
-                        {
-                            name = "Y",
-                            type = "float"
-                        },
-                        new param
-                        {
-                            name = "Z",
-                            type = "float"
-                        }
-                    };
+                    #endregion
 
                     #region Position
-
-                    var positionArrayName = string.Format("{0}-positions-array", modelName);
-                    var positionAccessor = new accessor
-                    {
-                        count = (ulong)elementGroupCount,
-                        offset = 0,
-                        source = string.Format("#{0}", positionArrayName),
-                        stride = 3,
-                        param = acessorParams
-                    };
-                    var positionTechnique = new sourceTechnique_common
-                    {
-                        accessor = positionAccessor
-                    };
-                    var positionArrayValues = new double[elementCount];
-                    var positionArray = new float_array
-                    {
-                        id = positionArrayName,
-                        count = (ulong)elementCount,
-                        Values = positionArrayValues
-                    };
-                    var positionName = string.Format("{0}-positions", modelName);
+                    var positionName = $"{modelName}-pos";
+                    var positionArrayName = $"{positionName}-array";
                     var positionSource = new source
                     {
                         id = positionName,
-                        name = "position",
-                        Item = positionArray,
-                        technique_common = positionTechnique
+                        Item = new float_array
+                        {
+                            id = positionArrayName,
+                            count = (ulong)positionValues.Count,
+                            Values = positionValues.ToArray(),
+                        },
+                        technique_common = new sourceTechnique_common
+                        {
+                            accessor = new accessor
+                            {
+                                count = (ulong)positionValues.Count / 3,
+                                offset = 0,
+                                source = $"#{positionArrayName}",
+                                stride = 3,
+                                param = acessorParams3d,
+                            },
+                        },
                     };
                     #endregion
 
                     #region Normal
-                    var normalArrayName = string.Format("{0}-normals-array", modelName);
-                    var normalAccessor = new accessor
-                    {
-                        count = (ulong)elementGroupCount,
-                        offset = 0,
-                        source = string.Format("#{0}", normalArrayName),
-                        stride = 3,
-                        param = acessorParams
-                    };
-                    var normalTechinique =
-                        new sourceTechnique_common
-                        {
-                            accessor = normalAccessor
-                        };
-                    var normalArrayValues = new double[elementCount];
-                    var normalArray = new float_array
-                    {
-                        id = normalArrayName,
-                        count = (ulong)elementCount,
-                        Values = normalArrayValues
-                    };
-                    var normalName = string.Format("{0}-normals", modelName);
+                    var normalName = $"{modelName}-norm";
+                    var normalArrayName = $"{normalName}-array";
                     var normalSource = new source
                     {
                         id = normalName,
-                        name = "normal",
-                        Item = normalArray,
-                        technique_common = normalTechinique
+                        Item = new float_array
+                        {
+                            id = normalArrayName,
+                            count = (ulong)normalValues.Count,
+                            Values = normalValues.ToArray(),
+                        },
+                        technique_common = new sourceTechnique_common
+                        {
+                            accessor = new accessor
+                            {
+                                count = (ulong)normalValues.Count / 3,
+                                offset = 0,
+                                source = $"#{normalArrayName}",
+                                stride = 3,
+                                param = acessorParams3d,
+                            },
+                        },
                     };
                     #endregion
 
-                    #region Processing
-                    var triangleIndices = new StringBuilder();
-                    for (var l = 0; l < model.Triangles.Length; l++)
+                    #region Color
+                    var colorName = $"{modelName}-color";
+                    var colorArrayName = $"{colorName}-array";
+                    var colorSource = new source
                     {
-                        var triangle = model.Triangles[l];
-                        for (var k = 0; k < 3; k++)
+                        id = colorName,
+                        Item = new float_array
                         {
-                            var elementIndex = l * 3 + k;
+                            id = colorArrayName,
+                            count = (ulong)colorValues.Count,
+                            Values = colorValues.ToArray(),
+                        },
+                        technique_common = new sourceTechnique_common
+                        {
+                            accessor = new accessor
+                            {
+                                count = (ulong)colorValues.Count / 3,
+                                offset = 0,
+                                source = $"#{colorArrayName}",
+                                stride = 3,
+                                param = acessorParams3d,
+                            },
+                        },
+                    };
+                    #endregion
 
-                            var vertex = triangle.Vertices[k];
-                            var normal = triangle.Normals[k];
-                            var color = triangle.Colors[k];
-                            var uv = triangle.Uv[k];
-
-                            positionArrayValues[elementIndex] = vertex.X;
-                            positionArrayValues[elementIndex + 1] = vertex.Y;
-                            positionArrayValues[elementIndex + 2] = vertex.Z;
-
-                            normalArrayValues[elementIndex] = normal.X;
-                            normalArrayValues[elementIndex + 1] = normal.Y;
-                            normalArrayValues[elementIndex + 2] = normal.Z;
-
-                            triangleIndices.Append(elementIndex);
-                            triangleIndices.Append(" ");
-                        }
+                    #region UV
+                    var uvName = $"{modelName}-uv";
+                    var uvArrayName = $"{uvName}-array";
+                    source uvSource = null;
+                    if (needsTexture)
+                    {
+                        uvSource = new source
+                        {
+                            id = uvName,
+                            Item = new float_array
+                            {
+                                id = uvArrayName,
+                                count = (ulong)uvValues.Count,
+                                Values = uvValues.ToArray(),
+                            },
+                            technique_common = new sourceTechnique_common
+                            {
+                                accessor = new accessor
+                                {
+                                    count = (ulong)uvValues.Count / 2,
+                                    offset = 0,
+                                    source = $"#{uvArrayName}",
+                                    stride = 2,
+                                    param = acessorParamsUv,
+                                },
+                            },
+                        };
                     }
-
                     #endregion
 
                     #region Vertices
-                    var verticesName = string.Format("{0}-vertices", modelName);
-                    var triangles = new triangles 
-                    {
-                        count = (ulong)triangleCount,
-                        material = materialName,
-                        input = new[]
-                        {
-                            new InputLocalOffset
-                            {
-                                offset = 0,
-                                semantic = "VERTEX",
-                                source = string.Format("#{0}", verticesName)
-                            }//,
-                            //new InputLocalOffset
-                            //{
-                            //    offset = 1,
-                            //    semantic = "NORMAL",
-                            //    source = string.Format("#{0}", normalName)
-                            //}
-                        },
-                        p = triangleIndices.ToString()
-                    };
-                    #endregion
+                    var verticesName = $"{modelName}-vert";
 
-                    #region Mesh
-                    var mesh = new mesh
+                    var sources = new List<source>();
+                    sources.Add(positionSource);
+                    sources.Add(normalSource);
+                    sources.Add(colorSource);
+                    if (needsTexture)
                     {
-                        source = new[] { positionSource, normalSource },
-                        vertices = new vertices
+                        sources.Add(uvSource);
+                    }
+
+                    var verticesInputs = new List<InputLocal>();
+                    verticesInputs.Add(new InputLocal
+                    {
+                        semantic = "POSITION",
+                        source = $"#{positionName}",
+                    });
+                    if (normalInVertices)
+                    {
+                        verticesInputs.Add(new InputLocal
                         {
-                            id = verticesName,
-                            input = new[]
-                            {
-                                new InputLocal
-                                {
-                                    semantic = "POSITION",
-                                    source = string.Format("#{0}", positionName)
-                                }
-                            }
-                        },
-                        Items = new object[] { triangles }
-                    };
+                            semantic = "NORMAL",
+                            source = $"#{normalName}",
+                        });
+                    }
+                    if (colorInVertices)
+                    {
+                        verticesInputs.Add(new InputLocal
+                        {
+                            semantic = "COLOR",
+                            source = $"#{colorName}",
+                        });
+                    }
+
+                    ulong inputsOffset = 0;
+                    var trianglesInputs = new List<InputLocalOffset>();
+                    trianglesInputs.Add(new InputLocalOffset
+                    {
+                        offset = inputsOffset++,
+                        semantic = "VERTEX",
+                        source = $"#{verticesName}",
+                    });
+                    if (!normalInVertices)
+                    {
+                        trianglesInputs.Add(new InputLocalOffset
+                        {
+                            offset = inputsOffset++,
+                            semantic = "NORMAL",
+                            source = $"#{normalName}",
+                        });
+                    }
+                    if (!colorInVertices)
+                    {
+                        trianglesInputs.Add(new InputLocalOffset
+                        {
+                            offset = inputsOffset++,
+                            semantic = "COLOR",
+                            source = $"#{colorName}",
+                        });
+                    }
+                    if (needsTexture)
+                    {
+                        trianglesInputs.Add(new InputLocalOffset
+                        {
+                            offset = inputsOffset++,
+                            semantic = "TEXCOORD",
+                            source = $"#{uvName}",
+                        });
+                    }
                     #endregion
 
                     #region Geometry
-                    var geometryName = string.Format("{0}-geometry", modelName);
-                    var geometry = new geometry
+                    geometries.geometry[i] = new geometry
                     {
-                        id = geometryName,
-                        name = geometryName,
-                        Item = mesh
+                        id = modelName,
+                        Item = new mesh
+                        {
+                            source = sources.ToArray(),
+                            vertices = new vertices
+                            {
+                                id = verticesName,
+                                input = verticesInputs.ToArray(),
+                            },
+                            Items = new[]
+                            {
+                                new triangles
+                                {
+                                    count = (ulong)model.Triangles.Length,
+                                    material = materialInstanceName,
+                                    input = trianglesInputs.ToArray(),
+                                    p = triangleIndices.ToString(),
+                                }
+                            },
+                        },
                     };
-                    geometries.geometry[j] = geometry;
                     #endregion
 
                     #region Visual Node
-                    var visualSceneNodeName = string.Format("{0}-node", modelName);
-                    visualSceneNodes[j] = new node
+                    var nodeName = $"{modelName}-node";
+
+                    var worldMatrix = model.WorldMatrix;
+                    var translation = worldMatrix.ExtractTranslation();
+                    var rotation = worldMatrix.ExtractRotationSafe();
+                    var scale = worldMatrix.ExtractScale();
+                    translation.Y *= -1f;
+                    translation.Z *= -1f;
+                    rotation.Y *= -1f;
+                    rotation.Z *= -1f;
+                    var matrix = Matrix4.CreateScale(scale) * Matrix4.CreateFromQuaternion(rotation) * Matrix4.CreateTranslation(translation);
+
+                    visualSceneNodes[i] = new node
                     {
-                        name = visualSceneNodeName,
-                        id = visualSceneNodeName,
+                        id = nodeName,
+                        Items = new object[]
+                        {
+                            new matrix
+                            {
+                                Values = new double[]
+                                {
+                                    matrix.M11, matrix.M21, matrix.M31, matrix.M41,
+                                    matrix.M12, matrix.M22, matrix.M32, matrix.M42,
+                                    matrix.M13, matrix.M23, matrix.M33, matrix.M43,
+                                    matrix.M14, matrix.M24, matrix.M34, matrix.M44,
+                                },
+                            }
+                        },
+                        ItemsElementName = new[]
+                        {
+                            ItemsChoiceType2.matrix,
+                        },
                         instance_geometry = new[]
                         {
                             new instance_geometry
                             {
-                                url = string.Format("#{0}", geometryName)
+                                url = $"#{modelName}",
+                                bind_material = new bind_material
+                                {
+                                    technique_common = new instance_material[]
+                                    {
+                                        new instance_material
+                                        {
+                                            symbol = materialInstanceName,
+                                            target = $"#{materialName}",
+                                            bind_vertex_input = needsTexture
+                                                ? new[]
+                                                {
+                                                    new instance_materialBind_vertex_input
+                                                    {
+                                                        semantic = $"UVSET0",
+                                                        input_semantic = "TEXCOORD",
+                                                        input_set = (ulong)0,
+                                                        input_setSpecified = true,
+                                                    }
+                                                }
+                                                : null,
+                                        },
+                                    },
+                                },
                             }
-                        }
+                        },
                     };
                     #endregion
                 }
+
+                var colladaItems = new List<object>();
+                if (_options.ExportTextures && imagesDictionary.Count > 0)
+                {
+                    colladaItems.Add(images);
+                }
+                colladaItems.Add(materials);
+                colladaItems.Add(effects);
+                colladaItems.Add(geometries);
+                colladaItems.Add(visualScenes);
+
                 var collada = new COLLADA
                 {
-                    Items = new object[]
-                    {
-                        geometries,
-                        visualScenes
-                    },
+                    asset = asset,
+                    Items = colladaItems.ToArray(),
                     scene = new COLLADAScene
                     {
                         instance_visual_scene = new InstanceWithExtra
                         {
-                            url = string.Format("#{0}", visualSceneName)
-                        }
-                    }
+                            url = $"#{visualSceneName}",
+                        },
+                    },
                 };
-                var fileName = string.Format("{0}/dae{1}.dae", selectedPath, i);
-                collada.Save(fileName);
+
+                // Optional handling to output cleaner float values.
+                // This modifies the auto-generated schema, but the property can be safely removed if needed.
+                var oldStrictFloatFormat = COLLADA.StrictFloatFormat;
+                try
+                {
+                    COLLADA.StrictFloatFormat = _options.StrictFloatFormat;
+
+                    using (var stream = File.Create(filePath))
+                    {
+                        var xmlWriter = new XmlTextWriter(stream, Encoding.UTF8)
+                        {
+                            Formatting = _options.ReadableFormat ? Formatting.Indented : Formatting.None,
+                            Indentation = 1,
+                            IndentChar = '\t',
+                        };
+                        var xmlSerializer = new XmlSerializer(typeof(COLLADA));
+                        xmlSerializer.Serialize(xmlWriter, collada);
+                    }
+                }
+                finally
+                {
+                    COLLADA.StrictFloatFormat = oldStrictFloatFormat;
+                }
             }
+        }
+
+        private bool NeedsTexture(ModelEntity model)
+        {
+            return _options.ExportTextures && model.HasTexture;
         }
     }
 }

--- a/Common/Exporters/ExportModelOptions.cs
+++ b/Common/Exporters/ExportModelOptions.cs
@@ -9,12 +9,15 @@ namespace PSXPrev.Common.Exporters
 
         public const string OBJ = "OBJ";
         public const string PLY = "PLY";
+        public const string DAE = "DAE";
         public const string GLTF2 = "glTF2";
 
         // These settings are only present for loading and saving purposes.
         // File path:
         [JsonProperty("path")]
         public string Path { get; set; } = string.Empty;
+        [JsonProperty("name")]
+        public string Name { get; set; } = string.Empty;
         // Format:
         [JsonProperty("format")]
         public string Format { get; set; } = OBJ;
@@ -36,6 +39,12 @@ namespace PSXPrev.Common.Exporters
         public bool MergeEntities { get; set; } = false;
         [JsonProperty("attachLimbs")]
         public bool AttachLimbs { get; set; } = true;
+        [JsonProperty("vertexIndexReuse")]
+        public bool VertexIndexReuse { get; set; } = true;
+        [JsonProperty("readableFormat")]
+        public bool ReadableFormat { get; set; } = true;
+        [JsonProperty("strictFloatFormat")]
+        public bool StrictFloatFormat { get; set; } = true;
         [JsonProperty("experimentalOBJVertexColor")]
         public bool ExperimentalOBJVertexColor { get; set; } = true;
 
@@ -46,8 +55,29 @@ namespace PSXPrev.Common.Exporters
         public bool ExportAnimations { get; set; }
 
 
-        public void Validate()
+        // Helpers
+        [JsonIgnore]
+        public string FloatFormat => StrictFloatFormat ? GeomMath.FloatFormat : "G";
+
+        public string GetBaseName(int index, int? entityIndex = null)
         {
+            // {baseName}{index}{"_{entityIndex}" | ""}
+            var baseName = $"{Name}{index}";
+            return entityIndex.HasValue ? $"{baseName}_{entityIndex}" : baseName;
+        }
+
+        public string GetTextureName(string baseName, int textureIndex)
+        {
+            // {"{Name}shared" | "{baseName}"}{"_{textureIndex}" | ""}
+            var baseTextureName = ShareTextures ? $"{Name}shared" : baseName;
+            return !SingleTexture ? $"{baseTextureName}_{textureIndex}" : baseTextureName;
+        }
+
+
+        public void Validate(string defaultName)
+        {
+            Name = string.IsNullOrWhiteSpace(Name) ? defaultName : Name.Trim();
+
             if (!ExportTextures)
             {
                 ShareTextures = false;

--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -149,7 +149,7 @@ namespace PSXPrev.Common.Exporters
             }
 
             // Create a new tiled texture that repeats the needed amount of times.
-            tiledInfo.SetupTiledTexture(maxUv, powerOfTwo: true);
+            tiledInfo.SetupTiledTexture(maxUv, powerOfTwo: !_options.SingleTexture);
 
             // Assign new tiled texture to models.
             foreach (var model in tiledInfo.Models)

--- a/Common/Exporters/PNGExporter.cs
+++ b/Common/Exporters/PNGExporter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using PSXPrev.Common.Renderer;
 
 namespace PSXPrev.Common.Exporters
@@ -59,7 +60,7 @@ namespace PSXPrev.Common.Exporters
 
         private void ExportBitmap(Bitmap bitmap, string name, string selectedPath)
         {
-            var filePath = $"{selectedPath}/{name}.png";
+            var filePath = Path.Combine(selectedPath, $"{name}.png");
             bitmap.Save(filePath, ImageFormat.Png);
         }
     }

--- a/Common/Exporters/collada_schema_1_4.cs
+++ b/Common/Exporters/collada_schema_1_4.cs
@@ -12,6 +12,10 @@
 //     the code is regenerated.
 // </auto-generated>
 //------------------------------------------------------------------------------
+// Modifications:
+// ConvertFromArray<T> now uses StrictFloatFormat static property. When false,
+// floats will be output with the "G" format specifier instead of a fixed one.               
+//------------------------------------------------------------------------------
 
 using System;
 using System.CodeDom.Compiler;
@@ -9853,6 +9857,8 @@ namespace Collada141
     {
         private static Regex regex = new Regex(@"\s+");
 
+        public static bool StrictFloatFormat { get; set; } = true;
+
         public static string ConvertFromArray<T>(IList<T> array)
         {
             if (array == null)
@@ -9866,10 +9872,22 @@ namespace Collada141
                 {
                     object value1 = array[i];
                     double value = (double) value1;
-                    text.Append(
-                        value.ToString(
-                            "0.000000",
-                            NumberFormatInfo.InvariantInfo));
+                    if (StrictFloatFormat)
+                    {
+                        text.Append(
+                            value.ToString(
+                                "0.000000",
+                                NumberFormatInfo.InvariantInfo));
+                    }
+                    else
+                    {
+                        // All of our data is stored as floats, so cast to reduce verbosity
+                        float valuef = (float) value;
+                        text.Append(
+                            valuef.ToString(
+                                "G",
+                                NumberFormatInfo.InvariantInfo));
+                    }
                     if ((i + 1) < array.Count)
                         text.Append(" ");
                 }

--- a/Common/Exporters/glTF2Exporter.Schema.cs
+++ b/Common/Exporters/glTF2Exporter.Schema.cs
@@ -1,0 +1,310 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+using PSXPrev.Common.Utils;
+
+namespace PSXPrev.Common.Exporters.glTF2Schema
+{
+    // Use the following attribute on properties that should be written, even when null.
+    // [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+
+    internal class glTF
+    {
+        public const string ExtensionUnlit = "KHR_materials_unlit";
+
+        public asset asset;
+        public int scene;
+        public List<scene> scenes;
+        public List<bufferView> bufferViews;
+        public List<sampler> samplers;
+        public List<image> images;
+        public List<texture> textures;
+        public List<material> materials;
+        public List<accessor> accessors;
+        public List<mesh> meshes;
+        public List<skin> skins;
+        //public List<camera> cameras;
+        public List<animation> animations;
+        public List<node> nodes;
+        public List<buffer> buffers;
+        public List<string> extensionsUsed;
+    }
+
+
+    internal class accessor
+    {
+        public string name;
+        public int bufferView;
+        [DefaultValue(0L), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public long byteOffset = 0;
+        // Serialize as int
+        public accessor_componentType componentType;
+        [DefaultValue(false), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool normalized = false;
+        public int count;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public accessor_type type;
+        public float[] min;
+        public float[] max;
+        //public animation_sparse sparse;
+    }
+
+    internal enum accessor_componentType
+    {
+        BYTE           = 5120,
+        UNSIGNED_BYTE  = 5121,
+        SHORT          = 5122,
+        UNSIGNED_SHORT = 5123,
+        UNSIGNED_INT   = 5125,
+        FLOAT          = 5126,
+    }
+
+    internal enum accessor_type
+    {
+        SCALAR,
+        VEC2,
+        VEC3,
+        VEC4,
+        MAT2,
+        MAT3,
+        MAT4,
+    }
+
+    internal class animation
+    {
+        public string name;
+        public List<animation_sampler> samplers;
+        public List<animation_channel> channels;
+    }
+
+    internal class animation_channel
+    {
+        public int sampler;
+        public animation_channel_target target;
+    }
+
+    internal class animation_channel_target
+    {
+        public int node;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public animation_channel_target_path path;
+    }
+
+    internal enum animation_channel_target_path
+    {
+        translation,
+        rotation,
+        scale,
+        weights,
+    }
+
+    internal class animation_sampler
+    {
+        public int input;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [DefaultValue(animation_sampler_interpolation.LINEAR), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public animation_sampler_interpolation interpolation = animation_sampler_interpolation.LINEAR;
+        public int output;
+    }
+
+    internal enum animation_sampler_interpolation
+    {
+        LINEAR,
+        STEP,
+        CUBICSPLINE,
+    }
+
+    internal class asset
+    {
+        public string copyright;
+        public string generator;
+        public string version;
+        public string minVersion;
+    }
+
+    internal class buffer
+    {
+        public string name;
+        public string uri;
+        public long byteLength;
+    }
+
+    internal class bufferView
+    {
+        public string name;
+        public int buffer;
+        [DefaultValue(0L), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public long byteOffset = 0;
+        public long byteLength;
+        public long? byteStride;
+        public bufferView_target? target;
+    }
+
+    internal enum bufferView_target
+    {
+        ARRAY_BUFFER         = 34962,
+        ELEMENT_ARRAY_BUFFER = 34963,
+    }
+
+    internal class image
+    {
+        public string name;
+        public string uri;
+    }
+
+    internal class material
+    {
+        public string name;
+        public material_pbrMetallicRoughness pbrMetallicRoughness;
+        public material_normalTextureInfo normalTexture;
+        public material_occlusionTextureInfo occlusionTexture;
+        public textureInfo emissiveTexture;
+        public float[] emissiveFactor;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [DefaultValue(material_alphaMode.OPAQUE), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public material_alphaMode alphaMode = material_alphaMode.OPAQUE;
+        [DefaultValue(0.5f), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float alphaCutoff = 0.5f;
+        [DefaultValue(false), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool doubleSided = false;
+        public Dictionary<string, object> extensions;
+        // extensions: KHR_materials_unlit
+    }
+
+    internal enum material_alphaMode
+    {
+        OPAQUE,
+        MASK,
+        BLEND,
+    }
+
+    internal class material_normalTextureInfo : textureInfo
+    {
+        [DefaultValue(1.0f), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float scale = 1.0f;
+    }
+
+    internal class material_occlusionTextureInfo : textureInfo
+    {
+        [DefaultValue(1.0f), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float strength = 1.0f;
+    }
+
+    internal class material_pbrMetallicRoughness
+    {
+        public float[] baseColorFactor;
+        public textureInfo baseColorTexture;
+        [DefaultValue(1.0f), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float metallicFactor = 1.0f;
+        [DefaultValue(1.0f), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float roughnessFactor = 1.0f;
+        public textureInfo metallicRoughnessTexture;
+    }
+
+    internal class mesh
+    {
+        public string name;
+        public List<mesh_primitive> primitives;
+        public List<float> weights;
+    }
+
+    internal class mesh_primitive
+    {
+        public mesh_primitive_attributes attributes;
+        public int? indices;
+        public int? material;
+        [DefaultValue(mesh_primitive_mode.TRIANGLES), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public mesh_primitive_mode mode = mesh_primitive_mode.TRIANGLES;
+        public List<int> targets;
+    }
+
+    internal class mesh_primitive_attributes
+    {
+        public int POSITION;
+        public int? NORMAL;
+        public int? COLOR_0;
+        public int? TEXCOORD_0;
+    }
+
+    internal enum mesh_primitive_mode
+    {
+        POINTS         = 0,
+        LINES          = 1,
+        LINE_LOOP      = 2,
+        LINE_STRIP     = 3,
+        TRIANGLES      = 4,
+        TRIANGLE_STRIP = 5,
+        TRIANGLE_FAN   = 6,
+    }
+
+    internal class node
+    {
+        public string name;
+        public List<int> children;
+        public int? camera;
+        public int? mesh;
+        public int? skin;
+        public float[] translation;
+        public float[] rotation;
+        public float[] scale;
+        public float[] matrix;
+        public List<float> weights;
+    }
+
+    internal class sampler
+    {
+        public string name;
+        public sampler_filter magFilter;
+        public sampler_filter minFilter;
+        [DefaultValue(sampler_wrap.REPEAT), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public sampler_wrap wrapS = sampler_wrap.REPEAT;
+        [DefaultValue(sampler_wrap.REPEAT), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public sampler_wrap wrapT = sampler_wrap.REPEAT;
+    }
+
+    internal enum sampler_filter
+    {
+        NEAREST                = 9728,
+        LINEAR                 = 9729,
+        // minFilter only
+        NEAREST_MIPMAP_NEAREST = 9984,
+        LINEAR_MIPMAP_NEAREST  = 9985,
+        NEAREST_MIPMAP_LINEAR  = 9986,
+        LINEAR_MIPMAP_LINEAR   = 9987,
+    }
+
+    internal enum sampler_wrap
+    {
+        REPEAT          = 10497,
+        CLAMP_TO_EDGE   = 33071,
+        MIRRORED_REPEAT = 33648,
+    }
+
+    internal class scene
+    {
+        public string name;
+        public List<int> nodes;
+    }
+
+    internal class skin
+    {
+        public string name;
+        public List<int> joints;
+        public int? inverseBindMatrices;
+        public int? skeleton;
+    }
+
+    internal class texture
+    {
+        public string name;
+        public int sampler;
+        public int source;
+    }
+
+    internal class textureInfo
+    {
+        public int index;
+        [DefaultValue(0), JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int texCoord = 0;
+    }
+}

--- a/Common/Utils/ManifestResourceLoader.cs
+++ b/Common/Utils/ManifestResourceLoader.cs
@@ -5,14 +5,12 @@ namespace PSXPrev.Common.Utils
 {
     public static class ManifestResourceLoader
     {
-        public static string BaseNamespace = "PSXPrev";
-
         private static string ConvertPath(string fileName)
         {
             // Replace path slashes with dots.
             var resourceName = fileName.Replace('\\', '.').Replace('/', '.');
             // Prefix path with base namespace.
-            return $"{BaseNamespace}.{resourceName}";
+            return $"{Program.RootNamespace}.{resourceName}";
         }
 
         public static Stream Open(string fileName, bool checkFileSystem = true)

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -258,15 +258,19 @@ namespace PSXPrev.Forms
             {
                 case ExportModelOptions.OBJ:
                     var objExporter = new OBJExporter();
-                    objExporter.Export(entities, options);
+                    objExporter.Export(options, entities);
                     break;
                 case ExportModelOptions.PLY:
                     var plyExporter = new PLYExporter();
-                    plyExporter.Export(entities, options);
+                    plyExporter.Export(options, entities);
+                    break;
+                case ExportModelOptions.DAE:
+                    var daeExporter = new DAEExporter();
+                    daeExporter.Export(options, entities);
                     break;
                 case ExportModelOptions.GLTF2:
                     var glTF2Exporter = new glTF2Exporter();
-                    glTF2Exporter.Export(entities, animations, animationBatch, options);
+                    glTF2Exporter.Export(options, entities, animations, animationBatch);
                     break;
             }
         }

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -181,16 +181,6 @@ namespace PSXPrev.Forms
             animationsTreeView.Nodes.Add(animationNode);
             AddAnimationObject(animation.RootAnimationObject, animationNode);
             animationsTreeView.EndUpdate();
-
-            // Debugging: Quickly export HMD animation on startup.
-            //if (_rootEntities.Count >= 1 && _animations.Count == 1)
-            //{
-            //    var options = new ExportModelOptions
-            //    {
-            //        Format = ExportModelOptions.GLTF2,
-            //    };
-            //    ExportModelsForm.Export(options, new[] { _rootEntities[0] }, new[] { _animations[0] }, _scene.AnimationBatch);
-            //}
         }
 
         public void AddRootEntities(List<RootEntity> entities)
@@ -256,6 +246,22 @@ namespace PSXPrev.Forms
                 stopScanningToolStripMenuItem.Enabled = false;
                 startScanToolStripMenuItem.Enabled = true;
                 clearScanResultsToolStripMenuItem.Enabled = true;
+
+                // Debugging: Quickly export models and animations on startup.
+                /*if (_rootEntities.Count >= 1 && _animations.Count >= 1)
+                {
+                    var options = new ExportModelOptions
+                    {
+                        Path = @"",
+                        Format = ExportModelOptions.GLTF2,
+                        SingleTexture = false,
+                        AttachLimbs = true,
+                        RedrawTextures = true,
+                        ExportAnimations = true,
+                    };
+                    ExportModelsForm.Export(options, new[] { _rootEntities[0] }, new[] { _animations[0] }, _scene.AnimationBatch);
+                    Close();
+                }*/
             }
         }
 

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Common\Exporters\DAEExporter.cs" />
     <Compile Include="Common\Exporters\ExportModelOptions.cs" />
     <Compile Include="Common\Exporters\glTF2Exporter.cs" />
+    <Compile Include="Common\Exporters\glTF2Exporter.Schema.cs" />
     <Compile Include="Common\Exporters\ModelPreparerExporter.cs" />
     <Compile Include="Common\Exporters\MTLExporter.cs" />
     <Compile Include="Common\Exporters\OBJExporter.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-
 using DiscUtils;
 using DiscUtils.Iso9660;
 using PSXPrev.Common;
@@ -22,6 +21,9 @@ namespace PSXPrev
 {
     public class Program
     {
+        public static string Name = "PSXPrev";
+        public static string RootNamespace = "PSXPrev";
+
         public static readonly Logger Logger = new Logger();
 
         private static PreviewForm PreviewForm;


### PR DESCRIPTION
* Added export option to reuse vertex indices (no UI control yet).
* Added export option to indent formatting for glTF2 and DAE (no UI control yet).
* Added export option to turn on or off strict formatting of floats by using fixed decimal places (no UI control yet).
* Added support for DAEExporter (no UI control yet).
* Added support for specifying custom prefix name for exported files (no UI control yet), empty will default to using the exporter's preset, which is declared when _options.Validate("preset") is called.
* ExportModelOptions now supplies FloatFormat property, GetBaseName, and GetTextureName, so that all exporters are consistent.
* Switched all cases of manual path combining with string formatting to Path.Combine.
* Fixed ModelPreparerExporter making tiled textures powers of two, even when exporting to single texture (which would just take up space needlessly).
* Replaced instances of File.Open with File.Create when the goal was to write a new file. File.Open won't reset the file size to zero.
* OBJ format now outputs $"o object{i}" for each entity in the model.
* OBJ and PLY now output vertex definitions in reverse order, meaning face definitions no longer need to be defined in reverse order.
* All exporters now correctly track if a shared texture has already been exported.
* glTF2Exporter now outputs .gltf file using DOM-based schema objects and Newtonsoft.Json serializer.
* General exporter refactoring. Intended for when a ModelExporterBase class is eventually added.