### PR TITLE
Add support for reading raw PS1 .bin CD files

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -23,6 +23,9 @@ namespace PSXPrev.Common.Animator
         [DisplayName("Animation Name")]
         public string AnimationName { get; set; }
 
+        [DisplayName("Format"), ReadOnly(true)]
+        public string FormatName { get; set; }
+
         [DisplayName("Frame Count"), ReadOnly(true)]
         public uint FrameCount { get; set; }
 

--- a/Common/Parsers/BinCDStream.cs
+++ b/Common/Parsers/BinCDStream.cs
@@ -1,0 +1,266 @@
+﻿using System;
+using System.IO;
+
+namespace PSXPrev.Common.Parsers
+{
+    public class BinCDStream : Stream
+    {
+        // 150 skips common data like PS1 logo model
+        public const int SectorsFirstIndex = 150;
+        public const int SectorRawSize = 2352;
+        public const int SectorUserStart = 24;
+        public const int SectorUserSize = 2048;
+
+        // File config
+        private readonly long _fileSectorsStart;
+        private readonly int _fileSectorRawSize;
+        private readonly int _fileSectorUserStart;
+        private readonly int _fileSectorUserSize;
+
+        private readonly Stream _stream;
+        private readonly bool _leaveOpen;
+        private readonly byte[] _buffer;
+        private readonly long _length;
+        private readonly int _sectorCount; // Total number of sectors in the file after _fileSectorsStart
+
+        private int _sectorIndex;          // Index of current sector
+        private int _sectorPosition;       // Index inside current sector
+        private int _lastReadSectorIndex;  // Index of last sector that was read into the buffer
+
+        public BinCDStream(string file, bool leaveOpen = false)
+            : this(File.OpenRead(file), leaveOpen)
+        {
+        }
+
+        public BinCDStream(Stream stream, bool leaveOpen = false)
+            : this(stream, SectorsFirstIndex, SectorRawSize, SectorUserStart, SectorUserSize, leaveOpen)
+        {
+        }
+
+        // Set sectorsFirstIndex to 0 to read information like PS1 logo model
+        // Set sectorUserSize to 2032 and sectorUserStart to 40 for Star Ocean 2
+        public BinCDStream(string file, int sectorsFirstIndex, int sectorRawSize, int sectorUserStart, int sectorUserSize, bool leaveOpen = false)
+            : this(File.OpenRead(file), sectorsFirstIndex, sectorRawSize, sectorUserStart, sectorUserSize, leaveOpen)
+        {
+        }
+
+        public BinCDStream(Stream stream, int sectorsFirstIndex, int sectorRawSize, int sectorUserStart, int sectorUserSize, bool leaveOpen = false)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _leaveOpen = leaveOpen;
+            if (!stream.CanRead || !stream.CanSeek)
+            {
+                throw new ArgumentException("Stream must be able to Read and Seek", nameof(stream));
+            }
+
+            _fileSectorsStart    = sectorsFirstIndex * sectorRawSize;
+            _fileSectorRawSize   = sectorRawSize;
+            _fileSectorUserStart = sectorUserStart;
+            _fileSectorUserSize  = sectorUserSize;
+            _buffer = new byte[sectorUserSize];
+
+            _sectorCount = Math.Max(0, SectorIndexFromRawPosition(stream.Length));
+            _length = SectorIndexToUserPosition(_sectorCount);
+            _sectorIndex = 0;
+            _sectorPosition = 0;
+            _lastReadSectorIndex = -1; // No sectors read into buffer
+        }
+
+
+        public static bool IsBINFile(string file) => IsBINFile(file, SectorRawSize);
+
+        public static bool IsBINFile(string file, int sectorRawSize)
+        {
+            try
+            {
+                var size = new FileInfo(file).Length;
+                return size > 0 && (size % sectorRawSize) == 0;
+            }
+            catch
+            {
+                // Failed to get file info? Clearly this isn't a raw PS1 bin file...
+            }
+            return false;
+        }
+
+
+        public int SectorIndex => _sectorIndex;
+
+        public int SectorCount => _sectorCount;
+
+        public override long Position
+        {
+            get => SectorIndexToUserPosition(_sectorIndex) + _sectorPosition;
+            set => Seek(value, SeekOrigin.Begin);
+        }
+
+        public override long Length => _length;
+
+        public override bool CanRead => _stream.CanRead;
+
+        public override bool CanSeek => _stream.CanSeek;
+
+        public override bool CanWrite => false;
+
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Current:
+                    offset += Position;
+                    break;
+                case SeekOrigin.End:
+                    offset += _length;
+                    break;
+            }
+            offset = GeomMath.Clamp(offset, 0, _length);
+
+            _sectorIndex = SectorIndexFromUserPosition(offset);
+            _sectorPosition = SectorPositionFromUserPosition(offset);
+            return Position;
+        }
+
+        public override int ReadByte()
+        {
+            if (!PrepareSectorForRead())
+            {
+                return -1; // End of stream
+            }
+            return _buffer[_sectorPosition++];
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentException("Count is less than 0", nameof(count));
+            }
+            var bytesRead = 0;
+            while (count > 0)
+            {
+                if (!PrepareSectorForRead())
+                {
+                    break; // End of stream
+                }
+                var sectorLeft = _fileSectorUserSize - _sectorPosition;
+                var sectorRead = Math.Min(sectorLeft, count);
+                Buffer.BlockCopy(_buffer, _sectorPosition, buffer, offset + bytesRead, sectorRead);
+                bytesRead += sectorRead;
+                count -= sectorRead;
+                _sectorPosition += sectorRead;
+            }
+            return bytesRead;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException("Stream is not writable");
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException("Stream is not writable");
+        }
+
+
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing && !_leaveOpen)
+                {
+                    _stream.Close();
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
+            }
+        }
+
+
+        private bool PrepareSectorForRead()
+        {
+            // Increment the sector if we've reached the end
+            if (_sectorPosition == _fileSectorUserSize)
+            {
+                _sectorIndex++;
+                _sectorPosition = 0;
+            }
+            // Check if we've reached EOF
+            if (_sectorIndex == _sectorCount)
+            {
+                return false; // Nothing more to read
+            }
+            // Read the sector into the buffer if we haven't already done so.
+            if (_sectorIndex != _lastReadSectorIndex)
+            {
+                // We always need to seek, since we need to skip non-user data between sectors
+                var rawPosition = SectorIndexToRawPosition(_sectorIndex);
+                _stream.Seek(rawPosition, SeekOrigin.Begin);
+                _stream.Read(_buffer, 0, _fileSectorUserSize);
+                _lastReadSectorIndex = _sectorIndex;
+            }
+            return true;
+        }
+
+
+        private int SectorPositionFromUserPosition(long position)
+        {
+            return (int)(position % _fileSectorUserSize);
+        }
+
+        private int SectorIndexFromUserPosition(long position)
+        {
+            return (int)(position / _fileSectorUserSize);
+        }
+
+        private long SectorIndexToUserPosition(int sectorIndex)
+        {
+            return ((long)sectorIndex * _fileSectorUserSize);
+        }
+
+        /*private int SectorPositionFromRawPosition(long rawPosition)
+        {
+            return (int)((rawPosition - _fileSectorsStart) % _fileSectorRawSize) - _fileSectorUserStart;
+        }*/
+
+        private int SectorIndexFromRawPosition(long rawPosition)
+        {
+            return (int)((rawPosition - _fileSectorsStart) / _fileSectorRawSize);
+        }
+
+        private long SectorIndexToRawPosition(int sectorIndex)
+        {
+            return _fileSectorsStart + ((long)sectorIndex * _fileSectorRawSize) + _fileSectorUserStart;
+        }
+
+        /*private long UserPositionToRawPosition(long position)
+        {
+            var sectorIndex = SectorIndexFromUserPosition(position);
+            // Shorthand verion: Add the difference between raw/user sector sizes and use position as-is.
+            //var rawAdditional = (long)sectorIndex * (_fileSectorRawSize - _fileSectorUserSize);
+            //return _fileSectorsStart + rawAdditional + position;
+            // Longer verion: Easier to read.
+            var rawPosition = SectorIndexToRawPosition(sectorIndex);
+            var sectorPosition = SectorPositionFromUserPosition(position);
+            return rawPosition + SECTOR_USER_START + sectorPosition;
+        }
+
+        private long UserPositionFromRawPosition(long rawPosition)
+        {
+            var sectorIndex = SectorIndexFromRawPosition(rawPosition);
+            if (sectorIndex < 0)
+            {
+                return 0;
+            }
+            var sectorPosition = GeomMath.Clamp(SectorPositionFromRawPosition(rawPosition), 0, _fileSectorUserSize);
+            return SectorIndexToUserPosition(sectorIndex) + sectorPosition;
+        }*/
+    }
+}

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -177,7 +177,7 @@ namespace PSXPrev.Common.Renderer
         // Draw texture onto page.
         public void DrawTexture(Texture texture, bool suppressUpdate = false)
         {
-            var index = texture.TexturePage;
+            var index = ClampTexturePage(texture.TexturePage);
             DrawTexture(_vramPages[index], texture);
 
             _usedPages[index] = true;

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -16,6 +16,9 @@ namespace PSXPrev.Common
         [Browsable(false)]
         public Coordinate[] Coords { get; set; }
 
+        [DisplayName("Format"), ReadOnly(true)]
+        public string FormatName { get; set; }
+
         [DisplayName("Total Triangles"), ReadOnly(false)]
         public int TotalTriangles
         {

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -68,6 +68,9 @@ namespace PSXPrev.Common
         [DisplayName("Name")]
         public string TextureName { get; set; }
 
+        [DisplayName("Format"), ReadOnly(true)]
+        public string FormatName { get; set; }
+
         [DisplayName("X")]
         public int X { get; set; }
 

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -216,7 +216,10 @@ namespace PSXPrev.Forms
                 statusCurrentFileProgressBar.Maximum = max;
                 statusCurrentFileProgressBar.Value = GeomMath.Clamp((int)(percent * max), 0, max);
 
-                statusMessageLabel.Text = message;
+                if (message != null)
+                {
+                    statusMessageLabel.Text = message;
+                }
 
                 if (reloadItems)
                 {
@@ -248,6 +251,12 @@ namespace PSXPrev.Forms
 
                 statusTotalFilesProgressBar.Visible = true;
                 statusCurrentFileProgressBar.Visible = true;
+                statusTotalFilesProgressBar.Maximum = 1;
+                statusTotalFilesProgressBar.Value = 0;
+                statusCurrentFileProgressBar.Maximum = 1;
+                statusCurrentFileProgressBar.Value = 1;
+
+                statusMessageLabel.Text = $"Scan Started";
 
                 statusStrip1.ResumeLayout();
                 statusStrip1.Refresh();
@@ -335,6 +344,7 @@ namespace PSXPrev.Forms
             {
                 Program.Logger.ReadSettings(Settings.Instance);
             }
+            Program.ConsoleLogger.ReadSettings(Settings.Instance);
 
             gridSnapUpDown.Value = (decimal)settings.GridSnap;
             angleSnapUpDown.Value = (decimal)settings.AngleSnap;
@@ -746,7 +756,7 @@ namespace PSXPrev.Forms
                             if (_gizmoType != GizmoType.Translate)
                             {
                                 SetGizmoType(GizmoType.Translate);
-                                //Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
+                                //Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
                             }
                             e.Handled = true;
                         }
@@ -757,7 +767,7 @@ namespace PSXPrev.Forms
                             if (_gizmoType != GizmoType.Rotate)
                             {
                                 SetGizmoType(GizmoType.Rotate);
-                                //Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
+                                //Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
                             }
                             e.Handled = true;
                         }
@@ -768,7 +778,7 @@ namespace PSXPrev.Forms
                             if (_gizmoType != GizmoType.Scale)
                             {
                                 SetGizmoType(GizmoType.Scale);
-                                //Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
+                                //Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"GizmoType: {_gizmoType}");
                             }
                             e.Handled = true;
                         }
@@ -780,7 +790,7 @@ namespace PSXPrev.Forms
                         if (IsControlDown) // Ctrl+D: Toggle debug visuals)
                         {
                             _scene.ShowDebugVisuals = !_scene.ShowDebugVisuals;
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugVisuals: {_scene.ShowDebugVisuals}");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugVisuals: {_scene.ShowDebugVisuals}");
                             e.Handled = true;
                         }
                         break;
@@ -790,7 +800,7 @@ namespace PSXPrev.Forms
                             if (IsControlDown) // Ctrl+P (Toggle debug picking ray)
                             {
                                 _scene.ShowDebugPickingRay = !_scene.ShowDebugPickingRay;
-                                Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugPickingRay: {_scene.ShowDebugPickingRay}");
+                                Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugPickingRay: {_scene.ShowDebugPickingRay}");
                                 e.Handled = true;
                             }
                             else if (_scene.ShowDebugPickingRay) // P (Set debug picking ray)
@@ -806,7 +816,7 @@ namespace PSXPrev.Forms
                             if (IsControlDown) // Ctrl+I (Toggle debug intersections)
                             {
                                 _scene.ShowDebugIntersections = !_scene.ShowDebugIntersections;
-                                Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugIntersections: {_scene.ShowDebugIntersections}");
+                                Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"ShowDebugIntersections: {_scene.ShowDebugIntersections}");
                                 e.Handled = true;
                             }
                             else if (_scene.ShowDebugIntersections) // Hold I/Hold Shift+I (Update debug intersections)
@@ -832,14 +842,14 @@ namespace PSXPrev.Forms
                     case Keys.C when state && sceneFocused:
                         if (_scene.ShowDebugVisuals && !IsControlDown)
                         {
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"CameraFOV      = {_scene.CameraFOV:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"CameraDistance = {_scene.CameraDistance:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"_cameraX       = {_scene.CameraX:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"_cameraY       = {_scene.CameraY:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"_cameraPitch   = {_scene.CameraPitch:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"_cameraYaw     = {_scene.CameraYaw:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"LightIntensity = {_scene.LightIntensity:R};");
-                            Program.Logger.WriteColorLine(ConsoleColor.Magenta, $"LightPitchYaw  = new Vector2({_scene.LightPitch:R}, {_scene.LightYaw:R});");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"CameraFOV      = {_scene.CameraFOV:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"CameraDistance = {_scene.CameraDistance:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"_cameraX       = {_scene.CameraX:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"_cameraY       = {_scene.CameraY:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"_cameraPitch   = {_scene.CameraPitch:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"_cameraYaw     = {_scene.CameraYaw:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"LightIntensity = {_scene.LightIntensity:R};");
+                            Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"LightPitchYaw  = new Vector2({_scene.LightPitch:R}, {_scene.LightYaw:R});");
                             e.Handled = true;
                         }
                         break;
@@ -847,33 +857,13 @@ namespace PSXPrev.Forms
 
                         // Debugging keys for testing AnimationBatch settings while they still don't have UI controls.
 #if false
-                    case Keys.A when state:
-                        var loopMode = _animationBatch.LoopMode + 1;
-                        if (loopMode > AnimationLoopMode.MirrorLoop)
-                        {
-                            loopMode = AnimationLoopMode.Once;
-                        }
-                        _animationBatch.LoopMode = loopMode;
-                        UpdateAnimationProgressLabel();
-                        Program.Logger.WriteLine($"LoopMode={_animationBatch.LoopMode,-10} Reverse={_animationBatch.Reverse}");
-                        break;
-                    case Keys.S when state:
-                        _animationBatch.Reverse = !_animationBatch.Reverse;
-                        UpdateAnimationProgressLabel();
-                        Program.Logger.WriteLine($"LoopMode={_animationBatch.LoopMode,-10} Reverse={_animationBatch.Reverse}");
-                        break;
-                    case Keys.D when state:
-                        _animationBatch.Restart();
-                        UpdateAnimationProgressLabel();
-                        Program.Logger.WriteLine("Restarted");
-                        break;
                     case Keys.F when state:
                         _animationBatch.LoopDelayTime += 0.5;
-                        Program.Logger.WriteLine($"LoopDelayTime={_animationBatch.LoopDelayTime}");
+                        Program.ConsoleLogger.WriteLine($"LoopDelayTime={_animationBatch.LoopDelayTime}");
                         break;
                     case Keys.G when state:
                         _animationBatch.LoopDelayTime -= 0.5;
-                        Program.Logger.WriteLine($"LoopDelayTime={_animationBatch.LoopDelayTime}");
+                        Program.ConsoleLogger.WriteLine($"LoopDelayTime={_animationBatch.LoopDelayTime}");
                         break;
 #endif
                 }
@@ -2881,11 +2871,12 @@ namespace PSXPrev.Forms
             {
                 _animationProgressBarRefreshDelayTimer.Reset();
 
-                var displayMax = Math.Max(1, (int)_animationBatch.FrameCount);
-                var displayValue = (int)_animationBatch.CurrentFrameTime;
+                // Display max can be shown as 0, even if we require a minimum of 1 internally.
+                var displayMax = (int)GeomMath.Clamp(_animationBatch.FrameCount, 0, int.MaxValue);
+                var displayValue = (int)GeomMath.Clamp(_animationBatch.CurrentFrameTime, 0, int.MaxValue);
 
-                var newMax = Math.Max(1, (int)(_animationBatch.FrameCount * AnimationProgressPrecision));
-                var newValue = (int)(_animationBatch.CurrentFrameTime * AnimationProgressPrecision);
+                var newMax = (int)GeomMath.Clamp(_animationBatch.FrameCount * AnimationProgressPrecision, 1, int.MaxValue);
+                var newValue = (int)GeomMath.Clamp(_animationBatch.CurrentFrameTime * AnimationProgressPrecision, 0, int.MaxValue);
 
                 animationProgressLabel.Text = $"{displayValue}/{displayMax}";
                 if (newMax != animationFrameTrackBar.Maximum || newValue != animationFrameTrackBar.Value)
@@ -2969,12 +2960,14 @@ namespace PSXPrev.Forms
             if (_inAnimationTab && !Playing)
             {
                 var value = (double)animationFrameTrackBar.Value;
-                if (IsShiftDown)
+                // Sanity check that max is less than intmax, if it isn't, then we aren't using progress precision.
+                if (IsShiftDown && animationFrameTrackBar.Maximum < int.MaxValue)
                 {
                     // Hold shift down to reduce precision to individual frames
                     value = GeomMath.Snap(value, AnimationProgressPrecision);
                 }
-                _animationBatch.FrameTime = value / AnimationProgressPrecision;
+                var delta = value / animationFrameTrackBar.Maximum;
+                _animationBatch.FrameTime = delta * _animationBatch.FrameCount;
                 UpdateAnimationProgressLabel();
             }
         }

--- a/Forms/ScannerForm.cs
+++ b/Forms/ScannerForm.cs
@@ -101,18 +101,25 @@ namespace PSXPrev.Forms
                 IgnoreTMDVersion = optionIgnoreTMDVersionCheckBox.Checked,
 
                 //todo
-                StartOffset = optionNoOffsetCheckBox.Checked ? (long?)0 : null,
-                StopOffset = optionNoOffsetCheckBox.Checked ? (long?)1 : null,
+                //Alignment = 1, //todo
+                //StartOffset = null, //todo
+                //StopOffset = null, //todo
+                NoOffset = optionNoOffsetCheckBox.Checked,
                 //NextOffset = false, //todo
 
-                //DepthFirstFileSearch = true, //todo
                 //AsyncFileScan = true, //todo
+                //DepthFirstFileSearch = true, //todo
+                ReadISOContents = true, //todo (default to true until we have an option for it)
+                //ReadBINContents = false, //todo
+                //BINAlignToSector = false, //todo
+                //BINSectorUserStart = null, //todo
+                //BINSectorUserSize = null, //todo
 
                 LogToFile = optionLogToFileCheckBox.Checked,
                 LogToConsole = !optionNoVerboseCheckBox.Checked,
                 Debug = optionDebugCheckBox.Checked,
                 ShowErrors = optionShowErrorsCheckBox.Checked,
-                //ConsoleColor = true, //todo
+                //UseConsoleColor = true, //todo
 
                 DrawAllToVRAM = optionDrawAllToVRAMCheckBox.Checked,
                 FixUVAlignment = !optionOldUVAlignmentCheckBox.Checked,

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Common\Exporters\PNGExporter.cs" />
     <Compile Include="Common\Parsers\ANParser.cs" />
     <Compile Include="Common\Parsers\BFFParser.cs" />
+    <Compile Include="Common\Parsers\BinCDStream.cs" />
     <Compile Include="Common\Parsers\FileOffsetScanner.cs" />
     <Compile Include="Common\Parsers\FileOffsetStream.cs" />
     <Compile Include="Common\Parsers\HMDHelper.cs" />

--- a/ScanOptions.cs
+++ b/ScanOptions.cs
@@ -48,17 +48,31 @@ namespace PSXPrev
         [JsonProperty("ignoreTMDVersion")]
         public bool IgnoreTMDVersion { get; set; } = false;
 
-        [JsonProperty("startFileOffset")]
+        [JsonProperty("fileOffsetAlign")]
+        public long Alignment { get; set; } = 1;
+        [JsonProperty("fileOffsetStart")]
         public long? StartOffset { get; set; } = null;
-        [JsonProperty("stopFileOffset")]
+        [JsonProperty("fileOffsetStop")]
         public long? StopOffset { get; set; } = null;
-        [JsonProperty("nextFileOffset")]
+        [JsonProperty("fileOffsetNone")]
+        public bool NoOffset { get; set; } = false;
+        [JsonProperty("fileOffsetNext")]
         public bool NextOffset { get; set; } = false;
 
-        [JsonProperty("depthFirstFileSearch")]
-        public bool DepthFirstFileSearch { get; set; } = true; // AKA top-down
-        [JsonProperty("asyncFileScan")]
+        [JsonProperty("fileScanAsync")]
         public bool AsyncFileScan { get; set; } = true;
+        [JsonProperty("fileSearchDepthFirst")]
+        public bool DepthFirstFileSearch { get; set; } = true; // AKA top-down
+        [JsonProperty("fileSearchISOContents")]
+        public bool ReadISOContents { get; set; } = false;
+        [JsonProperty("fileSearchBINContents")]
+        public bool ReadBINContents { get; set; } = false;
+        [JsonProperty("binSectorAlign")]
+        public bool BINAlignToSector { get; set; } = false;
+        [JsonProperty("binSectorUserStart")]
+        public int? BINSectorUserStart = null;
+        [JsonProperty("binSectorUserSize")]
+        public int? BINSectorUserSize = null;
 
         // Log options:
         [JsonProperty("logToFile")]


### PR DESCRIPTION
* Added support for reading raw PS1 .bin files (by parsing individual sectors) through the new class BinCDStream. This does not handle reading the file index yet.
* ISO file contents (and now BIN file contents) can now be scanned when scanning a directory (by default from the interface, or by specifying -scaniso, -scanbin from the command line).
* Max file position progress now only includes active parsers, so if a parser finishes, then the progress bar may go down to the new max progress.
* File progress bars now update more frequently, and no longer get stuck from the previous scan.
* Added error reporting for invalid command line argument parameters.
* Synchronous file scan now re-uses the same stream.
* Added leaveOpen option to FileOffsetStream.
* RootEntities, Textures, and Animations now have a FormatName property (Display name: "Format"), which can be viewed in the property grid to see what format scanned this item.
* Added Program.ConsoleLogger, for use outside of file scanning.
* VRAM.DrawTexture (instance method) now clamps texture page to avoid errors caused by drawing all textures to VRAM.
* Fixed animation slider errors when selecting malformed animations.

New command line arguments:
* -align <ALIGN> (scan files at offsets in specified increments)
* -start <OFFSET>
* -stop  <OFFSET>
* -nooffset  (changed to now use STOP=START+1 instead of START=0,STOP=1)
* -depthlast (scan files at lower folder depths first)
* -scaniso   (read .iso file contents)
* -scanbin   (read raw PS1 .bin file sectors)
* -binalign  (align offset to .bin sector size (for .bin files only))
* -binsector <START>,<SIZE> (configure .bin file sector dimensions, included because Star Ocean 2 has different dimensions)