### PR TITLE
Lower .NET Framework version to v4.5

### DIFF
--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PSXPrev</RootNamespace>
     <AssemblyName>PSXPrev</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Settings.cs
+++ b/Settings.cs
@@ -296,7 +296,11 @@ namespace PSXPrev
         {
             try
             {
-                Instance = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(FilePath));
+                Instance = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(FilePath), new JsonSerializerSettings
+                {
+                    // Fix security vulnerability in-case the settings file somehow gets replaced by someone else
+                    MaxDepth = 128,
+                });
                 Instance.Validate();
 
                 // Create a settings file if one doesn't already exist.


### PR DESCRIPTION
* Lower the version, since we don't need any of the newer features yet. Less users are likely to have v4.8 anyway.
* Fixed security vulnerability with loading settings.json file by reducing max depth to 128 (in the scenario that the file was replaced by something else with malicious intent).