### PR TITLE
Cache attached normals and attached entity bounds

### DIFF
--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -302,6 +302,18 @@ namespace PSXPrev.Common
             }
         }
 
+        public virtual void UnfixConnections()
+        {
+            if (ChildEntities == null)
+            {
+                return;
+            }
+            foreach (var child in ChildEntities)
+            {
+                child.UnfixConnections();
+            }
+        }
+
         public virtual void ClearConnectionsCache()
         {
             if (ChildEntities == null)

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -484,7 +484,7 @@ namespace PSXPrev.Common.Parsers
                     sharedVertices.Clear();
                     sharedNormals.Clear();
                 }
-                model.ComputeAttachedOnly();
+                model.ComputeAttached();
                 modelEntities.Add(model);
             }
             if (sharedVertices.Count > 0 || sharedNormals.Count > 0)

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -58,10 +58,10 @@ namespace PSXPrev.Common
             foreach (var entity in ChildEntities)
             {
                 // Not yet, there are some issues with this, like models that are only made of attached vertices.
-                //if (entity is ModelEntity model && (model.Triangles.Length == 0 || model.AttachedOnly))
-                //{
-                //    continue; // Don't count empty models in bounds, since they'll always be at (0, 0, 0).
-                //}
+                if (entity is ModelEntity model && (model.Triangles.Length == 0 || (model.AttachedOnly && !model.IsAttached)))
+                {
+                    continue; // Don't count empty models in bounds, since they'll always be at (0, 0, 0).
+                }
                 bounds.AddBounds(entity.Bounds3D);
             }
             if (!bounds.IsSet)

--- a/Common/Triangle.cs
+++ b/Common/Triangle.cs
@@ -107,7 +107,10 @@ namespace PSXPrev.Common
 
         // Cache of already-attached entities/vertices to speed up FixConnections.
         [Browsable(false)]
-        public Tuple<EntityBase, Vector3>[] AttachedCache { get; set; }
+        public Tuple<EntityBase, Vector3>[] AttachedVerticesCache { get; set; }
+        // Cache of already-attached entities/normals to speed up FixConnections.
+        [Browsable(false)]
+        public Tuple<EntityBase, Vector3>[] AttachedNormalsCache { get; set; }
 
         [Browsable(false)]
         public float IntersectionDistance { get; set; }

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -902,7 +902,18 @@ namespace PSXPrev.Forms
                 if (_animationBatch.SetupAnimationFrame(checkedEntities, _selectedRootEntity, _selectedModelEntity, true))
                 {
                     // Animation has been processed. Update attached limbs while animating.
-                    (_selectedRootEntity ?? _selectedModelEntity?.GetRootEntity())?.FixConnections();
+                    var rootEntity = _selectedRootEntity ?? _selectedModelEntity?.GetRootEntity();
+                    if (rootEntity != null)
+                    {
+                        if (_scene.AutoAttach)
+                        {
+                            rootEntity.FixConnections();
+                        }
+                        else
+                        {
+                            rootEntity.UnfixConnections();
+                        }
+                    }
                 }
             }
             _scene.Draw();
@@ -2097,7 +2108,14 @@ namespace PSXPrev.Forms
             if (rootEntity != null)
             {
                 rootEntity.ResetAnimationData();
-                rootEntity.FixConnections();
+                if (_scene.AutoAttach)
+                {
+                    rootEntity.FixConnections();
+                }
+                else
+                {
+                    rootEntity.UnfixConnections();
+                }
             }
             if (selectedEntityBase != null)
             {


### PR DESCRIPTION
* Attached normals are now cached and recalculated just like attached cached vertices.
* ModelEnity now stores information stating if FixConnections has been called. When true, Attached vertices will be included in ComputeBounds calculations.
* Minor cleanup in PSXParser with version/magic checks and vertex/normal assignment.