### PR TITLE
Normal fixes/visuals, intersection fixes, and helper functions

### DIFF
--- a/Common/BoundingBox.cs
+++ b/Common/BoundingBox.cs
@@ -5,11 +5,13 @@ namespace PSXPrev.Common
 {
     public class BoundingBox
     {
+        public const int CornerCount = 8;
+
         public Vector3 Min;
         public Vector3 Max;
         public bool IsSet { get; private set; } // True if at least one point has been added.
 
-        private readonly Vector3[] _corners = new Vector3[8];
+        private readonly Vector3[] _corners = new Vector3[CornerCount];
         public Vector3[] Corners
         {
             get

--- a/Common/Color.cs
+++ b/Common/Color.cs
@@ -21,8 +21,6 @@ namespace PSXPrev.Common
         public float G;
         public float B;
 
-        public Vector3 Vector => new Vector3(R, G, B);
-
         public Color(float r, float g, float b)
         {
             R = r;
@@ -30,13 +28,13 @@ namespace PSXPrev.Common
             B = b;
         }
 
-        public Color(Vector3 vector)
-            : this(vector.X, vector.Y, vector.Z)
+        public Color(Color fromColor)
+            : this(fromColor.R, fromColor.G, fromColor.B)
         {
         }
 
-        public Color(Color fromColor)
-            : this(fromColor.R, fromColor.G, fromColor.B)
+        public Color(Vector3 vector)
+            : this(vector.X, vector.Y, vector.Z)
         {
         }
 
@@ -47,14 +45,42 @@ namespace PSXPrev.Common
 
         public override string ToString()
         {
-            return R + "|" + G + "|" + B;
+            return $"{R}|{G}|{B}";
         }
 
 
         public static Color Lerp(Color a, Color b, float blend)
         {
             //blend = GeomMath.Clamp(blend, 0f, 1f);
-            return new Color(Vector3.Lerp(a.Vector, b.Vector, blend));
+            return new Color(Vector3.Lerp((Vector3)a, (Vector3)b, blend));
+        }
+
+        public static explicit operator Vector3(Color color)
+        {
+            return new Vector3(color.R, color.G, color.B);
+        }
+
+        public static explicit operator Color(Vector3 vector)
+        {
+            return new Color(vector.X, vector.Y, vector.Z);
+        }
+
+        public static explicit operator Vector4(Color color)
+        {
+            return new Vector4(color.R, color.G, color.B, 1f);
+        }
+
+        public static explicit operator System.Drawing.Color(Color color)
+        {
+            var r = (int)(GeomMath.Clamp(color.R, 0f, 1f) * 255);
+            var g = (int)(GeomMath.Clamp(color.G, 0f, 1f) * 255);
+            var b = (int)(GeomMath.Clamp(color.B, 0f, 1f) * 255);
+            return System.Drawing.Color.FromArgb(r, g, b);
+        }
+
+        public static explicit operator Color(System.Drawing.Color color)
+        {
+            return new Color(color.R / 255f, color.G / 255f, color.B / 255f);
         }
     }
 }

--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -137,6 +137,34 @@ namespace PSXPrev.Common
             set => Scale = new Vector3(Scale.X, Scale.Y, value);
         }
 
+        [DisplayName("Rotation X")]
+        public float RotationX
+        {
+            get => Rotation.X;
+            set => Rotation = new Quaternion(value, Rotation.Y, Rotation.Z, Rotation.W);
+        }
+
+        [DisplayName("Rotation Y")]
+        public float RotationY
+        {
+            get => Rotation.Y;
+            set => Rotation = new Quaternion(Rotation.X, value, Rotation.Z, Rotation.W);
+        }
+
+        [DisplayName("Rotation Z")]
+        public float RotationZ
+        {
+            get => Rotation.Z;
+            set => Rotation = new Quaternion(Rotation.X, Rotation.Y, value, Rotation.W);
+        }
+
+        [DisplayName("Rotation W")]
+        public float RotationW
+        {
+            get => Rotation.W;
+            set => Rotation = new Quaternion(Rotation.X, Rotation.Y, Rotation.Z, value);
+        }
+
         [ReadOnly(true), DisplayName("Sub-Models")]
         public string ChildCount => ChildEntities == null ? "0" : ChildEntities.Length.ToString(NumberFormatInfo.InvariantInfo);
 
@@ -149,6 +177,7 @@ namespace PSXPrev.Common
                 for (var i = 0; i < value.Length; i++)
                 {
                     value[i].EntityName = "Sub-Model " + i;
+                    value[i].ParentEntity = this;
                 }
                 _childEntities = value;
             }

--- a/Common/Exporters/DAEExporter.cs
+++ b/Common/Exporters/DAEExporter.cs
@@ -341,12 +341,12 @@ namespace PSXPrev.Common.Exporters
                             }
 
                             // Color
-                            if (!_options.VertexIndexReuse || !colorIndices.TryGetValue(color.Vector, out var colorIndex))
+                            if (!_options.VertexIndexReuse || !colorIndices.TryGetValue((Vector3)color, out var colorIndex))
                             {
                                 if (_options.VertexIndexReuse)
                                 {
                                     colorIndex = colorIndices.Count;
-                                    colorIndices.Add(color.Vector, colorIndex);
+                                    colorIndices.Add((Vector3)color, colorIndex);
                                 }
                                 else
                                 {

--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -413,6 +413,33 @@ namespace PSXPrev.Common.Exporters
             _rootEntityModels.Clear();
         }
 
+        // Order by:
+        // 1. Texture pages:
+        //     i. Page:   lowest to highest
+        // 2. Loose textures:
+        //     i. Width:  highest to lowest
+        //    ii. Height: highest to lowest
+        //   iii. Page:   lowest to highest
+        private static int CompareTextures(Texture a, Texture b)
+        {
+            if (!a.IsVRAMPage || !b.IsVRAMPage)
+            {
+                if (a.IsVRAMPage != b.IsVRAMPage)
+                {
+                    return -a.IsVRAMPage.CompareTo(b.IsVRAMPage);
+                }
+                else if (a.Width != b.Width)
+                {
+                    return -a.Width.CompareTo(b.Width);
+                }
+                else if (a.Height != b.Height)
+                {
+                    return -a.Height.CompareTo(b.Height);
+                }
+            }
+            return a.TexturePage.CompareTo(b.TexturePage);
+        }
+
 
         private class SingleTextureInfo : IDisposable
         {
@@ -466,24 +493,7 @@ namespace PSXPrev.Common.Exporters
                     //     i. Width:  highest to lowest
                     //    ii. Height: highest to lowest
                     //   iii. Page:   lowest to highest
-                    OriginalTextures.Sort((a, b) => {
-                        if (!a.IsVRAMPage || !b.IsVRAMPage)
-                        {
-                            if (a.IsVRAMPage != b.IsVRAMPage)
-                            {
-                                return -a.IsVRAMPage.CompareTo(b.IsVRAMPage);
-                            }
-                            else if (a.Width != b.Width)
-                            {
-                                return -a.Width.CompareTo(b.Width);
-                            }
-                            else if (a.Height != b.Height)
-                            {
-                                return -a.Height.CompareTo(b.Height);
-                            }
-                        }
-                        return a.TexturePage.CompareTo(b.TexturePage);
-                    });
+                    OriginalTextures.Sort(CompareTextures);
                 }
 
                 // Pack multiple loose textures into single cells to reduce required space.

--- a/Common/Exporters/PLYExporter.cs
+++ b/Common/Exporters/PLYExporter.cs
@@ -154,12 +154,13 @@ namespace PSXPrev.Common.Exporters
                     var materialIndex = 0; // Only one material is defined
 
                     var worldMatrix = model.WorldMatrix;
+                    Matrix4.Invert(ref worldMatrix, out var invWorldMatrix);
                     foreach (var triangle in model.Triangles)
                     {
                         for (var j = 2; j >= 0; j--)
                         {
                             WriteVertex(triangle.Vertices[j], triangle.Normals[j], triangle.Uv[j], triangle.Colors[j],
-                                        materialIndex, ref worldMatrix);
+                                        materialIndex, ref worldMatrix, ref invWorldMatrix);
                         }
                     }
                 }
@@ -179,10 +180,10 @@ namespace PSXPrev.Common.Exporters
             _writer = null;
         }
 
-        private void WriteVertex(Vector3 localVertex, Vector3 localNormal, Vector2 uv, Color color, int materialIndex, ref Matrix4 worldMatrix)
+        private void WriteVertex(Vector3 localVertex, Vector3 localNormal, Vector2 uv, Color color, int materialIndex, ref Matrix4 worldMatrix, ref Matrix4 invWorldMatrix)
         {
             Vector3.TransformPosition(ref localVertex, ref worldMatrix, out var vertex);
-            Vector3.TransformNormal(ref localNormal, ref worldMatrix, out var normal);
+            GeomMath.TransformNormalInverseNormalized(ref localNormal, ref invWorldMatrix, out var normal);
 
             // Output UV (6 and 7) twice, since we're supporting two different names for it.
             // vertex X Y Z, normal X Y Z, uv U V S T, color R G B, material index

--- a/Common/Parsers/BFFParser.cs
+++ b/Common/Parsers/BFFParser.cs
@@ -450,10 +450,6 @@ namespace PSXPrev.Common.Parsers
             if (models.Count > 0)
             {
                 var entity = new RootEntity();
-                foreach (var model in models)
-                {
-                    model.ParentEntity = entity;
-                }
                 entity.ChildEntities = models.ToArray();
                 entity.ComputeBounds();
                 return entity;

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -59,10 +59,7 @@ namespace PSXPrev.Common.Parsers
             if (modelEntities.Count > 0)
             {
                 rootEntity = new RootEntity();
-                foreach (var modelEntity in modelEntities)
-                {
-                    modelEntity.ParentEntity = rootEntity;
-                }
+                rootEntity.ChildEntities = modelEntities.ToArray();
                 if (TextureResults.Count > 0)
                 {
                     foreach (var texture in TextureResults)
@@ -79,7 +76,6 @@ namespace PSXPrev.Common.Parsers
                     }
                     rootEntity.OwnedAnimations.AddRange(AnimationResults);
                 }
-                rootEntity.ChildEntities = modelEntities.ToArray();
                 rootEntity.ComputeBounds();
             }
             else
@@ -1057,7 +1053,7 @@ namespace PSXPrev.Common.Parsers
 
                 var coordID = reader.ReadUInt16();
                 var numDiffs = reader.ReadUInt16();
-                if (numDiffs > Program.MaxHMDMIMEeDiffs)
+                if (numDiffs > Program.MaxHMDMIMeDiffs)
                 {
                     return null;
                 }
@@ -1156,11 +1152,11 @@ namespace PSXPrev.Common.Parsers
 
                 var numOriginals = reader.ReadUInt16();
                 var numDiffs = reader.ReadUInt16();
-                if (numDiffs > Program.MaxHMDMIMEeDiffs)
+                if (numDiffs > Program.MaxHMDMIMeDiffs)
                 {
                     return null;
                 }
-                if (numOriginals > Program.MaxHMDMIMEeOriginals)
+                if (numOriginals > Program.MaxHMDMIMeOriginals)
                 {
                     return null;
                 }

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -304,10 +304,6 @@ namespace PSXPrev.Common.Parsers
             if (models.Count > 0)
             {
                 var entity = new RootEntity();
-                foreach (var model in models)
-                {
-                    model.ParentEntity = entity;
-                }
                 entity.ChildEntities = models.ToArray();
                 entity.ComputeBounds();
                 return entity;

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -184,10 +184,6 @@ namespace PSXPrev.Common.Parsers
             if (models.Count > 0)
             {
                 var entity = new RootEntity();
-                foreach (var model in models)
-                {
-                    model.ParentEntity = entity;
-                }
                 entity.ChildEntities = models.ToArray();
                 entity.ComputeBounds();
                 return entity;

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -407,10 +407,6 @@ namespace PSXPrev.Common.Parsers
             if (modelEntities.Count > 0)
             {
                 rootEntity = new RootEntity();
-                foreach (var modelEntity in modelEntities)
-                {
-                    modelEntity.ParentEntity = rootEntity;
-                }
                 rootEntity.ChildEntities = modelEntities.ToArray();
                 rootEntity.ComputeBounds();
             }

--- a/Common/Parsers/TMDParser.cs
+++ b/Common/Parsers/TMDParser.cs
@@ -231,10 +231,6 @@ namespace PSXPrev.Common.Parsers
             if (models.Count > 0)
             {
                 var entity = new RootEntity();
-                foreach (var model in models)
-                {
-                    model.ParentEntity = entity;
-                }
                 entity.ChildEntities = models.ToArray();
                 entity.ComputeBounds();
                 return entity;

--- a/Common/Renderer/Scene.cs
+++ b/Common/Renderer/Scene.cs
@@ -77,6 +77,7 @@ namespace PSXPrev.Common.Renderer
         public static int AttributeIndexTiledArea = 4;
         public static int AttributeIndexTexture = 5;
 
+        public static int UniformNormalMatrix;
         public static int UniformModelMatrix;
         public static int UniformMVPMatrix;
         public static int UniformLightDirection;
@@ -96,9 +97,10 @@ namespace PSXPrev.Common.Renderer
         public const string AttributeNameTiledArea = "in_TiledArea";
         public const string AttributeNameTexture = "mainTex";
 
-        public const string UniformNameModel = "modelMatrix";
-        public const string UniformNameMVPMatrix = "mvpMatrix";
-        public const string UniformNameLightDirection = "lightDirection";
+        public const string UniformNormalMatrixName = "normalMatrix";
+        public const string UniformModelMatrixName = "modelMatrix";
+        public const string UniformMVPMatrixName = "mvpMatrix";
+        public const string UniformLightDirectionName = "lightDirection";
         public const string UniformMaskColorName = "maskColor";
         public const string UniformAmbientColorName = "ambientColor";
         public const string UniformSolidColorName = "solidColor";
@@ -444,9 +446,10 @@ namespace PSXPrev.Common.Renderer
             {
                 throw new Exception(GetInfoLog());
             }
-            UniformModelMatrix = GL.GetUniformLocation(_shaderProgram, UniformNameModel);
-            UniformMVPMatrix = GL.GetUniformLocation(_shaderProgram, UniformNameMVPMatrix);
-            UniformLightDirection = GL.GetUniformLocation(_shaderProgram, UniformNameLightDirection);
+            UniformNormalMatrix = GL.GetUniformLocation(_shaderProgram, UniformNormalMatrixName);
+            UniformModelMatrix = GL.GetUniformLocation(_shaderProgram, UniformModelMatrixName);
+            UniformMVPMatrix = GL.GetUniformLocation(_shaderProgram, UniformMVPMatrixName);
+            UniformLightDirection = GL.GetUniformLocation(_shaderProgram, UniformLightDirectionName);
             UniformMaskColor = GL.GetUniformLocation(_shaderProgram, UniformMaskColorName);
             UniformAmbientColor = GL.GetUniformLocation(_shaderProgram, UniformAmbientColorName);
             UniformSolidColor = GL.GetUniformLocation(_shaderProgram, UniformSolidColorName);
@@ -524,9 +527,9 @@ namespace PSXPrev.Common.Renderer
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
             GL.UseProgram(_shaderProgram);
 
+            GL.Uniform3(UniformMaskColor, MaskColor.ToVector3());
+            GL.Uniform3(UniformAmbientColor, AmbientColor.ToVector3());
             GL.Uniform3(UniformLightDirection, _transformedLight);
-            GL.Uniform3(UniformMaskColor, MaskColor.R / 255f, MaskColor.G / 255f, MaskColor.B / 255f);
-            GL.Uniform3(UniformAmbientColor, AmbientColor.R / 255f, AmbientColor.G / 255f, AmbientColor.B / 255f);
             GL.Uniform1(UniformLightIntensity, LightIntensity);
 
 
@@ -609,7 +612,7 @@ namespace PSXPrev.Common.Renderer
         {
             _time += seconds;
             _timeDelta = seconds;
-            if (seconds != 0)
+            if (Initialized && seconds != 0)
             {
                 TimeChanged?.Invoke(this, EventArgs.Empty);
             }
@@ -688,6 +691,7 @@ namespace PSXPrev.Common.Renderer
             var blend = 1f;
             if (_lightRayVisible && _lightRayTimer >= LightRotationRayDelayTime)
             {
+                // Make things look ~fancy~ by fading out after the delay.
                 var fadeTime = _lightRayTimer - LightRotationRayDelayTime;
                 if (fadeTime >= LightRotationRayFadeTime)
                 {
@@ -1030,9 +1034,14 @@ namespace PSXPrev.Common.Renderer
             return distance * _cameraDistanceScalar;
         }
 
+        private float GetGizmoScale(Vector3 position)
+        {
+            return CameraDistanceFrom(position);
+        }
+
         public Matrix4 GetGizmoScaleMatrix(Vector3 position)
         {
-            return Matrix4.CreateScale(CameraDistanceFrom(position));
+            return Matrix4.CreateScale(GetGizmoScale(position));
         }
 
         public void ResetIntersection()

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -381,13 +381,14 @@ namespace PSXPrev.Forms
         private void _openTkControl_Resize(object sender, EventArgs e)
         {
             _openTkControl.MakeCurrent();
+            // Make sure to use ClientSize to exclude size added by the borders.
             if (_scene.Initialized)
             {
-                _scene.Resize(_openTkControl.Size.Width, _openTkControl.Size.Height);
+                _scene.Resize(_openTkControl.ClientSize.Width, _openTkControl.ClientSize.Height);
             }
             else
             {
-                _scene.Initialize(_openTkControl.Size.Width, _openTkControl.Size.Height);
+                _scene.Initialize(_openTkControl.ClientSize.Width, _openTkControl.ClientSize.Height);
             }
         }
 
@@ -649,7 +650,7 @@ namespace PSXPrev.Forms
                 // Reset scene batches
                 _scene.MeshBatch.Reset(0);
                 _scene.BoundsBatch.Reset(1);
-                _scene.TriangleOutlineBatch.Reset(1);
+                _scene.TriangleOutlineBatch.Reset(2);
                 _scene.DebugIntersectionsBatch.Reset(1);
                 _scene.SetDebugPickingRay(false);
 
@@ -1196,7 +1197,7 @@ namespace PSXPrev.Forms
 
         private void UpdateSelectedTriangle(bool updateMeshData = true)
         {
-            _scene.TriangleOutlineBatch.Reset(1);
+            _scene.TriangleOutlineBatch.Reset(2);
             if (_selectedTriangle != null)
             {
                 _scene.TriangleOutlineBatch.BindTriangleOutline(_selectedTriangle.Item1.WorldMatrix, _selectedTriangle.Item2);

--- a/Program.cs
+++ b/Program.cs
@@ -92,8 +92,8 @@ namespace PSXPrev
         public static ulong MaxHMDAnimSequenceSize = 20000;
         public static ulong MaxHMDAnimSequenceCount = 1024;
         public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
-        public static ulong MaxHMDMIMEeDiffs = 100;
-        public static ulong MaxHMDMIMEeOriginals = 100;
+        public static ulong MaxHMDMIMeDiffs = 100;
+        public static ulong MaxHMDMIMeOriginals = 100;
         public static ulong MaxHMDVertices = 5000;
         public static ulong MaxMODModels = 1000;
         public static ulong MaxMODVertices = 10000;
@@ -998,7 +998,7 @@ namespace PSXPrev
         private static bool ProcessFile(string file, List<Func<FileOffsetScanner>> parsers)
         {
             ResetFileProgress();
-            if (_options.AsyncFileScan)
+            if (_options.AsyncFileScan && parsers.Count > 1)
             {
                 if (WaitOnScanState())
                 {

--- a/Shaders/Shader.frag
+++ b/Shaders/Shader.frag
@@ -10,6 +10,7 @@ in float discardPixel;
 
 out vec4 out_Color;
 
+uniform mat3 normalMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 mvpMatrix;
 uniform vec3 lightDirection;

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -1,6 +1,6 @@
 ﻿#version 150
 in vec3 in_Position;
-in vec3 in_Color; 
+in vec3 in_Color;
 in vec3 in_Normal;
 in vec2 in_Uv;
 in vec4 in_TiledArea;
@@ -13,6 +13,7 @@ out float pass_NormalDotLight;
 out float pass_NormalLength;
 out float discardPixel;
 
+uniform mat3 normalMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 mvpMatrix;
 uniform vec3 lightDirection;
@@ -28,14 +29,28 @@ uniform sampler2D mainTex;
 
 const float discardValue = 100000000;
 
-void main(void) {	
-	gl_Position = mvpMatrix * vec4(in_Position, 1.0);
+void main(void) {
+	// Check for discarded vertices (coordinates match discardValue)
 	discardPixel = step(discardValue, in_Position.x);
-	vec3 normal = (modelMatrix * vec4(in_Normal, 0.0)).xyz;
-	pass_NormalDotLight = clamp(dot(normal, lightDirection), 0.0, 1.0) * lightIntensity;
+
+	// Process position
+	gl_Position = mvpMatrix * vec4(in_Position, 1.0);
+
+	// Process normal and directional lighting
 	pass_NormalLength = length(in_Normal);
+	vec3 normal = normalMatrix * in_Normal;
+	if (dot(normal, normal) != 0.0) {
+		normal = normalize(normal);
+		// todo: Should we preserve original normal length?
+		//normal *= pass_NormalLength;
+	}
+	pass_NormalDotLight = clamp(dot(normal, lightDirection), 0.0, 1.0) * lightIntensity;
+
+	// Process UVs
 	pass_Uv = in_Uv;
 	pass_TiledArea = in_TiledArea;
+
+	// Process color
 	pass_Ambient = vec4(ambientColor, 1.0);
 	if (colorMode == 0) {
 		pass_Color = vec4(in_Color, 1.0);


### PR DESCRIPTION
* Selected triangles now display red lines that represent each vertex's normals.
* normalMatrix is now passed to shader and used to transform normals that may have been non-uniformly scaled.
* Fix typo in HMD limits "MIMEe" should have been "MIMe".
* ParentEntity is now assigned when assigning ChildEntities.
* Parallel is no longer used to scan files if there's only one parser.
* Removed Color.Vector and replaced it with an explicit cast operator.
* Added GeomMath ToVector extensions for System.Drawing.Color.
* Added GeomMath.TransformNormal*Normalized functions to handle non-uniform scaling.
* Added GeomMath.TransformNormal* and TransformPosition functions that take ref arguments but output the result in the return value (for one-liners where normally we'd be taking up two lines to assign the value of result).
* Fixed Scene.Resize getting openTkControl's Size instead of ClientSize (the borders were being included).
* Added -1 to calculation for UnProject (this along with the above were causing Gizmo intersections to annoyingly be a few pixels off).
* Added GeomMath transform ray functions for use with non-axis-aligned boxes.
* Fixed GeomMath.CalculateNormal returning the negated normal instead.
* Added PropertyGrid-accessible properties for EntityBase Quaternion rotation.
* Added GeomMath SwapAxes functions, for use with axis-aligned drawing where the user can specify any of primary axis.