### PR TITLE
Scanner Progress Optimizations

### DIFF
--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -673,6 +673,58 @@ namespace PSXPrev.Common
             return r < 0 ? r + m : r;
         }
 
+        // Integer division where the result is always rounded down, instead of rounded towards zero.
+        public static int FloorDiv(int x, int y)
+        {
+            // XOR to check if only one value is negative, modulus to avoid cases where the result is alread floored.
+            if (((x < 0) ^ (y < 0)) && (x % y != 0))
+            {
+                return (x / y) - 1;
+            }
+            else
+            {
+                return x / y;
+            }
+        }
+
+        public static long FloorDiv(long x, long y)
+        {
+            // XOR to check if only one value is negative, modulus to avoid cases where the result is alread floored.
+            if (((x < 0) ^ (y < 0)) && (x % y != 0))
+            {
+                return (x / y) - 1;
+            }
+            else
+            {
+                return x / y;
+            }
+        }
+
+        // Combination of FloorDiv and PositiveModulus. result is the remainder.
+        public static int FloorDivRem(int x, int y, out int result)
+        {
+            var div = Math.DivRem(x, y, out result);
+            // XOR to check if only one value is negative, non-zero to avoid cases where the result is alread floored.
+            if (((x < 0) ^ (y < 0)) && result != 0)
+            {
+                result += y;
+                div--;
+            }
+            return div;
+        }
+
+        public static long FloorDivRem(long x, long y, out long result)
+        {
+            var div = Math.DivRem(x, y, out result);
+            // XOR to check if only one value is negative, non-zero to avoid cases where the result is alread floored.
+            if (((x < 0) ^ (y < 0)) && result != 0)
+            {
+                result += y;
+                div--;
+            }
+            return div;
+        }
+
         // Yes, OpenTK.MathHelper.Clamp exists, but only for int, float, and double.
         // Using it when not expecting it to be missing other types is dangerous.
         // Like if using long with MathHelper.Clamp, YOU'LL GET A FLOAT OF ALL THINGS!!!

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -7,6 +7,10 @@ namespace PSXPrev.Common.Parsers
 {
     public class MODParser : FileOffsetScanner
     {
+        //private Vector3[] _boundingBox;
+        private Vector3[] _vertices;
+        private Vector3[] _normals;
+
         public MODParser(EntityAddedAction entityAdded)
             : base(entityAdded: entityAdded)
         {
@@ -42,7 +46,7 @@ namespace PSXPrev.Common.Parsers
             return new Vector3(x, -z, y);
         }
 
-        private static RootEntity ReadModels(BinaryReader reader)
+        private RootEntity ReadModels(BinaryReader reader)
         {
             var groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
 
@@ -85,10 +89,14 @@ namespace PSXPrev.Common.Parsers
                 var radius = reader.ReadInt32() / FIXED_DIV;
 
                 // Bounding box indices: <https://github.com/vs49688/CrocUtils/blob/5e07b7cb60fb5edec465a509d8924ae6682eaba7/libcroc/include/libcroc/moddef.h#L97-L108>
-                var boundingBox = new Vector3[9]; // 0 is the center.
+                //if (_boundingBox == null)
+                //{
+                //    _boundingBox = new Vector3[9];
+                //}
+                //var boundingBox = _boundingBox;// new Vector3[9]; // 0 is the center.
                 for (var j = 0; j < 9; j++)
                 {
-                    boundingBox[j] = ReadVector(reader);
+                    /*boundingBox[j] =*/ ReadVector(reader);
                 }
 
                 // See notes by countFaces.
@@ -97,8 +105,13 @@ namespace PSXPrev.Common.Parsers
                 {
                     return null;
                 }
-                var vertices = new Vector3[countVerts];
-                var normals = new Vector3[countVerts];
+                if (_vertices == null || _vertices.Length < countVerts)
+                {
+                    Array.Resize(ref _vertices, (int)countVerts);
+                    Array.Resize(ref _normals,  (int)countVerts);
+                }
+                var vertices = _vertices;// new Vector3[countVerts];
+                var normals = _normals;// new Vector3[countVerts];
                 for (var j = 0; j < countVerts; j++)
                 {
                     vertices[j] = ReadVector(reader);
@@ -139,7 +152,7 @@ namespace PSXPrev.Common.Parsers
                     //var materialName = Encoding.ASCII.GetString(reader.ReadBytes(64));
 
                     // This vector almost always has a length nearing 1 (more often than the normals list).
-                    // Only two files has been found where the vector length was 0.
+                    // Only two files have been found where the vector length was 0.
                     // (NEPT00.MOD and NEPTD00.MOD, where flags=0x00)
                     // 
                     // My theory is that this is an opportunity to allow using
@@ -240,7 +253,7 @@ namespace PSXPrev.Common.Parsers
                         var b = ((faceInfo >> 16) & 0xff) / 255f;
                         color = new Color(r, g, b);
 
-                        tPage = 0; //todo
+                        tPage = 0;
                     }
 
                     AddTriangle(new Triangle

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -273,10 +273,16 @@ namespace PSXPrev.Common.Parsers
                 ReadSharedVertices(reader, vo3, out v3x, out v3y, out v3z);
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
-            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt4, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r1, g1, b1, r2, g2, b2, u0, v0, u1, v1, u2, v2, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
-            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt4, false, false, null, null, 0, 0, 0, 0, 0,
-             0, r1, g1, b1, r3, g3, b3, r2, g2, b2, u1, v1, u3, v3, u2, v2, v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
+            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r0, g0, b0, r1, g1, b1, r2, g2, b2,
+                                                  u0, v0, u1, v1, u2, v2,
+                                                  v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r1, g1, b1, r3, g3, b3, r2, g2, b2,
+                                                  u1, v1, u3, v3, u2, v2,
+                                                  v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
             return new[] { triangle1, triangle2 };
         }
 
@@ -345,10 +351,16 @@ namespace PSXPrev.Common.Parsers
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
 
-            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g4, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r1, g1, b1, r2, g2, b2, 0, 0, 0, 0, 0, 0, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
-            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g4, false, false, null, null, 0, 0, 0, 0, 0,
-             0, r1, g1, b1, r3, g3, b3, r2, g2, b2, 0, 0, 0, 0, 0, 0, v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
+            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r0, g0, b0, r1, g1, b1, r2, g2, b2,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r1, g1, b1, r3, g3, b3, r2, g2, b2,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
             return new[] { triangle1, triangle2 };
         }
 
@@ -419,10 +431,16 @@ namespace PSXPrev.Common.Parsers
                 ReadSharedVertices(reader, vo3, out v3x, out v3y, out v3z);
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
-            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft4, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r, g, b, r, g, b, r, g, b, u0, v0, u1, v1, u2, v2, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
-            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft4, false, false, null, null, 0, 0, 0, 0, 0,
-               0, r, g, b, r, g, b, r, g, b, u1, v1, u3, v3, u2, v2, v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
+            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r, g, b, r, g, b, r, g, b,
+                                                  u0, v0, u1, v1, u2, v2,
+                                                  v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r, g, b, r, g, b, r, g, b,
+                                                  u1, v1, u3, v3, u2, v2,
+                                                  v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
             return new[] { triangle1, triangle2 };
         }
 
@@ -476,10 +494,16 @@ namespace PSXPrev.Common.Parsers
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
 
-            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f4, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r0, g0, b0, r0, g0, b0, 0, 0, 0, 0, 0, 0, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
-            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f4, false, false, null, null, 0, 0, 0, 0, 0,
-            0, r0, g0, b0, r0, g0, b0, r0, g0, b0, 0, 0, 0, 0, 0, 0, v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
+            var triangle1 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r0, g0, b0, r0, g0, b0, r0, g0, b0,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle2 = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f4, false, false, null, null,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  r0, g0, b0, r0, g0, b0, r0, g0, b0,
+                                                  0, 0, 0, 0, 0, 0,
+                                                  v1x, v1y, v1z, v3x, v3y, v3z, v2x, v2y, v2z);
             return new[] { triangle1, triangle2 };
         }
 
@@ -550,8 +574,11 @@ namespace PSXPrev.Common.Parsers
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
 
-            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt3, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r1, g1, b1, r2, g2, b2, u0, v0, u1, v1, u2, v2, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_gt3, false, false, null, null,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 r0, g0, b0, r1, g1, b1, r2, g2, b2,
+                                                 u0, v0, u1, v1, u2, v2,
+                                                 v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
             return triangle;
         }
 
@@ -597,8 +624,11 @@ namespace PSXPrev.Common.Parsers
                 ReadSharedVertices(reader, vo2, out v2x, out v2y, out v2z);
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
-            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f3, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r0, g0, b0, r0, g0, b0, 0, 0, 0, 0, 0, 0, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_f3, false, false, null, null,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 r0, g0, b0, r0, g0, b0, r0, g0, b0,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
             return triangle;
         }
 
@@ -655,8 +685,11 @@ namespace PSXPrev.Common.Parsers
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
 
-            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g3, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r0, g0, b0, r1, g1, b1, r2, g2, b2, 0, 0, 0, 0, 0, 0, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_g3, false, false, null, null,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 r0, g0, b0, r1, g1, b1, r2, g2, b2,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
             return triangle;
         }
 
@@ -717,8 +750,11 @@ namespace PSXPrev.Common.Parsers
                 ReadSharedVertices(reader, vo2, out v2x, out v2y, out v2z);
                 reader.BaseStream.Seek(position, SeekOrigin.Begin);
             }
-            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft3, false, false, null, null, 0, 0, 0, 0, 0,
-                0, r, g, b, r, g, b, r, g, b, u0, v0, u1, v1, u2, v2, v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
+            var triangle = TriangleFromPrimitive(Triangle.PrimitiveTypeEnum._poly_ft3, false, false, null, null,
+                                                 0, 0, 0, 0, 0, 0,
+                                                 r, g, b, r, g, b, r, g, b,
+                                                 u0, v0, u1, v1, u2, v2,
+                                                 v0x, v0y, v0z, v1x, v1y, v1z, v2x, v2y, v2z);
             return triangle;
         }
 

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -49,6 +49,8 @@ namespace PSXPrev.Forms
         }
         public AnimationBatch AnimationBatch { get; private set; }
 
+        public ExportModelOptions Options { get; private set; }
+
         public ExportModelsForm()
         {
             InitializeComponent();
@@ -142,16 +144,7 @@ namespace PSXPrev.Forms
             WriteSettings(Settings.Instance, options);
             Settings.Instance.Save();
 
-            if (DialogResult != DialogResult.OK)
-            {
-                return;
-            }
-
-            //var options = CreateOptions();
-            //WriteSettings(Settings.Instance, options);
-            //Settings.Instance.Save();
-
-            Export(options, Entities, Animations, AnimationBatch);
+            Options = options;
         }
 
         private ExportModelOptions CreateOptions()
@@ -288,14 +281,18 @@ namespace PSXPrev.Forms
             }
         }
 
-        public static bool Show(IWin32Window owner, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
+        public static ExportModelOptions Show(IWin32Window owner, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
         {
             using (var form = new ExportModelsForm())
             {
                 form.Entities = entities;
                 form.Animations = animations;
                 form.AnimationBatch = animationBatch;
-                return form.ShowDialog(owner) == DialogResult.OK;
+                if (form.ShowDialog(owner) == DialogResult.OK)
+                {
+                    return form.Options;
+                }
+                return null;
             }
         }
     }

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -314,6 +314,7 @@ namespace PSXPrev.Forms
             this.entitiesTreeView.Size = new System.Drawing.Size(330, 200);
             this.entitiesTreeView.TabIndex = 9;
             this.entitiesTreeView.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterCheck);
+            this.entitiesTreeView.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.entitiesTreeView_BeforeExpand);
             this.entitiesTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterSelect);
             this.entitiesTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.entitiesTreeView_NodeMouseClick);
             // 
@@ -715,6 +716,7 @@ namespace PSXPrev.Forms
             this.animationsTreeView.Name = "animationsTreeView";
             this.animationsTreeView.Size = new System.Drawing.Size(330, 400);
             this.animationsTreeView.TabIndex = 10;
+            this.animationsTreeView.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.animationsTreeView_BeforeExpand);
             this.animationsTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.animationsTreeView_AfterSelect);
             // 
             // animationPropertyGrid

--- a/Forms/ScannerForm.cs
+++ b/Forms/ScannerForm.cs
@@ -10,6 +10,8 @@ namespace PSXPrev.Forms
     {
         private bool _showAdvanved;
 
+        public ScanOptions Options { get; private set; }
+
         public ScannerForm()
         {
             InitializeComponent();
@@ -181,20 +183,7 @@ namespace PSXPrev.Forms
             WriteSettings(Settings.Instance, options);
             Settings.Instance.Save();
 
-            if (DialogResult != DialogResult.OK)
-            {
-                return;
-            }
-
-            //var options = CreateOptions();
-            //WriteSettings(Settings.Instance, options);
-            //Settings.Instance.Save();
-
-            if (!Program.ScanAsync(options))
-            {
-                MessageBox.Show(this, $"Directory/File not found: {options.Path}", "Scan Failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                DialogResult = DialogResult.Cancel; // Change dialog result so that Show returns false.
-            }
+            Options = options;
         }
 
         private ScanOptions CreateOptions()
@@ -231,7 +220,8 @@ namespace PSXPrev.Forms
                 AsyncFileScan = optionAsyncScanCheckBox.Checked,
                 //TopDownFileSearch = true, // Not that important, don't add to reduce UI clutter
                 ReadISOContents = isoContentsCheckBox.Checked,
-                ReadBINContents = binContentsCheckBox.Checked,
+                ReadBINContents = false, //todo
+                ReadBINSectorData = binContentsCheckBox.Checked,
                 //BINAlignToSector = false, // Just enter size into Align, don't add to reduce UI clutter
                 BINSectorUserStartSizeHasValue = binSectorCheckBox.Checked,
                 BINSectorUserStartValue = (int)binSectorStartUpDown.Value,
@@ -285,7 +275,8 @@ namespace PSXPrev.Forms
 
             optionAsyncScanCheckBox.Checked = options.AsyncFileScan;
             isoContentsCheckBox.Checked = options.ReadISOContents;
-            binContentsCheckBox.Checked = options.ReadBINContents;
+            // todo: ReadBINContents
+            binContentsCheckBox.Checked = options.ReadBINSectorData;
             binSectorCheckBox.Checked = options.BINSectorUserStartSizeHasValue;
             binSectorStartUpDown.SetValueSafe(options.BINSectorUserStartValue);
             binSectorSizeUpDown.SetValueSafe(options.BINSectorUserSizeValue);
@@ -311,11 +302,15 @@ namespace PSXPrev.Forms
         }
 
 
-        public static bool Show(IWin32Window owner)
+        public static ScanOptions Show(IWin32Window owner)
         {
             using (var form = new ScannerForm())
             {
-                return form.ShowDialog(owner) == DialogResult.OK;
+                if (form.ShowDialog(owner) == DialogResult.OK)
+                {
+                    return form.Options;
+                }
+                return null;
             }
         }
     }

--- a/Forms/Utils/ControlExtensions.cs
+++ b/Forms/Utils/ControlExtensions.cs
@@ -47,6 +47,55 @@ namespace PSXPrev.Forms.Utils
         }
 
 
+        // ProgressBars introduced a moving animation in Vista, which means you can't instantly force a progress
+        // bar to a specific position UNLESS the value being assigned is less than the current value.
+        // This solves that by first assigning value + 1, then assigning value.
+        // <https://stackoverflow.com/questions/977278/how-can-i-make-the-progress-bar-update-fast-enough>
+        public static void SetValueInstant(this ProgressBar progressBar, int value)
+        {
+            value = Constrain(progressBar, value);
+            if (value < progressBar.Maximum)
+            {
+                progressBar.Value = value + 1;
+                progressBar.Value = value;
+            }
+            else if (progressBar.Maximum < int.MaxValue)
+            {
+                progressBar.Maximum++;
+                progressBar.Value = value + 1;
+                progressBar.Value = value;
+                progressBar.Maximum--;
+            }
+        }
+
+        public static void SetValueInstant(this ToolStripProgressBar progressBar, int value)
+        {
+            value = Constrain(progressBar, value);
+            if (value < progressBar.Maximum)
+            {
+                progressBar.Value = value + 1;
+                progressBar.Value = value;
+            }
+            else if (progressBar.Maximum < int.MaxValue)
+            {
+                progressBar.Maximum++;
+                progressBar.Value = value + 1;
+                progressBar.Value = value;
+                progressBar.Maximum--;
+            }
+        }
+
+        public static void UpdateValueInstant(this ProgressBar progressBar)
+        {
+            SetValueInstant(progressBar, progressBar.Value);
+        }
+
+        public static void UpdateValueInstant(this ToolStripProgressBar progressBar)
+        {
+            SetValueInstant(progressBar, progressBar.Value);
+        }
+
+
         public static T GetFocusedControlOfType<T>(this ContainerControl container) where T : Control
         {
             var focusedControl = container.ActiveControl;

--- a/ScanOptions.cs
+++ b/ScanOptions.cs
@@ -77,7 +77,9 @@ namespace PSXPrev
         [JsonProperty("fileSearchISOContents")]
         public bool ReadISOContents { get; set; } = true; // Disable this by default when parsing command line arguments
         [JsonProperty("fileSearchBINContents")]
-        public bool ReadBINContents { get; set; } = false;
+        public bool ReadBINContents { get; set; } = false; // Read indexed files instead of data of BIN file.
+        [JsonProperty("fileSearchBINSectorData")]
+        public bool ReadBINSectorData { get; set; } = false;
         [JsonProperty("binSectorAlign")]
         public bool BINAlignToSector { get; set; } = false;
 


### PR DESCRIPTION
* Settings no longer revert to defaults if a property is invalid, rather that property is just ignored. This will make changing settings cleaner for users, as newer versions won't wipe their settings anymore.
* Settings now store a version property, which can be used to adjust values in the future if the version is outdated.
* Added missing value validating to newer settings.
* Resetting settings to default will now preserve scan and export paths.
* Fixed scanner current file progress bar initially starting at full.
* Renamed -scanbin command line option to -databin, and added -scanbin command line option that reads .bin files the same way .iso files are read. No UI option yet.
* Fixed errors during scanning failing to put the PreviewForm out of the scanning state.
* Fixed progress bars not updating their position to max when the scan is finished, this was due to Vista introducing animation to the progress bar value changing, there's a hack that can be used to instantly change the value.
* Animation object tree view items no longer have checkboxes.
* ScannerForm and ExportModelsForm Show functions now return the options instead of a boolean. The options must be used by the caller to execute the scan/export action. This is useful, since PreviewForm now wants to get the DrawAllToVRAM option for scanning without help from Program.

### Major optimizations for scanning
* ScanThread now uses MTA ApparentmentState.
* Scanning a file normally now wraps the scanner in a stream that remembers its own position, since asking for and changing the position of a file stream is expensive.
* Scanning interactions with the form are now done through a progressCallback. Because of this, Program now has no attachments to PreviewForm besides the fact that it creates it during Initialize.
* Progress callbacks now store the most recent report and add results to populate. The report updating and populating are done on a timer, with populating being very infrequent to reduce constant UI lag. These can be adjusted as advanced settings in the settings.json file (stored in seconds).
* Tree View item children are now populated via lazy loading. The necessary information is stored in tags.
* Tree View and Image List View items are now always added via AddRange (when possible), this removes the need for Begin/EndUpdate (which can actually slow things down a bit...).
* Optimized BinCDStream.Seek a bit, since apparently that's a very performance critical method (changes with scanning BFF models could change time from 2m8s to 3m8s).
* MOD, PMD, and TMD parsers now store re-usable array fields for vertices and such, this reduces the strain on the garbage collector from constantly collecting large arrays for every file or failed file. Note that it's now very important to make sure you compare against the actual count, and not the length of these arrays.