### PR TITLE
MeshBuilder shapes, Scene/MeshRender additions, future VibRibbon support

### DIFF
--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -372,6 +372,17 @@ namespace PSXPrev.Common
             throw new IndexOutOfRangeException(nameof(axis) + " must be between 0 and 2");
         }
 
+        // Double is used for precision, since Math.Round already returns a double.
+        public static float Snap(float x, double step)
+        {
+            return (float)(Math.Round(x / step) * step);
+        }
+
+        public static Vector3 Snap(Vector3 vector, double step)
+        {
+            return new Vector3(Snap(vector.X, step), Snap(vector.Y, step), Snap(vector.Z, step));
+        }
+
         public static int PositiveModulus(int x, int m)
         {
             var r = x % m;

--- a/Common/Line.cs
+++ b/Common/Line.cs
@@ -21,5 +21,18 @@ namespace PSXPrev.Common
             //Uv = EmptyUv;
             Colors = new[] { color0, color1 ?? color0 };
         }
+
+
+        public Triangle ToTriangle()
+        {
+            return new Triangle
+            {
+                Vertices = new[] { Vertices[0], Vertices[1], Vertices[1] },
+                Normals = Triangle.EmptyNormals,
+                Uv = Triangle.EmptyUv,
+                Colors = new[] { Colors[0], Colors[1], Colors[1] },
+                AttachableIndices = Triangle.EmptyAttachableIndices,
+            };
+        }
     }
 }

--- a/Common/ModelEntity.cs
+++ b/Common/ModelEntity.cs
@@ -19,6 +19,14 @@ namespace PSXPrev.Common
         [DisplayName("Mixture Rate")]
         public MixtureRate MixtureRate { get; set; }
 
+        public bool Visible { get; set; } = true;
+
+        // Debug render settings for testing, not for use with PlayStation models.
+        // Note: DebugMeshRenderInfo's TexturePage, RenderFlags, MixtureRate, and Visible are ignored.
+        [Browsable(false)]
+        public Renderer.MeshRenderInfo DebugMeshRenderInfo { get; set; }
+
+
         [DisplayName("Triangles"), ReadOnly(true)]
         public int TrianglesCount => Triangles.Length;
 
@@ -101,10 +109,8 @@ namespace PSXPrev.Common
         //[ReadOnly(true)]
         //public uint PrimitiveIndex { get; set; }
 
-        [Browsable(false)]
-        public int MeshIndex { get; set; }
-
-        public bool Visible { get; set; } = true;
+        //[Browsable(false)]
+        //public int MeshIndex { get; set; }
 
         [Browsable(false)]
         public float Interpolator { get; set; }
@@ -200,6 +206,18 @@ namespace PSXPrev.Common
                 vertex = Vector3.TransformPosition(vertex, TempWorldMatrix.Inverted());
             }
             return vertex;
+        }
+
+        private Vector3 ConnectNormal(EntityBase subModel, Vector3 normal)
+        {
+            // We only need to transform the vertex if it's not attached to the same model.
+            if (subModel != this)
+            {
+                // todo: Is the first normalize needed for if the first scale is non-uniform?
+                normal = GeomMath.TransformNormalNormalized(normal, subModel.TempWorldMatrix);
+                normal = GeomMath.TransformNormalNormalized(normal, TempWorldMatrix.Inverted());
+            }
+            return normal;
         }
 
         public override void FixConnections()

--- a/Common/RenderInfo.cs
+++ b/Common/RenderInfo.cs
@@ -16,7 +16,9 @@ namespace PSXPrev.Common
         Subdivision       = (1 << 6),
         AutomaticDivision = (1 << 7),
 
+        VibRibbon         = (1 << 16),
 
+        // Not PlayStation render flags
         NoAmbient         = (1 << 28),
 
         // Bits 29-31 are reserved for MixtureRate.
@@ -38,7 +40,8 @@ namespace PSXPrev.Common
     {
         // Use this mask when separating meshes by render info.
         public const RenderFlags SupportedFlags = RenderFlags.DoubleSided | RenderFlags.Unlit |
-                                                  RenderFlags.SemiTransparent | RenderFlags.Textured;
+                                                  RenderFlags.SemiTransparent | RenderFlags.Textured |
+                                                  RenderFlags.VibRibbon;
 
         public uint TexturePage { get; }
         public RenderFlags RenderFlags { get; }

--- a/Common/Renderer/LineMeshBuilder.cs
+++ b/Common/Renderer/LineMeshBuilder.cs
@@ -6,10 +6,116 @@ namespace PSXPrev.Common.Renderer
 {
     public class LineMeshBuilder : MeshRenderInfo
     {
-        public List<Line> Lines { get; } = new List<Line>();
+        public List<Line> Lines { get; }
 
         public int Count => Lines.Count;
 
+        public int Capacity
+        {
+            get => Lines.Capacity;
+            set => Lines.Capacity = value;
+        }
+
+
+        public LineMeshBuilder(MeshRenderInfo fromRenderInfo = null)
+        {
+            Lines = new List<Line>();
+            if (fromRenderInfo != null)
+            {
+                CopyFrom(fromRenderInfo);
+            }
+        }
+
+        // Does NOT copy Lines list, use IEnumerable overload for that.
+        public LineMeshBuilder(LineMeshBuilder fromLineBuilder)
+        {
+            Lines = new List<Line>();
+            if (fromLineBuilder != null)
+            {
+                CopyFrom(fromLineBuilder);
+            }
+        }
+
+        public LineMeshBuilder(int capacity, MeshRenderInfo fromRenderInfo = null)
+        {
+            Lines = new List<Line>(capacity);
+            if (fromRenderInfo != null)
+            {
+                CopyFrom(fromRenderInfo);
+            }
+        }
+
+        public LineMeshBuilder(int capacity, LineMeshBuilder fromLineBuilder)
+        {
+            Lines = new List<Line>(capacity);
+            if (fromLineBuilder != null)
+            {
+                CopyFrom(fromLineBuilder);
+            }
+        }
+
+        public LineMeshBuilder(IEnumerable<Line> lines, MeshRenderInfo fromRenderInfo = null)
+        {
+            Lines = new List<Line>(lines);
+            if (fromRenderInfo != null)
+            {
+                CopyFrom(fromRenderInfo);
+            }
+        }
+
+        public LineMeshBuilder(IEnumerable<Line> lines, LineMeshBuilder fromLineBuilder)
+        {
+            Lines = new List<Line>(lines);
+            if (fromLineBuilder != null)
+            {
+                CopyFrom(fromLineBuilder);
+            }
+        }
+
+        // Does NOT copy Lines list.
+        public void CopyFrom(LineMeshBuilder lineBuilder)
+        {
+            base.CopyFrom(lineBuilder);
+            // No extra settings to copy over yet
+        }
+
+
+        // Debug functions for testing built models in the PSXPrev scene viewer.
+        internal ModelEntity CreateModelEntity(Matrix4? modelMatrix = null)
+        {
+            var triangles = new Triangle[Lines.Count];
+            for (var i = 0; i < triangles.Length; i++)
+            {
+                triangles[i] = Lines[i].ToTriangle();
+            }
+            return new ModelEntity
+            {
+                TexturePage = TexturePage,
+                RenderFlags = RenderFlags | RenderFlags.VibRibbon,
+                MixtureRate = MixtureRate,
+                Visible = Visible,
+                DebugMeshRenderInfo = new MeshRenderInfo(this),
+                Triangles = triangles,
+                LocalMatrix = modelMatrix ?? Matrix4.Identity,
+            };
+        }
+
+        internal RootEntity CreateRootEntity(Matrix4? modelMatrix = null, string rootEntityName = null)
+        {
+            var modelEntity = CreateModelEntity(modelMatrix);
+            var rootEntity = new RootEntity
+            {
+                EntityName = rootEntityName ?? nameof(RootEntity),
+                ChildEntities = new EntityBase[] { modelEntity },
+            };
+            return rootEntity;
+        }
+
+
+        public void Clear()
+        {
+            Lines.Clear();
+        }
 
         public void AddLine(Line line)
         {
@@ -25,18 +131,15 @@ namespace PSXPrev.Common.Renderer
         {
             if (matrix.HasValue)
             {
-                vertex0 = Vector3.TransformPosition(vertex0, matrix.Value);
-                vertex1 = Vector3.TransformPosition(vertex1, matrix.Value);
+                var matrixValue = matrix.Value;
+                vertex0 = GeomMath.TransformPosition(ref vertex0, ref matrixValue);
+                vertex1 = GeomMath.TransformPosition(ref vertex1, ref matrixValue);
             }
             Lines.Add(new Line(vertex0, vertex1, color0, color1));
         }
 
         private void AddCorners(Vector3[] corners, Color color = null)
         {
-            if (color == null)
-            {
-                color = Color.White;
-            }
             AddLine(corners[0], corners[2], color);
             AddLine(corners[2], corners[4], color);
             AddLine(corners[4], corners[1], color);
@@ -51,7 +154,7 @@ namespace PSXPrev.Common.Renderer
             AddLine(corners[3], corners[0], color);
         }
 
-        public void AddBounds(BoundingBox bounds, Color color = null)
+        public void AddBoundsOutline(BoundingBox bounds, Color color = null)
         {
             if (bounds == null)
             {
@@ -60,7 +163,7 @@ namespace PSXPrev.Common.Renderer
             AddCorners(bounds.Corners, color);
         }
 
-        public void AddBounds(Matrix4? matrix, BoundingBox bounds, Color color = null)
+        public void AddBoundsOutline(Matrix4? matrix, BoundingBox bounds, Color color = null)
         {
             if (bounds == null)
             {
@@ -69,38 +172,103 @@ namespace PSXPrev.Common.Renderer
             var corners = bounds.Corners;
             if (matrix.HasValue)
             {
-                var newCorners = new Vector3[corners.Length];
-                for (var i = 0; i < corners.Length; i++)
+                var matrixValue = matrix.Value;
+
+                var newCorners = new Vector3[BoundingBox.CornerCount];
+                for (var i = 0; i < BoundingBox.CornerCount; i++)
                 {
-                    newCorners[i] = Vector3.TransformPosition(corners[i], matrix.Value);
+                    Vector3.TransformPosition(ref corners[i], ref matrixValue, out newCorners[i]);
                 }
                 corners = newCorners;
             }
             AddCorners(corners, color);
         }
 
-        public void AddCube(Vector3 center, Vector3 size, Color color = null)
+        // Size refers to the distance from the center to the corners.
+        public void AddCubeOutline(Vector3 center, Vector3 size, Color color = null)
         {
             var bounds = new BoundingBox();
             bounds.AddPoint(center - size);
             bounds.AddPoint(center + size);
-            AddBounds(bounds, color);
+            AddBoundsOutline(bounds, color);
         }
 
-        public void AddCube(Matrix4? matrix, Vector3 center, Vector3 size, Color color = null)
+        public void AddCubeOutline(Matrix4? matrix, Vector3 center, Vector3 size, Color color = null)
         {
             var bounds = new BoundingBox();
+            bounds.AddPoint(center - size);
+            bounds.AddPoint(center + size);
+            AddBoundsOutline(matrix, bounds, color);
+        }
+
+        // Size refers to the distance from the center to the corners.
+        public void AddRectangleOutline(int axis, Vector3 center, Vector2 size, Color color = null)
+        {
+            AddRectangleOutline(null, axis, center, size, color);
+        }
+
+        public void AddRectangleOutline(Matrix4? matrix, int axis, Vector3 center, Vector2 size, Color color = null)
+        {
+            var vertex0 = center + GeomMath.SwapAxes(axis, 0f,  size.X,  size.Y);
+            var vertex1 = center + GeomMath.SwapAxes(axis, 0f, -size.X,  size.Y);
+            var vertex2 = center + GeomMath.SwapAxes(axis, 0f, -size.X, -size.Y);
+            var vertex3 = center + GeomMath.SwapAxes(axis, 0f,  size.X, -size.Y);
+
             if (matrix.HasValue)
             {
-                bounds.AddPoint(Vector3.TransformPosition(center - size, matrix.Value));
-                bounds.AddPoint(Vector3.TransformPosition(center + size, matrix.Value));
+                var matrixValue = matrix.Value;
+
+                vertex0 = GeomMath.TransformPosition(ref vertex0, ref matrixValue);
+                vertex1 = GeomMath.TransformPosition(ref vertex1, ref matrixValue);
+                vertex2 = GeomMath.TransformPosition(ref vertex2, ref matrixValue);
+                vertex3 = GeomMath.TransformPosition(ref vertex3, ref matrixValue);
+            }
+
+            AddLine(vertex0, vertex1, color);
+            AddLine(vertex1, vertex2, color);
+            AddLine(vertex2, vertex3, color);
+            AddLine(vertex3, vertex0, color);
+        }
+
+        public void AddCircleOutline(int axis, Vector3 center, float radius, int sides, Color color = null)
+        {
+            AddCircleOutline(null, axis, center, radius, sides, color);
+        }
+
+        public void AddCircleOutline(Matrix4? matrix, int axis, Vector3 center, float radius, int sides, Color color = null)
+        {
+            var direction = GeomMath.SwapAxes(axis, 0f, 1f, 0f); // 0f, (float)Math.Cos(0f), (float)Math.Sin(0f));
+            var vertexLast = center + direction * radius;
+
+            Matrix4 matrixValue;
+            Matrix4 invMatrixValue;
+            if (matrix.HasValue)
+            {
+                matrixValue = matrix.Value;
+
+                vertexLast = GeomMath.TransformPosition(ref vertexLast, ref matrixValue);
             }
             else
             {
-                bounds.AddPoint(center - size);
-                bounds.AddPoint(center + size);
+                matrixValue = new Matrix4();
+                invMatrixValue = new Matrix4();
             }
-            AddBounds(bounds, color);
+
+            for (var i = 1; i <= sides; i++)
+            {
+                var theta = (Math.PI * 2d) * ((double)i / sides);
+                direction = GeomMath.SwapAxes(axis, 0f, (float)Math.Cos(theta), (float)Math.Sin(theta));
+                var vertex = center + direction * radius;
+
+                if (matrix.HasValue)
+                {
+                    vertex = GeomMath.TransformPosition(ref vertex, ref matrixValue);
+                }
+
+                AddLine(vertexLast, vertex, color);
+
+                vertexLast = vertex;
+            }
         }
 
         public void AddEntityBounds(EntityBase entity, Color color = null)
@@ -109,7 +277,7 @@ namespace PSXPrev.Common.Renderer
             {
                 return;
             }
-            AddBounds(entity.Bounds3D, color);
+            AddBoundsOutline(entity.Bounds3D, color);
         }
 
         public void AddTriangleOutline(Triangle triangle, Color color = null)
@@ -117,10 +285,6 @@ namespace PSXPrev.Common.Renderer
             if (triangle == null)
             {
                 return;
-            }
-            if (color == null)
-            {
-                color = Color.White;
             }
             var vertex0 = triangle.Vertices[0];
             var vertex1 = triangle.Vertices[1];
@@ -136,18 +300,20 @@ namespace PSXPrev.Common.Renderer
             {
                 return;
             }
-            if (color == null)
-            {
-                color = Color.White;
-            }
-            var vertex0 = triangle.Vertices[0];
-            var vertex1 = triangle.Vertices[1];
-            var vertex2 = triangle.Vertices[2];
+            Vector3 vertex0, vertex1, vertex2;
             if (matrix.HasValue)
             {
-                vertex0 = Vector3.TransformPosition(triangle.Vertices[0], matrix.Value);
-                vertex1 = Vector3.TransformPosition(triangle.Vertices[1], matrix.Value);
-                vertex2 = Vector3.TransformPosition(triangle.Vertices[2], matrix.Value);
+                var matrixValue = matrix.Value;
+
+                Vector3.TransformPosition(ref triangle.Vertices[0], ref matrixValue, out vertex0);
+                Vector3.TransformPosition(ref triangle.Vertices[1], ref matrixValue, out vertex1);
+                Vector3.TransformPosition(ref triangle.Vertices[2], ref matrixValue, out vertex2);
+            }
+            else
+            {
+                vertex0 = triangle.Vertices[0];
+                vertex1 = triangle.Vertices[1];
+                vertex2 = triangle.Vertices[2];
             }
             AddLine(vertex0, vertex1, color);
             AddLine(vertex1, vertex2, color);

--- a/Common/Renderer/MeshRenderInfo.cs
+++ b/Common/Renderer/MeshRenderInfo.cs
@@ -1,7 +1,13 @@
-﻿namespace PSXPrev.Common.Renderer
+﻿using System;
+using OpenTK;
+
+namespace PSXPrev.Common.Renderer
 {
     public class MeshRenderInfo
     {
+        public static readonly Vector3 DefaultLightDirection = -Vector3.UnitZ;
+        public static readonly Color DefaultAmbientColor = new Color(System.Drawing.Color.LightGray);
+
         public uint TexturePage { get; set; }
         public RenderFlags RenderFlags { get; set; }
         public MixtureRate MixtureRate { get; set; }
@@ -11,14 +17,59 @@
             get => _alpha;
             set => _alpha = GeomMath.Clamp(value, 0f, 1f);
         }
-        public float Thickness { get; set; } = 1f;
-        public Color SolidColor { get; set; }
+        private float _thickness = 1f;
+        public float Thickness
+        {
+            get => _thickness;
+            set => _thickness = Math.Max(0f, value);
+        }
+        public Vector3? LightDirection { get; set; } // Overrides Scene's or MeshBatch's light direction
+        public float? LightIntensity { get; set; } // Overrides Scene's or MeshBatch's light intensity
+        public Color AmbientColor { get; set; } // Overrides Scene's or MeshBatch's ambient color
+        public Color SolidColor { get; set; } // Overrides Mesh's vertex colors
         public bool Visible { get; set; } = true;
 
         public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
 
-        public bool IsOpaque => RenderInfo.IsOpaque(RenderFlags, MixtureRate, Alpha);
+        public bool IsOpaque => RenderInfo.IsOpaque(RenderFlags, MixtureRate, _alpha);
 
-        public bool IsSemiTransparent => RenderInfo.IsSemiTransparent(RenderFlags, MixtureRate, Alpha);
+        public bool IsSemiTransparent => RenderInfo.IsSemiTransparent(RenderFlags, MixtureRate, _alpha);
+
+
+        public MeshRenderInfo()
+        {
+        }
+
+        public MeshRenderInfo(MeshRenderInfo fromRenderInfo)
+        {
+            CopyFrom(fromRenderInfo);
+        }
+
+        public void CopyFrom(ModelEntity modelEntity)
+        {
+            if (modelEntity.DebugMeshRenderInfo != null)
+            {
+                CopyFrom(modelEntity.DebugMeshRenderInfo);
+            }
+            // Always use the settings built into ModelEntity over MeshRenderInfo.
+            TexturePage = modelEntity.TexturePage;
+            RenderFlags = modelEntity.RenderFlags;
+            MixtureRate = modelEntity.MixtureRate;
+            Visible     = modelEntity.Visible;
+        }
+
+        public void CopyFrom(MeshRenderInfo renderInfo)
+        {
+            TexturePage = renderInfo.TexturePage;
+            RenderFlags = renderInfo.RenderFlags;
+            MixtureRate = renderInfo.MixtureRate;
+            _alpha = renderInfo._alpha;
+            _thickness = renderInfo._thickness;
+            LightDirection = renderInfo.LightDirection;
+            LightIntensity = renderInfo.LightIntensity;
+            AmbientColor = renderInfo.AmbientColor;
+            SolidColor = renderInfo.SolidColor;
+            Visible = renderInfo.Visible;
+        }
     }
 }


### PR DESCRIPTION
* Added GeomMath.Snap to snap values to some multiple.
* Renamed PreviewForm.AlignToGrid to SnapToGrid, and added Vector3 overload.
* Added VibRibbon render flag, which can be used in the future to build triangles where only the first two vertices are used.
* When the VibRibbon flag is present or Scene.VibRibbonWireframe is on, ModelEntity meshes will be built into MeshDataType.Lines.
* Added LightDirection, LightIntensity, and AmbientColor options to MeshRenderInfo and MeshBatch, these can be used to override the scene's default settings. For example, the light rotation ray will always use the opposite light direction so that the face where the line comes out is lit up. This is also useful to have scene visuals that aren't completely ruined when setting the ambient color to black, or turning off lighting, when lighting might be useful to understand the visual.
* MeshRenderInfo.Thickness is now enforced to a minimum value of 0f.
* Fixed CubeNormals being reversed in TriangleMeshBuilder.
* Added new TriangleMeshBuilder and LineMeshBuilder shapes: Cylinder, Cone, Ring, Sphere (both standard and octahedron), RectangleOutline, and CircleOutline.
* Added AddTriangle function that takes 3 normals instead of just one.
* Added debug functions to MeshBuilders to create model entities and root entities for testing in the scene viewer.
* AddTriangle now allows a null color, which will default to White.
* Added delay timer to modelPropertyGrid refreshing if the selected object is unchanged. This prevents huge amounts of lag when using the mover gizmo.
* Fixed selected triangle moving to next triangle in the remembered list if the user unselected a triangle first.
* Gizmo mover now accounts for scale and rotation, however non-uniform scale with rotation is not accounted for...