### PR TITLE
Add rotate and scale gizmos

### DIFF
--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -64,6 +64,9 @@ namespace PSXPrev.Common
         }
 
         [Browsable(false)]
+        public Vector3 WorldOrigin => WorldMatrix.ExtractTranslation();
+
+        [Browsable(false)]
         public Matrix4 WorldMatrix
         {
             get

--- a/Common/Exporters/OBJExporter.cs
+++ b/Common/Exporters/OBJExporter.cs
@@ -124,7 +124,7 @@ namespace PSXPrev.Common.Exporters
             }
 
             var worldMatrix = model.WorldMatrix;
-            Matrix4.Invert(ref worldMatrix, out var invWorldMatrix);
+            GeomMath.InvertSafe(ref worldMatrix, out var invWorldMatrix);
             // Write vertex positions (and colors if experimental)
             foreach (var triangle in model.Triangles)
             {
@@ -207,7 +207,7 @@ namespace PSXPrev.Common.Exporters
         private void WriteGroup(int groupIndex, ref int vertexIndex, ref int uvIndex, ModelEntity model)
         {
             var worldMatrix = model.WorldMatrix;
-            Matrix4.Invert(ref worldMatrix, out var invWorldMatrix);
+            GeomMath.InvertSafe(ref worldMatrix, out var invWorldMatrix);
             var needsTexture = NeedsTexture(model);
             var materialName = _mtlExporter.GetMaterialName(_options.ExportTextures ? model.Texture : null);
 

--- a/Common/Exporters/PLYExporter.cs
+++ b/Common/Exporters/PLYExporter.cs
@@ -154,7 +154,7 @@ namespace PSXPrev.Common.Exporters
                     var materialIndex = 0; // Only one material is defined
 
                     var worldMatrix = model.WorldMatrix;
-                    Matrix4.Invert(ref worldMatrix, out var invWorldMatrix);
+                    GeomMath.InvertSafe(ref worldMatrix, out var invWorldMatrix);
                     foreach (var triangle in model.Triangles)
                     {
                         for (var j = 2; j >= 0; j--)

--- a/Common/Renderer/GizmoId.cs
+++ b/Common/Renderer/GizmoId.cs
@@ -1,10 +1,19 @@
 ﻿namespace PSXPrev.Common.Renderer
 {
+    public enum GizmoType
+    {
+        None,
+        Translate,
+        Rotate,
+        Scale,
+    }
+
     public enum GizmoId
     {
         None,
-        XMover,
-        YMover,
-        ZMover
+        AxisX,
+        AxisY,
+        AxisZ,
+        Uniform, // For Scale only
     }
 }

--- a/Common/Renderer/MeshBatch.cs
+++ b/Common/Renderer/MeshBatch.cs
@@ -683,8 +683,8 @@ namespace PSXPrev.Common.Renderer
             }
 
             var modelMatrix = mesh.WorldMatrix;
-            var normalMatrix = new Matrix3(modelMatrix);
-            normalMatrix.Invert();
+            // Use Inverted() since it checks determinant to avoid singular matrix exception.
+            var normalMatrix = new Matrix3(modelMatrix).Inverted();
             normalMatrix.Transpose();
             var mvpMatrix = modelMatrix * viewMatrix * projectionMatrix;
             GL.UniformMatrix3(Scene.UniformNormalMatrix, false, ref normalMatrix);

--- a/Common/Renderer/TriangleMeshBuilder.cs
+++ b/Common/Renderer/TriangleMeshBuilder.cs
@@ -208,7 +208,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 vertex0 = GeomMath.TransformPosition(ref vertex0, ref matrixValue);
                 vertex1 = GeomMath.TransformPosition(ref vertex1, ref matrixValue);
@@ -224,7 +224,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 vertex0 = GeomMath.TransformPosition(ref vertex0, ref matrixValue);
                 vertex1 = GeomMath.TransformPosition(ref vertex1, ref matrixValue);
@@ -269,7 +269,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 vertex0 = GeomMath.TransformPosition(ref vertex0, ref matrixValue);
                 vertex1 = GeomMath.TransformPosition(ref vertex1, ref matrixValue);
@@ -317,7 +317,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 var newCorners = new Vector3[BoundingBox.CornerCount];
                 var newNormals = new Vector3[BoundingBox.CornerCount];
@@ -392,7 +392,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 topBottomVertices[0] = GeomMath.TransformPosition(ref topBottomVertices[0], ref matrixValue);
                 topBottomVertices[1] = GeomMath.TransformPosition(ref topBottomVertices[1], ref matrixValue);
@@ -485,7 +485,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 for (var top = 0; top < 2; top++)
                 {
@@ -603,7 +603,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 for (var face = 0; face < 8; face++)
                 {
@@ -719,7 +719,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 var matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out var invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out var invMatrixValue);
 
                 for (var h = 0; h <= stacks; h++)
                 {
@@ -798,7 +798,7 @@ namespace PSXPrev.Common.Renderer
             if (matrix.HasValue)
             {
                 matrixValue = matrix.Value;
-                Matrix4.Invert(ref matrixValue, out invMatrixValue);
+                GeomMath.InvertSafe(ref matrixValue, out invMatrixValue);
 
                 vertexTop = GeomMath.TransformPosition(ref vertexTop, ref matrixValue);
                 vertexBottom = GeomMath.TransformPosition(ref vertexBottom, ref matrixValue);

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -1448,7 +1448,7 @@ namespace PSXPrev.Forms
             this.showUVToolStripMenuItem.Name = "showUVToolStripMenuItem";
             this.showUVToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.showUVToolStripMenuItem.Text = "Show UV";
-            this.showUVToolStripMenuItem.Click += new System.EventHandler(this.showUVToolStripMenuItem_Click);
+            this.showUVToolStripMenuItem.CheckedChanged += new System.EventHandler(this.showUVToolStripMenuItem_CheckedChanged);
             // 
             // animationsToolStripMenuItem
             // 


### PR DESCRIPTION
* GeomMath.InvertSafe should now be used instead of Matrix3 and Matrix4 Invert functions. This is because these functions will throw an exception if the matrix is singular (has a scale componenet of zero). Interestingly enough, the OpenTK matrix "InvertED" function DOES check the determinant to avoid this exception.
* Fixed ShowUV menu item not using CheckedChanged event, and also having its default state set to true.
* Added EntityBase.WorldOrigin property, which extracts its world translation.
* Added GeomMath.BoxIntersect2 which takes a center and size instead of min and max.
* Added and changed most GeomMath intersection functions. New functions are based off shadertoy examples found here: <https://iquilezles.org/articles/intersectors/>
* Added GeomMath.IsZero overload for Vector2.
* Added Scene WorldToScreenPoint and ScreenToWorldPoint.
* Added rotate and scale gizmos (can be changed by pressing Ctrl+G while the openTk control is focused, I'll add menu items later).
* Currently new gizmos only act based off the model's local transform. So using the X scale will only increase X scale, even if it's rotated 90deg. The same goes for the Translate gizmo, its rotation will now point towards the rotation of the parent model (functionally it already behaved this way, just not visually).
* Pressing right click while using a gizmo will cancel its action.
* Gizmo actions no longer accumulate change, but calculate change from the same start point every update, this means that you'll always get the same result at the same mouse position.
* Gizmo rotation is aligned where grid size = 1 -> 1 degree.
* Gizmo scale is aligned where grid size = 1 -> 0.05 scale.

![image](https://github.com/rickomax/psxprev/assets/9752430/bab88804-f97a-4539-ae83-e25a0e796898)
