### PR TITLE
Experimental TMD StraightLine and Sprite support

### DIFF
--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -484,6 +484,7 @@ namespace PSXPrev.Common.Parsers
                     sharedVertices.Clear();
                     sharedNormals.Clear();
                 }
+                model.ComputeAttachedOnly();
                 modelEntities.Add(model);
             }
             if (sharedVertices.Count > 0 || sharedNormals.Count > 0)

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -399,6 +399,7 @@ namespace PSXPrev.Common.Parsers
                             TMDID = psxModel.ModelIndex, //todo
                             OriginalLocalMatrix = Matrix4.CreateTranslation(psxModel.X, psxModel.Y, psxModel.Z)
                         };
+                        model.ComputeAttachedOnly();
                         modelEntities.Add(model);
                     }
                 }

--- a/Common/Parsers/PrimitiveData.cs
+++ b/Common/Parsers/PrimitiveData.cs
@@ -290,6 +290,8 @@ namespace PSXPrev.Common.Parsers
                     return 1;
                 case PrimitiveDataType.CBA:
                 case PrimitiveDataType.TSB:
+                case PrimitiveDataType.W:
+                case PrimitiveDataType.H:
                 case PrimitiveDataType.VERTEX0:
                 case PrimitiveDataType.VERTEX1:
                 case PrimitiveDataType.VERTEX2:

--- a/Common/Parsers/PrimitiveDataType.cs
+++ b/Common/Parsers/PrimitiveDataType.cs
@@ -27,6 +27,8 @@
         // 2 bytes:
         CBA,
         TSB,
+        W,
+        H,
         VERTEX0,
         VERTEX1,
         VERTEX2,

--- a/Common/RenderInfo.cs
+++ b/Common/RenderInfo.cs
@@ -16,7 +16,10 @@ namespace PSXPrev.Common
         Subdivision       = (1 << 6),
         AutomaticDivision = (1 << 7),
 
-        VibRibbon         = (1 << 16),
+        // Also known as VibRibbon (only use Vertex0 and Vertex1).
+        Line              = (1 << 16),
+        // Always face the camera (assumes direction is (0, 0, -1), so X and Y components should be used for size).
+        Sprite            = (1 << 17), // WIP
 
         // Not PlayStation render flags
         NoAmbient         = (1 << 28),
@@ -41,7 +44,7 @@ namespace PSXPrev.Common
         // Use this mask when separating meshes by render info.
         public const RenderFlags SupportedFlags = RenderFlags.DoubleSided | RenderFlags.Unlit |
                                                   RenderFlags.SemiTransparent | RenderFlags.Textured |
-                                                  RenderFlags.VibRibbon;
+                                                  RenderFlags.Line | RenderFlags.Sprite;
 
         public uint TexturePage { get; }
         public RenderFlags RenderFlags { get; }

--- a/Common/Renderer/LineMeshBuilder.cs
+++ b/Common/Renderer/LineMeshBuilder.cs
@@ -91,12 +91,13 @@ namespace PSXPrev.Common.Renderer
             return new ModelEntity
             {
                 TexturePage = TexturePage,
-                RenderFlags = RenderFlags | RenderFlags.VibRibbon,
+                RenderFlags = RenderFlags | RenderFlags.Line,
                 MixtureRate = MixtureRate,
+                SpriteCenter = SpriteCenter,
                 Visible = Visible,
                 DebugMeshRenderInfo = new MeshRenderInfo(this),
                 Triangles = triangles,
-                LocalMatrix = modelMatrix ?? Matrix4.Identity,
+                OriginalLocalMatrix = modelMatrix ?? Matrix4.Identity,
             };
         }
 

--- a/Common/Renderer/MeshRenderInfo.cs
+++ b/Common/Renderer/MeshRenderInfo.cs
@@ -27,6 +27,7 @@ namespace PSXPrev.Common.Renderer
         public float? LightIntensity { get; set; } // Overrides Scene's or MeshBatch's light intensity
         public Color AmbientColor { get; set; } // Overrides Scene's or MeshBatch's ambient color
         public Color SolidColor { get; set; } // Overrides Mesh's vertex colors
+        public Vector3 SpriteCenter { get; set; }
         public bool Visible { get; set; } = true;
 
         public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
@@ -55,6 +56,7 @@ namespace PSXPrev.Common.Renderer
             TexturePage = modelEntity.TexturePage;
             RenderFlags = modelEntity.RenderFlags;
             MixtureRate = modelEntity.MixtureRate;
+            SpriteCenter = modelEntity.SpriteCenter;
             Visible     = modelEntity.Visible;
         }
 
@@ -69,6 +71,7 @@ namespace PSXPrev.Common.Renderer
             LightIntensity = renderInfo.LightIntensity;
             AmbientColor = renderInfo.AmbientColor;
             SolidColor = renderInfo.SolidColor;
+            SpriteCenter = renderInfo.SpriteCenter;
             Visible = renderInfo.Visible;
         }
     }

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -57,7 +57,16 @@ namespace PSXPrev.Common
             var bounds = new BoundingBox();
             foreach (var entity in ChildEntities)
             {
+                // Not yet, there are some issues with this, like models that are only made of attached vertices.
+                //if (entity is ModelEntity model && (model.Triangles.Length == 0 || model.AttachedOnly))
+                //{
+                //    continue; // Don't count empty models in bounds, since they'll always be at (0, 0, 0).
+                //}
                 bounds.AddBounds(entity.Bounds3D);
+            }
+            if (!bounds.IsSet)
+            {
+                bounds.AddPoint(WorldMatrix.ExtractTranslation());
             }
             Bounds3D = bounds;
         }

--- a/Common/Triangle.cs
+++ b/Common/Triangle.cs
@@ -133,7 +133,7 @@ namespace PSXPrev.Common
 
 
         // A fix to correct UVs where either all U or V coordinates are identical, which causes tearing.
-        public void CorrectUVTearing()
+        public Triangle CorrectUVTearing()
         {
             // This fix should be applied even if all 3 UVs are Vector2.Zero.
             // However, it should not be applied if this face is untextured.
@@ -209,6 +209,7 @@ namespace PSXPrev.Common
                 }
 #endif
             }
+            return this;
         }
     }
 }


### PR DESCRIPTION
* TMDHelper now treats gouraud as gradation (when unlit) for TMD too (removed mode checks since they're no longer needed).
* Add support for parsing StraightLine and Sprite in TMDHelper. Not tested when any real or hand-made data yet.
* TMDParser now honors Scale value (which is 2^Scale).
* Fixed MeshBuilders Create debug functions assigning LocalMatrix instead of OriginalLocalMatrix.
* Changed TriangleMeshBuilder AddTriangle and AddQuad functions to accept 3-4 colors just like LineMeshBuilder. color0 defaults to White, and all other colors default to color0.
* Added UV overloads to TriangleMeshBuilder AddTriangle and AddQuad.
* Split up AddTriangle and AddQuad into four regions: AddTriangle, AddTriangle (matrix), AddQuad, and AddQuad (matrix).
* Added TriangleMeshBuilder AddSprite for testing purposes.
* Renamed RenderFlags.VibRibbon to Line.
* Added RenderFlags.Sprite and added SpriteCenter property to ModelEntity/RenderInfo. This property should be assigned as the origin of the sprite, so it knows where to rotate around. (Currently sprites are stored as a quad, and so they don't retain their center information. The only other good solution for this would be to make a geometry shader to build sprites).
* (Implemented, but RootEntity doens not respect this yet due to issues) ModelEntity now has a property AttachedOnly, when true, all triangles are attached, meaning the model has no vertices of its own. When this is the case, RootEntity will ignore it when computing bounds. ComputeAttachedOnly is called by HMDParser and PSXParser, as they're the only models that can have attached vertices.
* MeshBatch focus no longer uses the individual bounds of the selected root entity's models, but the root entity's bounds itself.
* MeshBatch now modifies modelMatrix during DrawMesh when the Sprite render flag is set. (Math is not 100% accurate for transforming the sprite position, but its orientation always seems fine.