### PR TITLE
Basic HMD MIMe joint animation support

### DIFF
--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -166,13 +166,13 @@ namespace PSXPrev.Common.Animator
             Time += seconds;
         }
 
-        public void SetTimeToFrame(AnimationFrame frame)
+        public void SetTimeToFrame(AnimationFrame frame, bool endOfFrame = false)
         {
             var timeMultiplier = FPS * Math.Abs(frame.AnimationObject.Speed);
             if (timeMultiplier != 0)
             {
                 //const double EPSILON = 0.0001d;
-                Time = (frame.FrameEnd - EPSILON) / timeMultiplier;
+                Time = (!endOfFrame ? frame.FrameTime : (frame.FrameEnd - EPSILON)) / timeMultiplier;
             }
             else
             {

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -65,7 +65,6 @@ namespace PSXPrev.Common
 
         public static void TransformNormalInverseNormalized(ref Vector3 normal, ref Matrix4 invMatrix, out Vector3 result)
         {
-            Vector3.TransformPosition(Vector3.Zero, Matrix4.Zero);
             Vector3.TransformNormalInverse(ref normal, ref invMatrix, out result);
             if (!result.IsZero())
             {
@@ -632,6 +631,11 @@ namespace PSXPrev.Common
         public static float Snap(float x, double step)
         {
             return (float)(Math.Round(x / step) * step);
+        }
+
+        public static double Snap(double x, double step)
+        {
+            return (Math.Round(x / step) * step);
         }
 
         public static Vector3 Snap(Vector3 vector, double step)

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -23,7 +23,8 @@
         public static ulong MaxHMDAnimSequenceSize = 20000;
         public static ulong MaxHMDAnimSequenceCount = 1024;
         public static ulong MaxHMDAnimInstructions = ushort.MaxValue + 1; // Hard cap
-        public static ulong MaxHMDMIMeDiffs = 100;
+        public static ulong MaxHMDAnimInterpolationTypes = 128; // Hard cap
+        public static ulong MaxHMDMIMeKeys = 32;
         public static ulong MaxHMDMIMeOriginals = 100;
         public static ulong MaxHMDVertices = 5000;
 
@@ -35,6 +36,7 @@
 
         public static ulong MaxTIMResolution = 1024;
 
+        public static ulong MaxTMDVertices = 20000; // Also used for normals
         public static ulong MaxTMDPrimitives = 10000;
         public static ulong MaxTMDObjects = 10000;
 

--- a/Common/Parsers/TMDParser.cs
+++ b/Common/Parsers/TMDParser.cs
@@ -64,6 +64,10 @@ namespace PSXPrev.Common.Parsers
                     primitiveTop += objTop;
                 }
 
+                if (nVert > Limits.MaxTMDVertices || nNormal > Limits.MaxTMDVertices)
+                {
+                    return null;
+                }
                 if (nPrimitive > Limits.MaxTMDPrimitives)
                 {
                     return null;


### PR DESCRIPTION
* Added basic support for HMD MIMe Joint and RPY (Roll Pitch Yaw) animations. Added notes for MIMe Vertex Normal about what is incorrect.
* Changed some HMD header parsing to treat more values as optional. For example, coordTop was missing from NonShared(?) header once.
* Added helper function to print HMD animation interpolation types used in an instruction set.
* Added Limits.MaxTMDVertices for use with TMDParser NVert and NNormal.
* AnimationBatch.SetTimeToFrame now defaults to setting the time to the start of the frame, but has an optional parameter to use the end of the frame instead.
* Added GeomMath.Snap double x overload.
* Removed leftover function call in GeomMath that was only used to look up references in Visual Studio.