### PR TITLE
TIMParser refactoring and add more HMD/PMD Limits

### DIFF
--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -208,7 +208,7 @@ namespace PSXPrev.Common.Animator
             // Support using AnimationBatch even if we have no Scene.
             if (!simulate && _scene != null)
             {
-                _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, selectedModelEntity, selectedRootEntity, updateMeshData || _scene.AutoAttach, false, true);
+                _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, selectedModelEntity, selectedRootEntity, updateMeshData || _scene.AutoAttach, false);
             }
 
             ComputePlaybackFrameTime();

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -32,6 +32,10 @@
         public static ulong MaxMODVertices = 10000;
         public static ulong MaxMODFaces = 10000;
 
+        public static ulong MaxPMDObjects = 4000;
+        public static ulong MaxPMDPointers = 4000;
+        public static ulong MaxPMDPackets = 4000;
+
         public static ulong MaxPSXObjectCount = 1024;
 
         public static ulong MaxTIMResolution = 1024;

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -57,7 +57,7 @@ namespace PSXPrev.Common.Parsers
             var primPoint = reader.ReadUInt32();
             var vertPoint = reader.ReadUInt32();
             var nObj = reader.ReadUInt32();
-            if (nObj < 1 || nObj > 4000)
+            if (nObj < 1 || nObj > Limits.MaxPMDObjects)
             {
                 return null;
             }
@@ -65,7 +65,7 @@ namespace PSXPrev.Common.Parsers
             for (uint o = 0; o < nObj; o++)
             {
                 var nPointers = reader.ReadUInt32();
-                if (nPointers < 1 || nPointers > 4000)
+                if (nPointers < 1 || nPointers > Limits.MaxPMDPointers)
                 {
                     return null;
                 }
@@ -75,7 +75,7 @@ namespace PSXPrev.Common.Parsers
                     var pointer = reader.ReadUInt32();
                     reader.BaseStream.Seek(_offset + pointer, SeekOrigin.Begin);
                     var nPacket = reader.ReadUInt16();
-                    if (nPacket > 4000)
+                    if (nPacket > Limits.MaxPMDPackets)
                     {
                         return null;
                     }

--- a/Common/Renderer/MeshBatch.cs
+++ b/Common/Renderer/MeshBatch.cs
@@ -79,7 +79,7 @@ namespace PSXPrev.Common.Renderer
         }
 
 
-        public void SetupMultipleEntityBatch(RootEntity[] checkedEntities = null, ModelEntity selectedModelEntity = null, RootEntity selectedRootEntity = null, bool updateMeshData = true, bool focus = false, bool hasAnimation = false)
+        public void SetupMultipleEntityBatch(RootEntity[] checkedEntities = null, ModelEntity selectedModelEntity = null, RootEntity selectedRootEntity = null, bool updateMeshData = true, bool focus = false, bool tmdidOfSelected = false)
         {
             if (selectedModelEntity == null && selectedRootEntity == null)
             {
@@ -110,10 +110,25 @@ namespace PSXPrev.Common.Renderer
             //focus
             if (selectedRootEntity != null)
             {
-                modelCount += selectedRootEntity.ChildEntities.Length;
-                if (focus)
+                if (selectedModelEntity != null && tmdidOfSelected)
                 {
-                    bounds.AddBounds(selectedRootEntity.Bounds3D);
+                    var tmdidModels = selectedRootEntity.GetModelsWithTMDID(selectedModelEntity.TMDID);
+                    modelCount += tmdidModels.Count;
+                    foreach (var modelEntity in tmdidModels)
+                    {
+                        if (focus && (modelEntity.Triangles.Length > 0 && (!modelEntity.AttachedOnly || modelEntity.IsAttached)))
+                        {
+                            bounds.AddBounds(modelEntity.Bounds3D);
+                        }
+                    }
+                }
+                else
+                {
+                    modelCount += selectedRootEntity.ChildEntities.Length;
+                    if (focus)
+                    {
+                        bounds.AddBounds(selectedRootEntity.Bounds3D);
+                    }
                 }
             }
             //reset
@@ -147,7 +162,16 @@ namespace PSXPrev.Common.Renderer
             //root entity
             if (selectedRootEntity != null)
             {
-                foreach (ModelEntity modelEntity in selectedRootEntity.ChildEntities)
+                IEnumerable<EntityBase> models;
+                if (selectedModelEntity != null && tmdidOfSelected)
+                {
+                    models = selectedRootEntity.GetModelsWithTMDID(selectedModelEntity.TMDID);
+                }
+                else
+                {
+                    models = selectedRootEntity.ChildEntities;
+                }
+                foreach (ModelEntity modelEntity in models)
                 {
                     BindModelMesh(modelEntity, selectedRootEntity.TempMatrix * modelEntity.TempWorldMatrix, updateMeshData,
                         modelEntity.InitialVertices, modelEntity.InitialNormals,

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -91,6 +91,7 @@ namespace PSXPrev.Forms
         private bool _autoDrawModelTextures;
         private bool _autoSelectAnimationModel;
         private bool _autoPlayAnimations;
+        private bool _onlyModelsWithSameTMDID;
 
         private GizmoType _gizmoType;
         private GizmoId _hoveredGizmo;
@@ -324,6 +325,9 @@ namespace PSXPrev.Forms
         {
             Settings.LoadDefaults();
             ReadSettings(Settings.Instance);
+
+            // temp: Add this here until its a proper feature
+            _onlyModelsWithSameTMDID = false;
         }
 
         public void LoadSettings()
@@ -782,6 +786,12 @@ namespace PSXPrev.Forms
                             }
                             e.Handled = true;
                         }
+                        break;
+
+                    case Keys.M when state && sceneFocused:
+                        _onlyModelsWithSameTMDID = !_onlyModelsWithSameTMDID;
+                        Program.ConsoleLogger.WriteColorLine(ConsoleColor.Magenta, $"_onlyModelsWithSameTMDID: {_onlyModelsWithSameTMDID}");
+                        UpdateSelectedEntity();
                         break;
 
                     // Debugging keys for testing picking rays.
@@ -2183,7 +2193,7 @@ namespace PSXPrev.Forms
                 // todo: Ensure we focus when switching to a different root entity, even if the selected entity is a sub-model.
                 var focus = _selectionSource == EntitySelectionSource.TreeView && _selectedModelEntity == null;
                 var checkedEntities = GetCheckedEntities();
-                _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, _selectedModelEntity, _selectedRootEntity, updateMeshData, focus);
+                _scene.MeshBatch.SetupMultipleEntityBatch(checkedEntities, _selectedModelEntity, _selectedRootEntity, updateMeshData, focus, tmdidOfSelected: _onlyModelsWithSameTMDID);
             }
             else
             {


### PR DESCRIPTION
* HMDParser now checks MaxHMDVertices during ProcessSharedIndicesData.
* Added three Limits values for PMDParser (all 4000).
* Removed MeshBatch.SetupMultipleEntityBatch hasAnimation argument and replaced it with tmdidOfSelected, which will only show models in the root entity with the same TMDID as the selected model entity (not for checked entities).
* The tmdidOfSelected setting is now in PreviewForm as a keybind option by pressing M to toggle the setting. Will add UI menu item for it later.
* Refactored a lot of TIMParser. * It turns out the raw width value is actually stride (in 2-byte units). * Fixed rogue division by 255 that should be 256. * 24bpp images now handle padding based on stride. * Fixed 24bpp texture width not correctly calculating based off stride. Fixed the same for texture X.