### PR TITLE
Allow swapping between different texture CLUT indices

### DIFF
--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -291,7 +291,7 @@ namespace PSXPrev.Common.Exporters
                     if (_copiedVRAMPages[texturePage] == null)
                     {
                         // A copy doesn't exist yet, create one.
-                        vramTexture = new Texture(texture);
+                        vramTexture = new Texture(texture, true);
                         vramTexture.TextureName = $"{texture.TextureName ?? nameof(Texture)} Copy";
                         _copiedVRAMPages[texturePage] = vramTexture;
                     }
@@ -579,7 +579,7 @@ namespace PSXPrev.Common.Exporters
                     var bitmap = VRAM.ConvertSingleTexture(_packedTextures, _countX, _countY, false);
                     try
                     {
-                        SingleTexture = new Texture(bitmap, 0, 0, 32, 0, 0, 0);
+                        SingleTexture = new Texture(bitmap, 0, 0, 32, 0, 0, null, null);
                         SingleTexture.TextureName = $"Single[{_countX}x{_countY}]";
                         //SingleTexture.SemiTransparentMap = VRAM.ConvertSingleTexture(_packedTextures, _countX, _countY, true);
                     }
@@ -745,7 +745,7 @@ namespace PSXPrev.Common.Exporters
                     var bitmap = VRAM.ConvertTiledTexture(OriginalTexture, srcRect, _repeatX, _repeatY, fullWidth, fullHeight, false);
                     try
                     {
-                        TiledTexture = new Texture(bitmap, 0, 0, 32, TexturePage, 0, 0);
+                        TiledTexture = new Texture(bitmap, 0, 0, 32, TexturePage, 0, null, null);
                         //TiledTexture.TextureName = $"Tiled[{srcX},{srcY} {srcWidth}x{srcHeight}]";
                         TiledTexture.TextureName = $"Tiled[{_repeatX}x{_repeatY}]";
                         //TiledTexture.SemiTransparentMap = VRAM.ConvertTiledTexture(OriginalTexture, srcRect, _repeatX, _repeatY, fullWidth, fullHeight, true);

--- a/Common/Parsers/TIMParser.cs
+++ b/Common/Parsers/TIMParser.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using PSXPrev.Common.Animator;
 
@@ -23,16 +25,16 @@ namespace PSXPrev.Common.Parsers
                 var version = reader.ReadUInt16();
                 if (Limits.IgnoreTIMVersion || version == 0x00)
                 {
-                    var textures = ParseTim(reader);
-                    if (textures != null)
+                    var texture = ParseTim(reader);
+                    if (texture != null)
                     {
-                        TextureResults.AddRange(textures);
+                        TextureResults.Add(texture);
                     }
                 }
             }
         }
 
-        private List<Texture> ParseTim(BinaryReader reader)
+        private Texture ParseTim(BinaryReader reader)
         {
             var flag = reader.ReadUInt32();
             var pmode = (flag & 0x7);
@@ -47,7 +49,7 @@ namespace PSXPrev.Common.Parsers
             //    return null;
             //}
 
-            System.Drawing.Color[][] palettes = null;
+            int[][] palettes = null;
             bool[][] semiTransparentPalettes = null;
             if (hasClut)
             {
@@ -67,10 +69,7 @@ namespace PSXPrev.Common.Parsers
                     pmode = 1; // 8bpp (256clut)
                 }
 
-                // temp: Only support loading the first clut,
-                // because loading every clut variation is a mess currently.
-                var firstOnly = true;
-                palettes = ReadPalettes(reader, pmode, clutWidth, clutHeight, out semiTransparentPalettes, false, firstOnly);
+                palettes = ReadPalettes(reader, pmode, clutWidth, clutHeight, out semiTransparentPalettes, false);
             }
 
             if (pmode < 2 && palettes == null)
@@ -84,29 +83,10 @@ namespace PSXPrev.Common.Parsers
             var imgStride = reader.ReadUInt16(); // Stride in units of 2 bytes
             var imgHeight = reader.ReadUInt16();
 
-            var imagePosition = reader.BaseStream.Position;
-            var imageCount = palettes?.Length ?? 1;
-            var textures = new List<Texture>(imageCount);
-            for (var i = 0; i < imageCount; i++)
-            {
-                if (i > 0)
-                {
-                    // We only need to seek back on later loops
-                    reader.BaseStream.Seek(imagePosition, SeekOrigin.Begin);
-                }
-                // Allow out of bounds to support HMDs with invalid image data, but valid model data.
-                var texture = ReadTexture(reader, i, imageCount - 1, imgStride, imgHeight, imgDx, imgDy, pmode, palettes[i], semiTransparentPalettes[i], false);
-                if (texture == null)
-                {
-                    break; // Every other attempt to read will fail too, just break now
-                }
-                textures.Add(texture);
-            }
-
-            return textures;
+            return ReadTexture(reader, imgStride, imgHeight, imgDx, imgDy, pmode, 0, palettes, semiTransparentPalettes, false);
         }
 
-        public static System.Drawing.Color[] ReadPalette(BinaryReader reader, uint pmode, uint clutWidth, out bool[] semiTransparentPalette, bool allowOutOfBounds)
+        public static int[] ReadPalette(BinaryReader reader, uint pmode, uint clutWidth, out bool[] semiTransparentPalette, bool allowOutOfBounds)
         {
             semiTransparentPalette = null;
 
@@ -127,23 +107,24 @@ namespace PSXPrev.Common.Parsers
             }
 
             // We should probably allocate the full 16clut or 256clut in-case an image pixel has bad data.
-            var paletteSize = pmode == 0 ? 16 : 256; // clutWidth;
-            var palette = new System.Drawing.Color[paletteSize];
+            var count = pmode == 0 ? 16 : 256; // clutWidth;
+            int[] palette = null;
 
-            for (var c = 0; c < palette.Length; c++)
+            for (var c = 0; c < count; c++)
             {
-                System.Drawing.Color color;
+                int argb;
                 if (c >= clutWidth)
                 {
                     // Use default masking black as fallback color.
-                    color = System.Drawing.Color.FromArgb(255, 0, 0, 0);
+                    // No need to assign empty color
+                    //argb = (0 << 24) | (0 << 16) | (0 << 8) | 0;
                 }
                 else
                 {
                     var data = reader.ReadUInt16();
-                    var r = (data) & 0x1f;
-                    var g = (data >> 5) & 0x1f;
-                    var b = (data >> 10) & 0x1f;
+                    var r = ((data      ) & 0x1f) << 3;
+                    var g = ((data >>  5) & 0x1f) << 3;
+                    var b = ((data >> 10) & 0x1f) << 3;
                     var stp = ((data >> 15) & 0x1) == 1; // Semi-transparency: 0-Off, 1-On
                     var a = 255;
 
@@ -152,7 +133,7 @@ namespace PSXPrev.Common.Parsers
                     {
                         if (semiTransparentPalette == null)
                         {
-                            semiTransparentPalette = new bool[palette.Length];
+                            semiTransparentPalette = new bool[count];
                         }
                         semiTransparentPalette[c] = true;
                     }
@@ -161,15 +142,28 @@ namespace PSXPrev.Common.Parsers
                         a = 0; // Transparent when black and !stp
                     }
 
-                    color = System.Drawing.Color.FromArgb(a, r * 8, g * 8, b * 8);
+                    if (data != 0)
+                    {
+                        argb = (a << 24) | (r << 16) | (g << 8) | b;
+
+                        if (palette == null)
+                        {
+                            palette = new int[count];
+                        }
+                        palette[c] = argb;
+                    }
                 }
-                palette[c] = color;
+            }
+
+            if (palette == null)
+            {
+                palette = pmode == 0 ? Texture.EmptyPalette16 : Texture.EmptyPalette256;
             }
 
             return palette;
         }
 
-        public static System.Drawing.Color[][] ReadPalettes(BinaryReader reader, uint pmode, uint clutWidth, uint clutHeight, out bool[][] semiTransparentPalettes, bool allowOutOfBounds, bool firstOnly = false)
+        public static int[][] ReadPalettes(BinaryReader reader, uint pmode, uint clutWidth, uint clutHeight, out bool[][] semiTransparentPalettes, bool allowOutOfBounds, bool firstOnly = false)
         {
             semiTransparentPalettes = null;
 
@@ -190,14 +184,22 @@ namespace PSXPrev.Common.Parsers
             }
 
             var count = firstOnly ? 1 : clutHeight;
-            var palettes = new System.Drawing.Color[count][];
-            semiTransparentPalettes = new bool[count][];
+            var palettes = new int[count][];
+            semiTransparentPalettes = null;
 
             for (var i = 0; i < clutHeight; i++)
             {
                 if (i < count)
                 {
-                    palettes[i] = ReadPalette(reader, pmode, clutWidth, out semiTransparentPalettes[i], allowOutOfBounds);
+                    palettes[i] = ReadPalette(reader, pmode, clutWidth, out var semiTransparentPalette, allowOutOfBounds);
+                    if (semiTransparentPalette != null)
+                    {
+                        if (semiTransparentPalettes == null)
+                        {
+                            semiTransparentPalettes = new bool[count][];
+                        }
+                        semiTransparentPalettes[i] = semiTransparentPalette;
+                    }
                 }
                 else
                 {
@@ -205,13 +207,23 @@ namespace PSXPrev.Common.Parsers
                     reader.BaseStream.Seek(clutWidth * 2, SeekOrigin.Current);
                 }
             }
+            if (semiTransparentPalettes != null)
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    if (semiTransparentPalettes[i] == null)
+                    {
+                        semiTransparentPalettes[i] = pmode == 0 ? Texture.EmptySemiTransparentPalette16 : Texture.EmptySemiTransparentPalette256;
+                    }
+                }
+            }
 
             return palettes;
         }
 
-        public static Texture ReadTexture(BinaryReader reader, int clutIndex, int maxClutIndex, ushort stride, ushort height, ushort dx, ushort dy, uint pmode, System.Drawing.Color[] palette, bool[] semiTransparentPalette, bool allowOutOfBounds)
+        public static Texture ReadTexture(BinaryReader reader, ushort stride, ushort height, ushort dx, ushort dy, uint pmode, int clutIndex, int[][] palettes, bool[][] semiTransparentPalettes, bool allowOutOfBounds)
         {
-            if ((pmode == 0 || pmode == 1) && palette == null)
+            if ((pmode == 0 || pmode == 1) && palettes == null)
             {
                 return null; // No palette for clut format
             }
@@ -254,159 +266,253 @@ namespace PSXPrev.Common.Parsers
             var textureX = (dx - textureOffsetX) * 16 / textureBpp;// Math.Min(16, textureBpp); // todo: Or is this the same as textureWidth?
             var textureY = (dy - textureOffsetY);
 
+            var texture = new Texture(textureWidth, textureHeight, textureX, textureY, textureBpp, texturePage, clutIndex, palettes, semiTransparentPalettes);
 
-            var texture = new Texture(textureWidth, textureHeight, textureX, textureY, textureBpp, texturePage, clutIndex, maxClutIndex);
+            BitmapData bmpData = null;
+            BitmapData stpData = null;
             try
             {
                 var bitmap = texture.Bitmap;
-                var semiTransparentMap = semiTransparentPalette != null ? texture.SetupSemiTransparentMap() : null;
+                if (pmode <= 2 || semiTransparentPalettes != null)
+                {
+                    texture.SetupSemiTransparentMap();
+                }
 
+                var rect = new Rectangle(0, 0, textureWidth, textureHeight);
+                var pixelFormat = texture.Bitmap.PixelFormat; //Texture.GetPixelFormat(textureBpp);
+                bmpData = texture.Bitmap.LockBits(rect, ImageLockMode.WriteOnly, pixelFormat);
+                if (pmode <= 2 || semiTransparentPalettes != null)
+                {
+                    stpData = texture.SemiTransparentMap.LockBits(rect, ImageLockMode.WriteOnly, pixelFormat);
+                }
+                
                 switch (pmode)
                 {
                     case 0: // 4bpp (16clut)
-                        for (var y = 0; y < height; y++)
-                        {
-                            for (var x = 0; x < stride; x++)
-                            {
-                                var data = reader.ReadUInt16();
-                                var index1 = (data) & 0xf;
-                                var index2 = (data >> 4) & 0xf;
-                                var index3 = (data >> 8) & 0xf;
-                                var index4 = (data >> 12) & 0xf;
-
-                                var color1 = palette[index1];
-                                var color2 = palette[index2];
-                                var color3 = palette[index3];
-                                var color4 = palette[index4];
-
-                                bitmap.SetPixel((x * 4) + 0, y, color1);
-                                bitmap.SetPixel((x * 4) + 1, y, color2);
-                                bitmap.SetPixel((x * 4) + 2, y, color3);
-                                bitmap.SetPixel((x * 4) + 3, y, color4);
-
-                                if (semiTransparentPalette != null)
-                                {
-                                    if (semiTransparentPalette[index1])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 4) + 0, y, Texture.SemiTransparentFlag);
-                                    }
-                                    if (semiTransparentPalette[index2])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 4) + 1, y, Texture.SemiTransparentFlag);
-                                    }
-                                    if (semiTransparentPalette[index3])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 4) + 2, y, Texture.SemiTransparentFlag);
-                                    }
-                                    if (semiTransparentPalette[index4])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 4) + 3, y, Texture.SemiTransparentFlag);
-                                    }
-                                }
-                            }
-                        }
+                        Read4BppTexture(reader, texture, stride, bmpData, stpData);
                         break;
 
                     case 1: // 8bpp (256clut)
-                        for (var y = 0; y < height; y++)
-                        {
-                            for (var x = 0; x < stride; x++)
-                            {
-                                var data = reader.ReadUInt16();
-                                var index1 = (data) & 0xff;
-                                var index2 = (data >> 8) & 0xff;
-
-                                var color1 = palette[index1];
-                                var color2 = palette[index2];
-
-                                bitmap.SetPixel((x * 2) + 0, y, color1);
-                                bitmap.SetPixel((x * 2) + 1, y, color2);
-
-                                if (semiTransparentPalette != null)
-                                {
-                                    if (semiTransparentPalette[index1])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 2) + 0, y, Texture.SemiTransparentFlag);
-                                    }
-                                    if (semiTransparentPalette[index2])
-                                    {
-                                        semiTransparentMap.SetPixel((x * 2) + 1, y, Texture.SemiTransparentFlag);
-                                    }
-                                }
-                            }
-                        }
+                        Read8BppTexture(reader, texture, stride, bmpData, stpData);
                         break;
 
                     case 2: // 16bpp (5/5/5)
-                        for (var y = 0; y < height; y++)
-                        {
-                            for (var x = 0; x < stride; x++)
-                            {
-                                var data = reader.ReadUInt16();
-                                var r = (data) & 0x1f;
-                                var g = (data >> 5) & 0x1f;
-                                var b = (data >> 10) & 0x1f;
-                                var stp = ((data >> 15) & 0x1) == 1; // Semi-transparency: 0-Off, 1-On
-                                var a = 255;
-
-                                // Note: stpMode (not stp) is defined on a per polygon basis. We can't apply alpha now, only during rendering.
-                                if (stp)
-                                {
-                                    if (semiTransparentMap == null)
-                                    {
-                                        semiTransparentMap = texture.SetupSemiTransparentMap();
-                                    }
-                                    semiTransparentMap.SetPixel(x, y, Texture.SemiTransparentFlag);
-                                }
-                                else if (r == 0 && g == 0 && b == 0)
-                                {
-                                    a = 0; // Transparent when black and !stp
-                                }
-
-                                var color1 = System.Drawing.Color.FromArgb(a, r * 8, g * 8, b * 8);
-
-                                bitmap.SetPixel(x, y, color1);
-                            }
-                        }
+                        Read16BppTexture(reader, texture, stride, bmpData, stpData);
                         break;
 
                     case 3: // 24bpp
-                        var padding = (stride * 2) - (textureWidth * 3);
-
-                        for (var y = 0; y < height; y++)
-                        {
-                            for (var x = 0; x < textureWidth; x++)
-                            {
-                                var r = reader.ReadByte();
-                                var g = reader.ReadByte();
-                                var b = reader.ReadByte();
-
-                                var color1 = System.Drawing.Color.FromArgb(255, r, g, b);
-
-                                bitmap.SetPixel(x, y, color1);
-                            }
-                            // todo: Is there padding at the end of rows?
-                            //       It's probably padding to 2-bytes if there is any, rather than 4-bytes.
-                            for (var p = 0; p < padding; p++)
-                            {
-                                reader.ReadByte();
-                            }
-                        }
+                        Read24BppTexture(reader, texture, stride, bmpData);
                         break;
+                }
 
-                    case 4: // Mixed (not supported yet)
-                        texture.Dispose();
-                        texture = null;
-                        break;
+                if (bmpData != null)
+                {
+                    texture.Bitmap.UnlockBits(bmpData);
+                }
+                if (stpData != null)
+                {
+                    texture.SemiTransparentMap.UnlockBits(stpData);
                 }
             }
             catch
             {
+                // We can't put this in a finally block, since we don't want to Dispose of texture first
+                if (bmpData != null)
+                {
+                    texture.Bitmap.UnlockBits(bmpData);
+                }
+                if (stpData != null)
+                {
+                    texture.SemiTransparentMap.UnlockBits(stpData);
+                }
                 texture.Dispose(); // Cleanup on failure to parse
                 throw;
             }
 
             return texture;
+        }
+
+        // Gets pixel data and extra padding if data is non-null, and performs a lot of safety checks since we're using unsafe.
+        // writeStride should be expected stride for writing (without any padding).
+        private static IntPtr GetPixelData(Texture texture, BitmapData data, int writeStride, PixelFormat expectedFormat, out int padding, bool nonNull)
+        {
+            if (data != null)
+            {
+                padding = data.Stride - writeStride;
+
+                var width  = texture.Width;
+                var height = texture.Height;
+
+                // Don't use Debug.Assert, since that won't execute in release builds.
+                // Ensure we have the correct format
+                Trace.Assert(data.PixelFormat == expectedFormat, "Unexpected pixel data format in unsafe context");
+                // Ensure the dimensions are the same
+                Trace.Assert(data.Width == width && data.Height == height, "Unexpected pixel data dimensions in unsafe context");
+                // Ensure stride isn't smaller than our expected write stride
+                Trace.Assert(padding >= 0, "Unexpected pixel data stride in unsafe context");
+                // Ensure there's enough data to write to without going out of bounds
+                Trace.Assert(data.Height * data.Stride >= height * (writeStride + padding), "Unexpected pixel data size in unsafe context");
+                // Ensure our pointer is non-null
+                Trace.Assert(data.Scan0 != IntPtr.Zero, "Unexpected pixel data null pointer in unsafe context");
+
+                return data.Scan0;
+            }
+            else if (nonNull)
+            {
+                throw new ArgumentNullException("bmpData");
+            }
+            padding = 0;
+            return IntPtr.Zero;
+        }
+
+        private static unsafe void Read4BppTexture(BinaryReader reader, Texture texture, ushort stride, BitmapData bmpData, BitmapData stpData)
+        {
+            var width  = texture.Width;
+            var height = texture.Height;
+
+            // This expects 4bpp Textures to use 4bpp indexed format
+            var writeStride = width / 2;
+            var expectedFormat = PixelFormat.Format4bppIndexed;
+            var p = (byte*)GetPixelData(texture, bmpData, writeStride, expectedFormat, out var bmpPadding, true);
+            var s = (byte*)GetPixelData(texture, stpData, writeStride, expectedFormat, out var stpPadding, false);
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width / 2; x++)
+                {
+                    // Swap order of 4-bit indices in bytes
+                    var data = reader.ReadByte();
+                    var index1 = (data >> 4) & 0xf;
+                    var index2 = (data     ) & 0xf;
+                    data = (byte)((index2 << 4) | index1);
+
+                    *p++ = data;
+                    if (s != null)
+                    {
+                        *s++ = data;
+                    }
+                }
+
+                p += bmpPadding;
+                if (s != null)
+                {
+                    s += stpPadding;
+                }
+            }
+        }
+
+        private static unsafe void Read8BppTexture(BinaryReader reader, Texture texture, ushort stride, BitmapData bmpData, BitmapData stpData)
+        {
+            var width  = texture.Width;
+            var height = texture.Height;
+
+            // This expects 8bpp Textures to use 8bpp indexed format
+            var writeStride = width;
+            var expectedFormat = PixelFormat.Format8bppIndexed;
+            var p = (byte*)GetPixelData(texture, bmpData, writeStride, expectedFormat, out var bmpPadding, true);
+            var s = (byte*)GetPixelData(texture, stpData, writeStride, expectedFormat, out var stpPadding, false);
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var data = reader.ReadByte();
+                    *p++ = data;
+                    if (s != null)
+                    {
+                        *s++ = data;
+                    }
+                }
+
+                p += bmpPadding;
+                if (s != null)
+                {
+                    s += stpPadding;
+                }
+            }
+        }
+
+        private static unsafe void Read16BppTexture(BinaryReader reader, Texture texture, ushort stride, BitmapData bmpData, BitmapData stpData)
+        {
+            var width  = texture.Width;
+            var height = texture.Height;
+
+            // This expects 16bpp Textures to use 32bpp format
+            var writeStride = width * 4;
+            var expectedFormat = PixelFormat.Format32bppArgb;
+            var p = (int*)GetPixelData(texture, bmpData, writeStride, expectedFormat, out var bmpPadding, true);
+            var s = (int*)GetPixelData(texture, stpData, writeStride, expectedFormat, out var stpPadding, false);
+
+            var noStpArgb = Texture.NoSemiTransparentFlag.ToArgb();
+            var stpArgb   = Texture.SemiTransparentFlag.ToArgb();
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var data = reader.ReadUInt16();
+                    var r = ((data      ) & 0x1f) << 3;
+                    var g = ((data >>  5) & 0x1f) << 3;
+                    var b = ((data >> 10) & 0x1f) << 3;
+                    var stp = ((data >> 15) & 0x1) == 1; // Semi-transparency: 0-Off, 1-On
+                    var a = 255;
+
+                    // Note: stpMode (not stp) is defined on a per polygon basis. We can't apply alpha now, only during rendering.
+                    if (!stp && r == 0 && g == 0 && b == 0)
+                    {
+                        a = 0; // Transparent when black and !stp
+                    }
+
+                    var argb = (a << 24) | (r << 16) | (g << 8) | b;
+                    *p++ = argb;
+                    if (s != null)
+                    {
+                        argb = stp ? stpArgb : noStpArgb;
+                        *s++ = argb;
+                    }
+                }
+
+                p = (int*)(((byte*)p) + bmpPadding);
+                if (s != null)
+                {
+                    s = (int*)(((byte*)s) + stpPadding);
+                }
+            }
+        }
+
+        private static unsafe void Read24BppTexture(BinaryReader reader, Texture texture, ushort stride, BitmapData bmpData)
+        {
+            var width  = texture.Width;
+            var height = texture.Height;
+            var readPadding = (stride * 2) - (width * 3);
+
+            // This expects 24bpp Textures to use 32bpp format
+            var writeStride = width * 4;
+            var expectedFormat = PixelFormat.Format32bppArgb;
+            var p = (int*)GetPixelData(texture, bmpData, writeStride, expectedFormat, out var bmpPadding, true);
+
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var r = reader.ReadByte();
+                    var g = reader.ReadByte();
+                    var b = reader.ReadByte();
+                    var a = 255;
+
+                    var argb = (a << 24) | (r << 16) | (g << 8) | b;
+                    *p++ = argb;
+                }
+
+                p = (int*)(((byte*)p) + bmpPadding);
+
+                // todo: Is there padding at the end of rows?
+                //       It's probably padding to 2-bytes if there is any, rather than 4-bytes.
+                for (var pad = 0; pad < readPadding; pad++)
+                {
+                    reader.ReadByte();
+                }
+            }
         }
 
         public static uint GetModeFromClut(ushort clutWidth)

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -70,7 +70,7 @@ namespace PSXPrev.Common.Renderer
                 {
                     // X coordinates [0,256) store texture data.
                     // X coordinates [256,512) store semi-transparency information for textures.
-                    _vramPages[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i, 0, 0, true); // Is VRAM page
+                    _vramPages[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i, 0, null, null, true); // Is VRAM page
                     _vramPages[i].TextureName = $"VRAM[{i}]";
                     ClearPage(i, suppressUpdate);
                 }

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -2,61 +2,95 @@
 using System.ComponentModel;
 using System.Drawing;
 using PSXPrev.Common.Renderer;
+using PSXPrev.Common.Utils;
 
 namespace PSXPrev.Common
 {
     public class Texture : IDisposable
     {
-        public static readonly System.Drawing.Color NoSemiTransparentFlag = System.Drawing.Color.FromArgb(255, 0, 0, 0);
+        public static readonly System.Drawing.Color NoSemiTransparentFlag = System.Drawing.Color.FromArgb(0, 0, 0, 0);
         public static readonly System.Drawing.Color SemiTransparentFlag = System.Drawing.Color.FromArgb(255, 255, 255, 255);
+
+        public static readonly int[] EmptyPalette16  = new int[16];
+        public static readonly int[] EmptyPalette256 = new int[256];
+
+        public static readonly bool[] EmptySemiTransparentPalette16  = new bool[16];
+        public static readonly bool[] EmptySemiTransparentPalette256 = new bool[256];
+
 
         private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
 
-        public Texture(Bitmap bitmap, int x, int y, int bpp, int texturePage, int clutIndex, int maxClutIndex, bool isVRAMPage = false)
+        public Texture(Bitmap bitmap, int x, int y, int bpp, int texturePage, int clutIndex, int[][] palettes, bool[][] semiTransparentPalettes, bool isVRAMPage = false)
         {
             Bitmap = bitmap;
             X = x;
             Y = y;
             Bpp = bpp;
             TexturePage = texturePage;
-            ClutIndex = clutIndex;
-            MaxClutIndex = maxClutIndex;
+            CLUTIndex = clutIndex;
+            Palettes = palettes;
+            SemiTransparentPalettes = semiTransparentPalettes;
             IsVRAMPage = isVRAMPage;
         }
 
-        public Texture(int width, int height, int x, int y, int bpp, int texturePage, int clutIndex, int maxClutIndex, bool isVRAMPage = false)
-            : this(new Bitmap(width, height), x, y, bpp, texturePage, clutIndex, maxClutIndex, isVRAMPage)
+        public Texture(int width, int height, int x, int y, int bpp, int texturePage, int clutIndex, int[][] palettes, bool[][] semiTransparentPalettes, bool isVRAMPage = false)
+            : this(new Bitmap(width, height, GetPixelFormat(bpp)), x, y, bpp, texturePage, clutIndex, palettes, semiTransparentPalettes, isVRAMPage)
         {
+            if (SemiTransparentPalettes != null)
+            {
+                var stpPalette = SemiTransparentPalettes[0];
+                if (!IsEmptySemiTransparentPalette(stpPalette))
+                {
+                    SetupSemiTransparentMap();
+                }
+            }
+            SetCLUTIndex(clutIndex, true);
+            // Throw away the palettes if we only have one, since we'll never need them again
+            if (Palettes != null && Palettes.Length == 1)
+            {
+                Palettes = null;
+            }
+            if (SemiTransparentPalettes != null && SemiTransparentPalettes.Length == 1)
+            {
+                SemiTransparentPalettes = null;
+            }
         }
 
-        public Texture(Texture fromTexture)
-            : this(fromTexture.Width, fromTexture.Height, fromTexture.X, fromTexture.Y, fromTexture.Bpp, fromTexture.TexturePage, fromTexture.ClutIndex, fromTexture.MaxClutIndex, fromTexture.IsVRAMPage)
+        // preserveFormat has no effect if HasPalette is false, otherwise the copy will be much slower when true.
+        public Texture(Texture fromTexture, bool preserveFormat)
         {
+            X = fromTexture.X;
+            Y = fromTexture.Y;
+            TexturePage = fromTexture.TexturePage;
+            IsVRAMPage = fromTexture.IsVRAMPage;
+            TextureName = fromTexture.TextureName;
+            FormatName = fromTexture.FormatName;
             try
             {
-                TextureName = fromTexture.TextureName;
-
-                // Copy main bitmap
-                using (var graphics = Graphics.FromImage(Bitmap))
+                // Preserve format only needs to do something special if we're paletted
+                if (preserveFormat && fromTexture.HasPalette)
                 {
-                    // Use SourceCopy to overwrite image alpha with alpha stored in textures.
-                    graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
-                    graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+                    Bpp = fromTexture.Bpp;
+                    CLUTIndex = fromTexture.CLUTIndex;
+                    Palettes = fromTexture.Palettes;
+                    SemiTransparentPalettes = fromTexture.SemiTransparentPalettes;
 
-                    graphics.DrawImage(fromTexture.Bitmap, 0, 0);
-                }
+                    Bitmap = fromTexture.Bitmap.DeepClone();
 
-                if (fromTexture.SemiTransparentMap != null)
-                {
-                    // Copy semi-transparent bitmap
-                    SetupSemiTransparentMap();
-                    using (var graphics = Graphics.FromImage(SemiTransparentMap))
+                    if (fromTexture.SemiTransparentMap != null)
                     {
-                        // Use SourceCopy to overwrite image alpha with alpha stored in textures.
-                        graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
-                        graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;
+                        SemiTransparentMap = fromTexture.SemiTransparentMap.DeepClone();
+                    }
+                }
+                else
+                {
+                    Bpp = fromTexture.HasPalette ? 32 : fromTexture.Bpp;
 
-                        graphics.DrawImage(fromTexture.SemiTransparentMap, 0, 0);
+                    Bitmap = new Bitmap(fromTexture.Bitmap);
+
+                    if (fromTexture.SemiTransparentMap != null)
+                    {
+                        SemiTransparentMap = new Bitmap(fromTexture.SemiTransparentMap);
                     }
                 }
             }
@@ -82,11 +116,11 @@ namespace PSXPrev.Common
         [DisplayName("VRAM Page")]
         public int TexturePage { get; set; }
 
-        [DisplayName("CLUT Index"), Browsable(false)]
-        public int ClutIndex { get; set; }
+        [DisplayName("CLUT Index"), ReadOnly(true), Browsable(false)]
+        public int CLUTIndex { get; set; }
 
-        [Browsable(false)]
-        public int MaxClutIndex { get; set; }
+        [DisplayName("CLUT Count"), ReadOnly(true)]
+        public int CLUTCount => (Palettes?.Length ?? (HasPalette ? 1 : 0));
 
         [DisplayName("BPP"), ReadOnly(true)]
         public int Bpp { get; set; }
@@ -103,6 +137,18 @@ namespace PSXPrev.Common
 
         [Browsable(false)]
         public int RenderHeight => IsVRAMPage ? VRAM.PageSize : Height;
+
+        [Browsable(false)]
+        public int[][] Palettes { get; set; }
+
+        [Browsable(false)]
+        public bool[][] SemiTransparentPalettes { get; set; }
+
+        [Browsable(false)]
+        public int PaletteSize => Palettes?[0].Length ?? 0;
+
+        [Browsable(false)]
+        public bool HasPalette => Bpp <= 8;
 
         [Browsable(false)]
         public bool IsVRAMPage { get; set; }
@@ -128,14 +174,35 @@ namespace PSXPrev.Common
         }
 
 
+        public void SetCLUTIndex(int clutIndex, bool force = false)
+        {
+            if (Palettes == null)
+            {
+                return;
+            }
+            if (clutIndex < 0 || clutIndex >= Palettes.Length)
+            {
+                clutIndex = 0; // Default to first CLUT index if we're out of bounds
+            }
+            if (force || CLUTIndex != clutIndex)
+            {
+                SetBitmapPalette(Bitmap, Palettes[clutIndex]);
+                if (SemiTransparentMap != null && SemiTransparentPalettes != null)
+                {
+                    SetSemiTransparentMapPalette(SemiTransparentMap, SemiTransparentPalettes[clutIndex]);
+                }
+                CLUTIndex = clutIndex;
+            }
+        }
+
         public Bitmap SetupSemiTransparentMap()
         {
             if (SemiTransparentMap == null)
             {
-                SemiTransparentMap = new Bitmap(Width, Height);
-                using (var graphics = Graphics.FromImage(SemiTransparentMap))
+                SemiTransparentMap = new Bitmap(Width, Height, Bitmap.PixelFormat);
+                if (SemiTransparentPalettes != null)
                 {
-                    graphics.Clear(Texture.NoSemiTransparentFlag);
+                    SetSemiTransparentMapPalette(SemiTransparentMap, SemiTransparentPalettes[0]);
                 }
             }
             return SemiTransparentMap;
@@ -145,6 +212,52 @@ namespace PSXPrev.Common
         {
             Bitmap?.Dispose();
             SemiTransparentMap?.Dispose();
+        }
+
+
+        public static System.Drawing.Imaging.PixelFormat GetPixelFormat(int bpp)
+        {
+            switch (bpp)
+            {
+                case 4: return System.Drawing.Imaging.PixelFormat.Format4bppIndexed;
+                case 8: return System.Drawing.Imaging.PixelFormat.Format8bppIndexed;
+                case 16:
+                case 24:
+                case 32: return System.Drawing.Imaging.PixelFormat.Format32bppArgb;
+                default: return 0;
+            }
+        }
+
+        public static bool IsEmptyPalette(int[] palette)
+        {
+            return palette == EmptyPalette16 || palette == EmptyPalette256;
+        }
+
+        public static bool IsEmptySemiTransparentPalette(bool[] stpPalette)
+        {
+            return stpPalette == EmptySemiTransparentPalette16 || stpPalette == EmptySemiTransparentPalette256;
+        }
+
+        private static void SetBitmapPalette(Bitmap bitmap, int[] palette)
+        {
+            var count = palette.Length;
+            var colorPalette = bitmap.Palette;
+            for (var i = 0; i < count; i++)
+            {
+                colorPalette.Entries[i] = System.Drawing.Color.FromArgb(palette[i]);
+            }
+            bitmap.Palette = colorPalette;
+        }
+
+        private static void SetSemiTransparentMapPalette(Bitmap semiTransparentMap, bool[] stpPalette)
+        {
+            var count = stpPalette.Length;
+            var stpColorPalette = semiTransparentMap.Palette;
+            for (var i = 0; i < count; i++)
+            {
+                stpColorPalette.Entries[i] = stpPalette[i] ? SemiTransparentFlag : NoSemiTransparentFlag;
+            }
+            semiTransparentMap.Palette = stpColorPalette;
         }
     }
 }

--- a/Common/Utils/DrawingExtensions.cs
+++ b/Common/Utils/DrawingExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Drawing;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace PSXPrev.Common.Utils
+{
+    public static class DrawingExtensions
+    {
+        // Needed to clone a bitmap while preserving its pixel format.
+        public static Bitmap DeepClone(this Bitmap bitmap)
+        {
+            var formatter = new BinaryFormatter();
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, bitmap);
+                stream.Seek(0, SeekOrigin.Begin);
+                return (Bitmap)formatter.Deserialize(stream);
+            }
+        }
+    }
+}

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -1882,8 +1882,7 @@ namespace PSXPrev.Forms
             this.setPaletteIndexToolStripMenuItem.Image = global::PSXPrev.Properties.Resources.Textures_SetPaletteIndex;
             this.setPaletteIndexToolStripMenuItem.Name = "setPaletteIndexToolStripMenuItem";
             this.setPaletteIndexToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.setPaletteIndexToolStripMenuItem.Text = "Set Palette Index";
-            this.setPaletteIndexToolStripMenuItem.Visible = false;
+            this.setPaletteIndexToolStripMenuItem.Text = "Set CLUT Index";
             this.setPaletteIndexToolStripMenuItem.Click += new System.EventHandler(this.setPaletteIndexToolStripMenuItem_Click);
             // 
             // autoDrawModelTexturesToolStripMenuItem

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>1</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\Icons\PlayStation_DarkSquare.ico</ApplicationIcon>
@@ -118,6 +120,7 @@
     <Compile Include="Common\Renderer\TextureBinder.cs" />
     <Compile Include="Common\Renderer\VRAM.cs" />
     <Compile Include="Common\Utils\BinaryReaderExtensions.cs" />
+    <Compile Include="Common\Utils\DrawingExtensions.cs" />
     <Compile Include="Common\Utils\FInt.cs" />
     <Compile Include="Common\Utils\JsonStringColorConverter.cs" />
     <Compile Include="Common\Utils\JsonStringEnumConverter.cs" />

--- a/Settings.cs
+++ b/Settings.cs
@@ -119,8 +119,8 @@ namespace PSXPrev
         [JsonProperty("colorDialogCustomColors", ItemConverterType = typeof(JsonStringColorConverter))]
         private System.Drawing.Color[] ColorDialogCustomColors { get; set; } = new System.Drawing.Color[0];
 
-        [JsonProperty("currentPaletteIndex")]
-        public int PaletteIndex { get; set; } = 0;
+        [JsonProperty("currentCLUTIndex")]
+        public int CurrentCLUTIndex { get; set; } = 0;
 
         [JsonProperty("showUVsInVRAM")]
         public bool ShowUVsInVRAM { get; set; } = true;
@@ -248,7 +248,7 @@ namespace PSXPrev
             BackgroundColor   = ValidateColor(BackgroundColor,   Defaults.BackgroundColor);
             AmbientColor      = ValidateColor(AmbientColor,      Defaults.AmbientColor);
             MaskColor         = ValidateColor(MaskColor,         Defaults.MaskColor);
-            PaletteIndex      = ValidateClamp(PaletteIndex,      Defaults.PaletteIndex, 0, 255);
+            CurrentCLUTIndex  = ValidateClamp(CurrentCLUTIndex,  Defaults.CurrentCLUTIndex, 0, 255);
             AnimationLoopMode = ValidateEnum( AnimationLoopMode, Defaults.AnimationLoopMode);
             AnimationSpeed    = ValidateClamp(AnimationSpeed,    Defaults.AnimationSpeed, 0.01f, 100f);
             LogStandardColor        = ValidateEnum(LogStandardColor,        Defaults.LogStandardColor);


### PR DESCRIPTION
* Added Textures > Set CLUT Index menu item to set the current CLUT index for all textures. This can also be changed with -/+ keys while the textures list view is focused.
* Textures are now stored in their native bit format (for paletted textures only, everything else is still 32 bpp).
* Textures are now written to using unsafe code (which is needed for indexed texture formats). A ton of safety asserts are in-place when using this code to avoid any possible chance of crashing. Because of this change, reading textures is much much faster now, and should also use up less memory, considering most textures are usually paletted.
* Textures now store all variations of their palettes (if more than one palette exists), palettes are now also stored as int[] instead of Color[], since Color is a waste of memory space (string, long, and more fields, just why??).