### PR TITLE
Move AnimationBatch out of Scene

### DIFF
--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -143,6 +143,7 @@ namespace PSXPrev.Common.Animator
         {
             _scene = scene;
             _lastRootEntity = new WeakReference<RootEntity>(null);
+            Invalidate();
         }
 
 
@@ -181,7 +182,8 @@ namespace PSXPrev.Common.Animator
 
         public void SetupAnimationBatch(Animation animation, bool simulate = false)
         {
-            if (!simulate)
+            // Support using AnimationBatch even if we have no Scene.
+            if (!simulate && _scene != null)
             {
                 // todo: Is this correct for handling reseting the mesh batch?
                 // What if the animation doesn't match the object?
@@ -203,7 +205,8 @@ namespace PSXPrev.Common.Animator
         {
             var rootEntity = selectedRootEntity ?? selectedModelEntity?.GetRootEntity();
 
-            if (!simulate)
+            // Support using AnimationBatch even if we have no Scene.
+            if (!simulate && _scene != null)
             {
                 _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, selectedModelEntity, selectedRootEntity, updateMeshData || _scene.AutoAttach, false, true);
             }

--- a/Common/Renderer/Scene.cs
+++ b/Common/Renderer/Scene.cs
@@ -189,7 +189,6 @@ namespace PSXPrev.Common.Renderer
         public MeshBatch LightRotationRayBatch { get; private set; }
         public MeshBatch DebugPickingRayBatch { get; private set; }
         public MeshBatch DebugIntersectionsBatch { get; private set; }
-        public AnimationBatch AnimationBatch { get; private set; }
         public TextureBinder TextureBinder { get; private set; }
 
         public event EventHandler CameraChanged;
@@ -464,16 +463,15 @@ namespace PSXPrev.Common.Renderer
                 LightIntensity = 1f,
             };
             DebugIntersectionsBatch = new MeshBatch(this);
-            AnimationBatch = new AnimationBatch(this);
 
-            TimeChanged += (sender, args) => {
+            TimeChanged += (sender, e) => {
                 if (ShowVisuals && ShowLightRotationRay && LightRotationRayBatch.Visible)
                 {
                     _lightRayTimer += _timeDelta;
                     UpdateLightRotationRay();
                 }
             };
-            LightChanged += (sender, args) => {
+            LightChanged += (sender, e) => {
                 if (ShowVisuals && ShowLightRotationRay)
                 {
                     _lightRayTimer = 0d; // Show light rotation ray and reset timer
@@ -481,7 +479,7 @@ namespace PSXPrev.Common.Renderer
                     UpdateLightRotationRay();
                 }
             };
-            CameraChanged += (sender, args) => {
+            CameraChanged += (sender, e) => {
                 UpdateLightRotationRay();
                 UpdateDebugPickingRay();
                 UpdateGizmoVisual(_gizmoEntity, _currentGizmoType, _highlightGizmo);

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -78,6 +78,23 @@ namespace PSXPrev.Common.Renderer
             Initialized = true;
         }
 
+        public void AssignModelTextures(RootEntity rootEntity)
+        {
+            foreach (ModelEntity model in rootEntity.ChildEntities)
+            {
+                AssignModelTextures(model);
+            }
+        }
+
+        public void AssignModelTextures(ModelEntity model)
+        {
+            model.TexturePage = ClampTexturePage(model.TexturePage);
+            if (model.IsTextured)
+            {
+                model.Texture = _vramPages[model.TexturePage];
+            }
+        }
+
         // Gets if a page has had at least one texture drawn to it.
         public bool IsPageUsed(uint index) => IsPageUsed((int)index);
 
@@ -101,7 +118,8 @@ namespace PSXPrev.Common.Renderer
         {
             if (force || _modifiedPages[index])
             {
-                _scene.UpdateTexture(_vramPages[index].Bitmap, index);
+                // Support using VRAM even if we have no Scene.
+                _scene?.UpdateTexture(_vramPages[index].Bitmap, index);
                 _modifiedPages[index] = false;
                 return true;
             }


### PR DESCRIPTION
* Moved AnimationBatch out of Scene, because Scene doesn't ever use it. Instead, PreviewForm now has _animationBatch. The reason AnimationBatch should be moved is because it's not directly tied to the renderer, and even has usage outside of rendering (with exporting). The only ties it has to Scene is resetting and setting up MeshBatch, and that could theoretically be moved out if needed.
* Added VRAM.AssignModelTextures in-place of manually assigning textures to models in PreviewForm.
* Both AnimationBatch and VRAM can now operate even if scene passed in the constructor is null. This is because they have utility outside of just being used for the renderer.
* AnimationBatch now calls Invalidate in its constructor, to ensure the first frame is always processed.