### PR TITLE
Add Limits static class for storing parser limits/strictness

### DIFF
--- a/Common/Parsers/ANParser.cs
+++ b/Common/Parsers/ANParser.cs
@@ -63,12 +63,12 @@ namespace PSXPrev.Common.Parsers
 
             var version = reader.ReadByte();
             var numJoints = reader.ReadByte();
-            if (numJoints == 0 || numJoints > Program.MaxANJoints)
+            if (numJoints == 0 || numJoints > Limits.MaxANJoints)
             {
                 return null;
             }
             var numFrames = reader.ReadUInt16();
-            if (numFrames == 0 || numFrames > Program.MaxANFrames)
+            if (numFrames == 0 || numFrames > Limits.MaxANFrames)
             {
                 return null;
             }

--- a/Common/Parsers/HMDHelper.cs
+++ b/Common/Parsers/HMDHelper.cs
@@ -298,7 +298,7 @@ namespace PSXPrev.Common.Parsers
             reader.BaseStream.Seek(offset + ctrlTop, SeekOrigin.Begin);
 
             var instructionCount = (paramTop - ctrlTop) / 4;
-            if (instructionCount > Program.MaxHMDAnimInstructions)
+            if (instructionCount > Limits.MaxHMDAnimInstructions)
             {
                 return;
             }

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -21,7 +21,7 @@ namespace PSXPrev.Common.Parsers
         protected override void Parse(BinaryReader reader)
         {
             var version = reader.ReadUInt32();
-            if (Program.IgnoreHmdVersion || version == 0x00000050)
+            if (Limits.IgnoreHMDVersion || version == 0x00000050)
             {
                 var rootEntity = ParseHMD(reader);
                 if (rootEntity != null)
@@ -36,7 +36,7 @@ namespace PSXPrev.Common.Parsers
             var mapFlag = reader.ReadUInt32();
             var primitiveHeaderTop = reader.ReadUInt32() * 4;
             var blockCount = reader.ReadUInt32();
-            if (blockCount == 0 || blockCount > Program.MaxHMDBlockCount)
+            if (blockCount == 0 || blockCount > Limits.MaxHMDBlockCount)
             {
                 return null;
             }
@@ -89,7 +89,7 @@ namespace PSXPrev.Common.Parsers
             {
                 // Coord units start after the first (pre-process) block and end before the last (post-process) block.
                 // We need to allow at least blockCount - 2 coords, so only check the max cap if we're over that.
-                if (coordCount > Program.MaxHMDCoordCount)
+                if (coordCount > Limits.MaxHMDCoordCount)
                 {
                     return null;
                 }
@@ -224,7 +224,7 @@ namespace PSXPrev.Common.Parsers
             uint chainLength = 0;
             while (true)
             {
-                if (++chainLength > Program.MaxHMDPrimitiveChainLength)
+                if (++chainLength > Limits.MaxHMDPrimitiveChainLength)
                 {
                     return;
                 }
@@ -234,7 +234,7 @@ namespace PSXPrev.Common.Parsers
                 var primitiveHeaderPointer = reader.ReadUInt32() * 4;
                 ReadMappedValue(reader, out var typeCountMapped, out var typeCount);
                 // Note: typeCount==0 is valid.
-                if (typeCount > Program.MaxHMDTypeCount)
+                if (typeCount > Limits.MaxHMDTypeCount)
                 {
                     return;
                 }
@@ -259,11 +259,11 @@ namespace PSXPrev.Common.Parsers
                     ReadMappedValue16(reader, out var dataCountMapped, out var dataCount);
                     dataSize *= 4;
 
-                    if (dataSize == 0 || dataSize > Program.MaxHMDDataSize)
+                    if (dataSize == 0 || dataSize > Limits.MaxHMDDataSize)
                     {
                         return;
                     }
-                    if (dataCount > Program.MaxHMDDataCount)
+                    if (dataCount > Limits.MaxHMDDataCount)
                     {
                         return;
                     }
@@ -806,11 +806,11 @@ namespace PSXPrev.Common.Parsers
                 ReadMappedValue16(reader, out _, out var sequenceCount);
                 sequenceSize *= 4;
 
-                if (sequenceSize == 0 || sequenceSize > Program.MaxHMDAnimSequenceSize)
+                if (sequenceSize == 0 || sequenceSize > Limits.MaxHMDAnimSequenceSize)
                 {
                     return null;
                 }
-                if (sequenceCount > Program.MaxHMDAnimSequenceCount)
+                if (sequenceCount > Limits.MaxHMDAnimSequenceCount)
                 {
                     return null;
                 }
@@ -1053,7 +1053,7 @@ namespace PSXPrev.Common.Parsers
 
                 var coordID = reader.ReadUInt16();
                 var numDiffs = reader.ReadUInt16();
-                if (numDiffs > Program.MaxHMDMIMeDiffs)
+                if (numDiffs > Limits.MaxHMDMIMeDiffs)
                 {
                     return null;
                 }
@@ -1152,11 +1152,11 @@ namespace PSXPrev.Common.Parsers
 
                 var numOriginals = reader.ReadUInt16();
                 var numDiffs = reader.ReadUInt16();
-                if (numDiffs > Program.MaxHMDMIMeDiffs)
+                if (numDiffs > Limits.MaxHMDMIMeDiffs)
                 {
                     return null;
                 }
-                if (numOriginals > Program.MaxHMDMIMeOriginals)
+                if (numOriginals > Limits.MaxHMDMIMeOriginals)
                 {
                     return null;
                 }
@@ -1180,7 +1180,7 @@ namespace PSXPrev.Common.Parsers
                     var vertexStart = reader.ReadUInt32();
                     reader.ReadUInt16(); //reserved
                     var vertexCount = reader.ReadUInt16();
-                    if (vertexCount + vertexStart == 0 || vertexCount + vertexStart >= Program.MaxHMDVertices)
+                    if (vertexCount + vertexStart == 0 || vertexCount + vertexStart >= Limits.MaxHMDVertices)
                     {
                         return null;
                     }
@@ -1577,10 +1577,10 @@ namespace PSXPrev.Common.Parsers
 
             var headerSize = reader.ReadUInt32();
             var animHeaderSize = reader.ReadUInt32();
-            if (animHeaderSize > Program.MaxHMDHeaderLength)
+            if (animHeaderSize > Limits.MaxHMDHeaderLength)
             {
                 // todo: We aren't setup to signal failure in this function, so just correct the issue.
-                animHeaderSize = (uint)Program.MaxHMDHeaderLength;
+                animHeaderSize = (uint)Limits.MaxHMDHeaderLength;
             }
             if (animHeaderSize > headerSize)
             {

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -1,0 +1,49 @@
+﻿namespace PSXPrev.Common.Parsers
+{
+    public static class Limits
+    {
+        // Strictness settings
+        public static bool IgnoreHMDVersion;
+        public static bool IgnoreTIMVersion;
+        public static bool IgnoreTMDVersion;
+
+        // Sanity check values
+        public static uint MaxANJoints = 512;
+        public static uint MaxANFrames = 5000;
+
+        public static ulong MaxHMDBlockCount = 1024;
+        public static ulong MaxHMDCoordCount = 1024; // Same as BlockCount, because they're related
+        public static ulong MaxHMDTypeCount = 1024;
+        public static ulong MaxHMDDataSize = 20000;
+        public static ulong MaxHMDDataCount = 5000;
+        public static ulong MaxHMDPrimitiveChainLength = 512;
+        public static ulong MaxHMDHeaderLength = 100;
+        public static ulong MinHMDStripMeshLength = 1;
+        public static ulong MaxHMDStripMeshLength = 1024;
+        public static ulong MaxHMDAnimSequenceSize = 20000;
+        public static ulong MaxHMDAnimSequenceCount = 1024;
+        public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
+        public static ulong MaxHMDMIMeDiffs = 100;
+        public static ulong MaxHMDMIMeOriginals = 100;
+        public static ulong MaxHMDVertices = 5000;
+
+        public static ulong MaxMODModels = 1000;
+        public static ulong MaxMODVertices = 10000;
+        public static ulong MaxMODFaces = 10000;
+
+        public static ulong MaxPSXObjectCount = 1024;
+
+        public static ulong MaxTIMResolution = 1024;
+
+        public static ulong MaxTMDPrimitives = 10000;
+        public static ulong MaxTMDObjects = 10000;
+
+        public static ulong MaxTODPackets = 10000;
+        public static ulong MaxTODFrames = 10000;
+
+        public static ulong MinVDFFrames = 3;
+        public static ulong MaxVDFFrames = 512;
+        public static ulong MaxVDFVertices = 1024;
+        public static ulong MaxVDFObjects = 512;
+    }
+}

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -71,7 +71,7 @@ namespace PSXPrev.Common.Parsers
             // This may be handled by another file...
 
             var count = reader.ReadUInt16();
-            if (count == 0 || count > Program.MaxMODModels)
+            if (count == 0 || count > Limits.MaxMODModels)
             {
                 return null;
             }
@@ -93,7 +93,7 @@ namespace PSXPrev.Common.Parsers
 
                 // See notes by countFaces.
                 var countVerts = reader.ReadUInt32();
-                if (countVerts > Program.MaxMODVertices)
+                if (countVerts > Limits.MaxMODVertices)
                 {
                     return null;
                 }
@@ -121,7 +121,7 @@ namespace PSXPrev.Common.Parsers
                     // we can check this now to set the capacity of triangles without wasting memory.
                     return null;
                 }
-                if (countFaces > Program.MaxMODFaces)
+                if (countFaces > Limits.MaxMODFaces)
                 {
                     return null;
                 }

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -65,7 +65,7 @@ namespace PSXPrev.Common.Parsers
             }
             var metaPtr = reader.ReadUInt32(); //todo: read meta
             var objectCount = reader.ReadUInt32();
-            if (objectCount == 0 || objectCount > Program.MaxPSXObjectCount)
+            if (objectCount == 0 || objectCount > Limits.MaxPSXObjectCount)
             {
                 return null;
             }
@@ -86,7 +86,7 @@ namespace PSXPrev.Common.Parsers
                 objectModels[i] = new PSXModel(x, y, z, modelIndex);
             }
             var modelCount = reader.ReadUInt32();
-            if (modelCount == 0 || modelCount > Program.MaxPSXObjectCount)
+            if (modelCount == 0 || modelCount > Limits.MaxPSXObjectCount)
             {
                 return null;
             }

--- a/Common/Parsers/TIMParser.cs
+++ b/Common/Parsers/TIMParser.cs
@@ -21,7 +21,7 @@ namespace PSXPrev.Common.Parsers
             if (id == 0x10)
             {
                 var version = reader.ReadUInt16();
-                if (Program.IgnoreTimVersion || version == 0x00)
+                if (Limits.IgnoreTIMVersion || version == 0x00)
                 {
                     var texture = ParseTim(reader);
                     if (texture != null)
@@ -149,7 +149,7 @@ namespace PSXPrev.Common.Parsers
             Bitmap bitmap = null;
             Bitmap semiTransparentMap = null;
 
-            if (imgWidth == 0 || imgHeight == 0 || imgWidth > Program.MaxTIMResolution || imgHeight > Program.MaxTIMResolution)
+            if (imgWidth == 0 || imgHeight == 0 || imgWidth > Limits.MaxTIMResolution || imgHeight > Limits.MaxTIMResolution)
             {
                 return null;
             }

--- a/Common/Parsers/TMDHelper.cs
+++ b/Common/Parsers/TMDHelper.cs
@@ -223,11 +223,11 @@ namespace PSXPrev.Common.Parsers
                 // For now, don't check the lower bounds of meshLength.
                 // It's possible that 0 is treated as 1 because its not accounted for.
                 // And note that SetMeshLength already ensures length is at least 1.
-                //if (meshLength < Program.MinHMDStripMeshLength)
+                //if (meshLength < Limits.MinHMDStripMeshLength)
                 //{
                 //    return null;
                 //}
-                if (meshLength > Program.MaxHMDStripMeshLength)
+                if (meshLength > Limits.MaxHMDStripMeshLength)
                 {
                     return null;
                 }

--- a/Common/Parsers/TMDParser.cs
+++ b/Common/Parsers/TMDParser.cs
@@ -17,7 +17,7 @@ namespace PSXPrev.Common.Parsers
         protected override void Parse(BinaryReader reader)
         {
             var version = reader.ReadUInt32();
-            if (Program.IgnoreTmdVersion || version == 0x00000041)
+            if (Limits.IgnoreTMDVersion || version == 0x00000041)
             {
                 var rootEntity = ParseTmd(reader);
                 if (rootEntity != null)
@@ -36,7 +36,7 @@ namespace PSXPrev.Common.Parsers
             }
 
             var nObj = reader.ReadUInt32();
-            if (nObj == 0 || nObj > Program.MaxTMDObjects)
+            if (nObj == 0 || nObj > Limits.MaxTMDObjects)
             {
                 return null;
             }
@@ -64,7 +64,7 @@ namespace PSXPrev.Common.Parsers
                     primitiveTop += objTop;
                 }
 
-                if (nPrimitive > Program.MaxTMDPrimitives)
+                if (nPrimitive > Limits.MaxTMDPrimitives)
                 {
                     return null;
                 }
@@ -86,7 +86,7 @@ namespace PSXPrev.Common.Parsers
                 var objBlock = objBlocks[o];
 
                 var vertices = new Vector3[objBlock.NVert];
-                if (Program.IgnoreTmdVersion && (int)objBlock.VertTop < 0)
+                if (Limits.IgnoreTMDVersion && (int)objBlock.VertTop < 0)
                 {
                     return null;
                 }
@@ -114,7 +114,7 @@ namespace PSXPrev.Common.Parsers
                 }
 
                 var normals = new Vector3[objBlock.NNormal];
-                if (Program.IgnoreTmdVersion && (int)objBlock.NormalTop < 0)
+                if (Limits.IgnoreTMDVersion && (int)objBlock.NormalTop < 0)
                 {
                     return null;
                 }
@@ -143,7 +143,7 @@ namespace PSXPrev.Common.Parsers
 
                 var groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
 
-                if (Program.IgnoreTmdVersion && (int)objBlock.PrimitiveTop < 0)
+                if (Limits.IgnoreTMDVersion && (int)objBlock.PrimitiveTop < 0)
                 {
                     return null;
                 }
@@ -172,7 +172,7 @@ namespace PSXPrev.Common.Parsers
                                     {
                                         if (index >= vertices.Length)
                                         {
-                                            if (Program.IgnoreTmdVersion)
+                                            if (Limits.IgnoreTMDVersion)
                                             {
                                                 return new Vector3(index, 0, 0);
                                             }
@@ -188,7 +188,7 @@ namespace PSXPrev.Common.Parsers
                                     {
                                         if (index >= normals.Length)
                                         {
-                                            if (Program.IgnoreTmdVersion)
+                                            if (Limits.IgnoreTMDVersion)
                                             {
                                                 return new Vector3(index, 0, 0);
                                             }

--- a/Common/Parsers/TODParser.cs
+++ b/Common/Parsers/TODParser.cs
@@ -64,7 +64,7 @@ namespace PSXPrev.Common.Parsers
             var version = reader.ReadByte();
             var resolution = reader.ReadUInt16();
             var frameCount = reader.ReadUInt32();
-            if (frameCount == 0 || frameCount > Program.MaxTODFrames)
+            if (frameCount == 0 || frameCount > Limits.MaxTODFrames)
             {
                 return null;
             }
@@ -77,7 +77,7 @@ namespace PSXPrev.Common.Parsers
                 var framePosition = reader.BaseStream.Position;
                 var frameSize = reader.ReadUInt16();
                 var packetCount = reader.ReadUInt16();
-                if (packetCount > Program.MaxTODPackets)
+                if (packetCount > Limits.MaxTODPackets)
                 {
                     return null;
                 }

--- a/Common/Parsers/VDFParser.cs
+++ b/Common/Parsers/VDFParser.cs
@@ -56,7 +56,7 @@ namespace PSXPrev.Common.Parsers
             }
 
             var frameCount = reader.ReadUInt32();
-            if (frameCount < Program.MinVDFFrames || frameCount > Program.MaxVDFFrames)
+            if (frameCount < Limits.MinVDFFrames || frameCount > Limits.MaxVDFFrames)
             {
                 return null;
             }
@@ -72,7 +72,7 @@ namespace PSXPrev.Common.Parsers
             for (uint f = 0; f < frameCount; f++)
             {
                 var objectId = reader.ReadUInt32();
-                if (objectId > Program.MaxVDFObjects)
+                if (objectId > Limits.MaxVDFObjects)
                 {
                     return null;
                 }
@@ -83,7 +83,7 @@ namespace PSXPrev.Common.Parsers
                 var vertexOffset = reader.ReadUInt32();
                 var skippedVertices = vertexOffset / 8;
                 var vertexCount = reader.ReadUInt32();
-                if (vertexCount + skippedVertices == 0 || vertexCount + skippedVertices > Program.MaxVDFVertices)
+                if (vertexCount + skippedVertices == 0 || vertexCount + skippedVertices > Limits.MaxVDFVertices)
                 {
                     return null;
                 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Common\Parsers\FileOffsetStream.cs" />
     <Compile Include="Common\Parsers\HMDHelper.cs" />
     <Compile Include="Common\Parsers\HMDParser.cs" />
+    <Compile Include="Common\Parsers\Limits.cs" />
     <Compile Include="Common\Parsers\MODParser.cs" />
     <Compile Include="Common\Parsers\PMDParser.cs" />
     <Compile Include="Common\Parsers\PrimitiveData.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -59,9 +59,6 @@ namespace PSXPrev
         public static bool HasTextureResults => _allTextures.Count > 0;
         public static bool HasAnimationResults => _allAnimations.Count > 0;
 
-        public static bool IgnoreHmdVersion => _options.IgnoreHMDVersion;
-        public static bool IgnoreTimVersion => _options.IgnoreTIMVersion;
-        public static bool IgnoreTmdVersion => _options.IgnoreTMDVersion;
         public static bool FixUVAlignment => _options.FixUVAlignment;
 
         public static bool Debug => _options.Debug;
@@ -70,38 +67,6 @@ namespace PSXPrev
 
         private static readonly string[] InvalidFileExtensions = { ".str", ".str;1", ".xa", ".xa;1", ".vb", ".vb;1" };
         private static readonly string[] ISOFileExtensions = { ".iso" };
-
-        // Sanity check values
-        public static ulong MaxTODPackets = 10000;
-        public static ulong MaxTODFrames = 10000;
-        public static ulong MaxTMDPrimitives = 10000;
-        public static ulong MaxTMDObjects = 10000;
-        public static ulong MaxTIMResolution = 1024;
-        public static ulong MinVDFFrames = 3;
-        public static ulong MaxVDFFrames = 512;
-        public static ulong MaxVDFVertices = 1024;
-        public static ulong MaxVDFObjects = 512;
-        public static ulong MaxPSXObjectCount = 1024;
-        public static ulong MaxHMDBlockCount = 1024;
-        public static ulong MaxHMDCoordCount = 1024; // Same as BlockCount, because they're related
-        public static ulong MaxHMDTypeCount = 1024;
-        public static ulong MaxHMDDataSize = 20000;
-        public static ulong MaxHMDDataCount = 5000;
-        public static ulong MaxHMDPrimitiveChainLength = 512;
-        public static ulong MaxHMDHeaderLength = 100;
-        public static ulong MinHMDStripMeshLength = 1;
-        public static ulong MaxHMDStripMeshLength = 1024;
-        public static ulong MaxHMDAnimSequenceSize = 20000;
-        public static ulong MaxHMDAnimSequenceCount = 1024;
-        public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
-        public static ulong MaxHMDMIMeDiffs = 100;
-        public static ulong MaxHMDMIMeOriginals = 100;
-        public static ulong MaxHMDVertices = 5000;
-        public static ulong MaxMODModels = 1000;
-        public static ulong MaxMODVertices = 10000;
-        public static ulong MaxMODFaces = 10000;
-        public static uint MaxANJoints = 512;
-        public static uint MaxANFrames = 5000;
 
 
         // This attribute is necessary since PreviewForm now runs on the main thread.
@@ -608,6 +573,11 @@ namespace PSXPrev
                 Program.Logger.WriteErrorLine($"Directory/File not found: {options.Path}");
                 return false;
             }
+
+            // Assign parser settings that are no longer stored in Program
+            Limits.IgnoreHMDVersion = options.IgnoreHMDVersion;
+            Limits.IgnoreTIMVersion = options.IgnoreTIMVersion;
+            Limits.IgnoreTMDVersion = options.IgnoreTMDVersion;
 
             _options = options;
             _scanning = true;


### PR DESCRIPTION
* Added Parsers/Limits.cs, which now stores IgnoreVersion strictness, and all Min/Max limits for parsers.
* Program now needs to assign IgnoreVersion Limits during start of scan, since it's no longer fetching them from _options.