### PR TITLE
PSX Textures, Semi-Transparency, Gouraud, Sprite support

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -26,6 +26,19 @@ namespace PSXPrev.Common.Animator
         [DisplayName("Format"), ReadOnly(true)]
         public string FormatName { get; set; }
 
+#if DEBUG
+        [DisplayName("Debug Data"), ReadOnly(true)]
+#else
+        [Browsable(false)]
+#endif
+        public string[] DebugData { get; set; }
+
+        [Browsable(false)]
+        public long FileOffset { get; set; }
+
+        [Browsable(false)]
+        public int ResultIndex { get; set; }
+
         [DisplayName("Frame Count"), ReadOnly(true)]
         public uint FrameCount { get; set; }
 

--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -15,8 +15,15 @@ namespace PSXPrev.Common
 
         [DisplayName("Name")]
         public string EntityName { get; set; }
-        
-        [ReadOnly(true), DisplayName("Bounds")]
+
+#if DEBUG
+        [DisplayName("Debug Data"), ReadOnly(true)]
+#else
+        [Browsable(false)]
+#endif
+        public string[] DebugData { get; set; }
+
+        [DisplayName("Bounds"), ReadOnly(true)]
         public BoundingBox Bounds3D { get; set; }
 
         // Store original transform so that gizmo translations can be reset by the user.
@@ -168,7 +175,8 @@ namespace PSXPrev.Common
             set => Rotation = new Quaternion(Rotation.X, Rotation.Y, Rotation.Z, value);
         }
 
-        [ReadOnly(true), DisplayName("Sub-Models")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DisplayName("Sub-Models"), ReadOnly(true)]
         public string ChildCount => ChildEntities == null ? "0" : ChildEntities.Length.ToString(NumberFormatInfo.InvariantInfo);
 
         [Browsable(false)]

--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -166,7 +166,7 @@ namespace PSXPrev.Common.Exporters
                         var uvs = new Vector2[3];
                         for (var j = 0; j < 3; j++)
                         {
-                            uvs[j] = tiledInfo.ConvertUV(baseUv[j]);
+                            uvs[j] = tiledInfo.ConvertUV(baseUv[j], false);
                         }
                         triangle.Uv = uvs;
                         triangle.TiledUv = null; // We're not tiled anymore.
@@ -217,7 +217,7 @@ namespace PSXPrev.Common.Exporters
                             var uvs = new Vector2[3];
                             for (var j = 0; j < 3; j++)
                             {
-                                uvs[j] = uvConverter.ConvertUV(origUv[j]);
+                                uvs[j] = uvConverter.ConvertUV(origUv[j], false);
                             }
                             triangle.Uv = uvs;
                             triangle.TiledUv = null; // We're not tiled anymore.
@@ -454,10 +454,13 @@ namespace PSXPrev.Common.Exporters
                 public float ScalarX;
                 public float ScalarY;
 
-                public Vector2 ConvertUV(Vector2 origUv)
+                public Vector2 ConvertUV(Vector2 origUv, bool tiled)
                 {
-                    return new Vector2(OffsetX + origUv.X * ScalarX, OffsetY + origUv.Y * ScalarY);
+                    return new Vector2((tiled ? 0f : OffsetX) + origUv.X * ScalarX,
+                                       (tiled ? 0f : OffsetY) + origUv.Y * ScalarY);
                 }
+
+                Vector4 IUVConverter.ConvertTiledArea(Vector4 tiledArea) => throw new NotImplementedException();
             }
 
             public List<Texture> OriginalTextures { get; } = new List<Texture>();
@@ -707,10 +710,12 @@ namespace PSXPrev.Common.Exporters
             }
 
 
-            public Vector2 ConvertUV(Vector2 baseUv)
+            public Vector2 ConvertUV(Vector2 baseUv, bool tiled)
             {
                 return new Vector2(baseUv.X * _scalarX, baseUv.Y * _scalarY);
             }
+
+            Vector4 IUVConverter.ConvertTiledArea(Vector4 tiledArea) => throw new NotImplementedException();
 
             public void SetupTiledTexture(Vector2 maxUv, bool powerOfTwo)
             {

--- a/Common/Parsers/FileOffsetScanner.cs
+++ b/Common/Parsers/FileOffsetScanner.cs
@@ -82,6 +82,7 @@ namespace PSXPrev.Common.Parsers
                         var offsetPostfix = (_offset > 0 ? $"_{_offset:X}" : string.Empty);
                         var name = $"{fileTitle}{offsetPostfix}";
 
+                        var resultIndex = 0;
                         foreach (var entity in EntityResults)
                         {
                             if (entity == null)
@@ -91,11 +92,15 @@ namespace PSXPrev.Common.Parsers
                             passed = true;
                             entity.EntityName = name;
                             entity.FormatName = FormatName;
+                            entity.FileOffset = _offset;
+                            entity.ResultIndex = resultIndex++;
                             _entityAddedAction(this, entity, _offset);
 
                             Program.Logger.WritePositiveLine($"Found {FormatName} Model {AtOffsetString}");
                         }
+
                         // Enumerate textures differently so that we know whether to dispose of them or not.
+                        resultIndex = 0;
                         while (TextureResults.Count > 0)
                         {
                             var texture = TextureResults[0]; // Pop (but remove later on)
@@ -108,12 +113,16 @@ namespace PSXPrev.Common.Parsers
                             passed = true;
                             texture.TextureName = name;
                             texture.FormatName = FormatName;
+                            texture.FileOffset = _offset;
+                            texture.ResultIndex = resultIndex++;
                             _textureAddedAction(this, texture, _offset);
 
                             TextureResults.RemoveAt(0); // We should no longer dispose of this during an exception
 
                             Program.Logger.WritePositiveLine($"Found {FormatName} Texture {AtOffsetString}");
                         }
+
+                        resultIndex = 0;
                         foreach (var animation in AnimationResults)
                         {
                             if (animation == null)
@@ -123,6 +132,8 @@ namespace PSXPrev.Common.Parsers
                             passed = true;
                             animation.AnimationName = name;
                             animation.FormatName = FormatName;
+                            animation.FileOffset = _offset;
+                            animation.ResultIndex = resultIndex++;
                             _animationAddedAction(this, animation, _offset);
 
                             Program.Logger.WritePositiveLine($"Found {FormatName} Animation {AtOffsetString}");

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -660,8 +660,8 @@ namespace PSXPrev.Common.Parsers
 
             var imageIndex = reader.ReadUInt32() * 4;
             uint pmode;
-            int[][] palettes;
-            bool[][] semiTransparentPalettes;
+            ushort[][] palettes = null;
+            bool? hasSemiTransparency = null;
             if (hasClut)
             {
                 var clutX = reader.ReadUInt16();
@@ -674,7 +674,7 @@ namespace PSXPrev.Common.Parsers
 
                 reader.BaseStream.Seek(_offset + clutTop + clutIndex, SeekOrigin.Begin);
                 // Allow out of bounds to support HMDs with invalid image data, but valid model data.
-                palettes = TIMParser.ReadPalettes(reader, pmode, clutWidth, clutHeight, out semiTransparentPalettes, true);
+                palettes = TIMParser.ReadPalettes(reader, pmode, clutWidth, clutHeight, out hasSemiTransparency, true);
                 if (palettes == null)
                 {
                     return null;
@@ -683,13 +683,11 @@ namespace PSXPrev.Common.Parsers
             else
             {
                 pmode = TIMParser.GetModeFromNoClut();
-                palettes = null;
-                semiTransparentPalettes = null;
             }
 
             reader.BaseStream.Seek(_offset + imageTop + imageIndex, SeekOrigin.Begin);
             // Allow out of bounds to support HMDs with invalid image data, but valid model data.
-            var texture = TIMParser.ReadTexture(reader, stride, height, x, y, pmode, 0, palettes, semiTransparentPalettes, true);
+            var texture = TIMParser.ReadTexture(reader, stride, height, x, y, pmode, 0, palettes, hasSemiTransparency, true);
             reader.BaseStream.Seek(position, SeekOrigin.Begin);
             return texture;
         }

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -13,7 +13,7 @@
 
         public static ulong MaxBFFPackets = 40000;
         public static ulong MaxBFFVertices = 20000;
-        public static ulong MaxBFFTextureMaps = 10000;
+        public static ulong MaxBFFTextureHashes = 10000;
 
         public static ulong MaxHMDBlockCount = 1024;
         public static ulong MaxHMDCoordCount = 1024; // Same as BlockCount, because they're related
@@ -41,6 +41,11 @@
         public static ulong MaxPMDPackets = 4000;
 
         public static ulong MaxPSXObjectCount = 1024;
+        public static ulong MaxPSXTaggedChunks = 256;
+        public static ulong MaxPSXTextureHashes = 10000;
+        public static ulong MaxPSXTextures = 2048;
+        public static ulong MaxPSXVertices = 20000;
+        public static ulong MaxPSXFaces = 10000;
 
         public static ulong MaxSPTSprites = 1024;
 

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -5,11 +5,15 @@ using OpenTK;
 
 namespace PSXPrev.Common.Parsers
 {
+    // Argonaut's Blazing Render engine: .MOD model format
     public class MODParser : FileOffsetScanner
     {
-        //private Vector3[] _boundingBox;
+        private float _scaleDivisor = 1f;
+        //private readonly Vector3[] _boundingBox = new Vector3[9];
         private Vector3[] _vertices;
         private Vector3[] _normals;
+        private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
+        private readonly List<ModelEntity> _models = new List<ModelEntity>();
 
         public MODParser(EntityAddedAction entityAdded)
             : base(entityAdded: entityAdded)
@@ -20,19 +24,16 @@ namespace PSXPrev.Common.Parsers
 
         protected override void Parse(BinaryReader reader)
         {
-            var rootEntity = ReadModels(reader);
-            if (rootEntity != null)
-            {
-                EntityResults.Add(rootEntity);
-            }
+            _scaleDivisor = Settings.Instance.AdvancedMODScaleDivisor;
+            _groupedTriangles.Clear();
+            _models.Clear();
+
+            ReadMOD(reader);
         }
 
-        // The real divisor is supposedly 4096f, but that creates VERY SMALL models.
-        private const float FIXED_DIV = 16f; // 4096f;
-
-        private static Vector3 ReadVector(BinaryReader reader, bool normal = false, bool readPad = true)
+        private Vector3 ReadVector(BinaryReader reader, bool normal = false, bool readPad = true)
         {
-            var div = (normal ? 4096f : FIXED_DIV);
+            var div = (normal ? 4096f : _scaleDivisor);
             var x = reader.ReadInt16() / div;
             var y = reader.ReadInt16() / div;
             var z = reader.ReadInt16() / div;
@@ -46,26 +47,8 @@ namespace PSXPrev.Common.Parsers
             return new Vector3(x, -z, y);
         }
 
-        private RootEntity ReadModels(BinaryReader reader)
+        private bool ReadMOD(BinaryReader reader)
         {
-            var groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
-
-            void AddTriangle(Triangle triangle, uint tPage, RenderFlags renderFlags)
-            {
-                renderFlags |= RenderFlags.DoubleSided; //todo
-                if (renderFlags.HasFlag(RenderFlags.Textured))
-                {
-                    triangle.CorrectUVTearing();
-                }
-                var renderInfo = new RenderInfo(tPage, renderFlags);
-                if (!groupedTriangles.TryGetValue(renderInfo, out var triangles))
-                {
-                    triangles = new List<Triangle>();
-                    groupedTriangles.Add(renderInfo, triangles);
-                }
-                triangles.Add(triangle);
-            }
-
             // Some data is properly handled thanks to vs49688's work on CrocUtils.
             // Notably: Fixed point size, flags, bounding box indices, color, UVs, and the collision section.
             // <https://github.com/vs49688/CrocUtils>
@@ -74,254 +57,305 @@ namespace PSXPrev.Common.Parsers
             // For example, TK##_TRK files are a giant collection of grid pieces all occupying the same space.
             // This may be handled by another file...
 
-            var count = reader.ReadUInt16();
-            if (count == 0 || count > Limits.MaxMODModels)
+            var modelCount = reader.ReadUInt16();
+            if (modelCount == 0 || modelCount > Limits.MaxMODModels)
             {
-                return null;
+                return false;
             }
             var flags = reader.ReadUInt16();
             var collision = ((flags >> 0) & 0x1) == 1;
 
-            var models = new List<ModelEntity>();
-            for (uint i = 0; i < count; i++)
+            for (uint i = 0; i < modelCount; i++)
             {
-                // Same fixed point fraction size used for Int16's.
-                var radius = reader.ReadInt32() / FIXED_DIV;
+                if (!ReadModel(reader, i, collision))
+                {
+                    return false;
+                }
+            }
 
-                // Bounding box indices: <https://github.com/vs49688/CrocUtils/blob/5e07b7cb60fb5edec465a509d8924ae6682eaba7/libcroc/include/libcroc/moddef.h#L97-L108>
-                //if (_boundingBox == null)
-                //{
-                //    _boundingBox = new Vector3[9];
-                //}
-                //var boundingBox = _boundingBox;// new Vector3[9]; // 0 is the center.
-                for (var j = 0; j < 9; j++)
-                {
-                    /*boundingBox[j] =*/ ReadVector(reader);
-                }
+            if (_models.Count > 0)
+            {
+                var rootEntity = new RootEntity();
+                rootEntity.ChildEntities = _models.ToArray();
+                rootEntity.ComputeBounds();
+                EntityResults.Add(rootEntity);
+                return true;
+            }
 
-                // See notes by countFaces.
-                var countVerts = reader.ReadUInt32();
-                if (countVerts > Limits.MaxMODVertices)
-                {
-                    return null;
-                }
-                if (_vertices == null || _vertices.Length < countVerts)
-                {
-                    Array.Resize(ref _vertices, (int)countVerts);
-                    Array.Resize(ref _normals,  (int)countVerts);
-                }
-                var vertices = _vertices;// new Vector3[countVerts];
-                var normals = _normals;// new Vector3[countVerts];
-                for (var j = 0; j < countVerts; j++)
-                {
-                    vertices[j] = ReadVector(reader);
-                }
-                for (var j = 0; j < countVerts; j++)
-                {
-                    normals[j] = ReadVector(reader, normal: true);
-                }
+            return false;
+        }
 
-                // It's valid for some models to define 0 vertices and/or faces.
-                // When this happens, it's likely that the MOD file is split up into multiple sub-models,
-                // and the one at this index is intended to be empty.
+        private bool ReadModel(BinaryReader reader, uint modelIndex, bool collision)
+        {
+            // Same fixed point fraction size used for Int16's.
+            var radius = reader.ReadInt32() / _scaleDivisor;
+
+            // Bounding box indices: <https://github.com/vs49688/CrocUtils/blob/5e07b7cb60fb5edec465a509d8924ae6682eaba7/libcroc/include/libcroc/moddef.h#L97-L108>
+            // 0 is the center.
+            for (var j = 0; j < 9; j++)
+            {
+                /*_boundingBox[j] =*/ ReadVector(reader);
+            }
+
+            // See notes by countFaces.
+            var vertexCount = reader.ReadUInt32();
+            if (vertexCount > Limits.MaxMODVertices)
+            {
+                return false;
+            }
+            if (_vertices == null || _vertices.Length < vertexCount)
+            {
+                Array.Resize(ref _vertices, (int)vertexCount);
+                Array.Resize(ref _normals,  (int)vertexCount);
+            }
+            for (var j = 0; j < vertexCount; j++)
+            {
+                _vertices[j] = ReadVector(reader);
+            }
+            for (var j = 0; j < vertexCount; j++)
+            {
+                _normals[j] = ReadVector(reader, normal: true);
+            }
+
+            // It's valid for some models to define 0 vertices and/or faces.
+            // When this happens, it's likely that the MOD file is split up into multiple sub-models,
+            // and the one at this index is intended to be empty.
+            // 
+            // Even if the counts are zero, we need to keep reading till the end of this sub-model,
+            // so that the reader offset for the next sub-model is correct.
+            var faceCount = reader.ReadUInt32();
+            if (faceCount > 0 && vertexCount == 0)
+            {
+                // Although this check is technically handled in the faces loop,
+                // we can check this now to set the capacity of triangles without wasting memory.
+                return false;
+            }
+            if (faceCount > Limits.MaxMODFaces)
+            {
+                return false;
+            }
+
+            // Groups are observed as consecutive faces that share some similar properties.
+            // They are defined by the fourth uint16 in a face. When non-zero, a new group is started.
+            // A non-zero value specifies how many faces (including this one) remain in the group.
+            // After that many values have passed, either a new group is started, or the end of the face list is reached.
+            // The only similar properties observed in groups is that each face always uses the same texture/quad flags.
+            //var groupRemaining = 0;
+
+            for (var j = 0; j < faceCount; j++)
+            {
+                // Not present in MOD files for the PSX.
+                //var materialName = Encoding.ASCII.GetString(reader.ReadBytes(64));
+
+                // This vector almost always has a length nearing 1 (more often than the normals list).
+                // Only two files have been found where the vector length was 0.
+                // (NEPT00.MOD and NEPTD00.MOD, where flags=0x00)
                 // 
-                // Even if the counts are zero, we need to keep reading till the end of this sub-model,
-                // so that the reader offset for the next sub-model is correct.
-                var countFaces = reader.ReadUInt32();
-                if (countFaces > 0 && countVerts == 0)
+                // My theory is that this is an opportunity to allow using
+                // a normal that differs from the vertex indices.
+                var unitVec = ReadVector(reader, normal: true, readPad: false);
+                var groupLength = reader.ReadUInt16(); // Zero means we're already in a group.
+
+                var index0 = reader.ReadUInt16();
+                var index1 = reader.ReadUInt16();
+                var index2 = reader.ReadUInt16();
+                var index3 = reader.ReadUInt16();
+                if (index0 >= vertexCount || index1 >= vertexCount || index2 >= vertexCount || index3 >= vertexCount)
                 {
-                    // Although this check is technically handled in the faces loop,
-                    // we can check this now to set the capacity of triangles without wasting memory.
-                    return null;
+                    return false;
                 }
-                if (countFaces > Limits.MaxMODFaces)
+
+                var faceInfo = reader.ReadUInt32();
+                var faceFlags = (faceInfo >> 24) & 0xff;
+                var textured = ((faceFlags >> 0) & 0x1) == 1;
+                var quad     = ((faceFlags >> 3) & 0x1) == 1;
+                var uvFlip   = ((faceFlags >> 4) & 0x1) == 1;
+                // This is just a guess, and I'm not confident in it.
+                //var gouraud = ((faceFlags >> 7) & 0x1) == 0;
+                // All other flag bits have been spotted (set and unset), the most common being 0x80.
+
+                //if (groupLength != 0)
+                //{
+                //    groupRemaining = groupLength;
+                //}
+                //else if (groupRemaining <= 0)
+                //{
+                //}
+                //groupRemaining--;
+
+                var vertex0 = _vertices[index0];
+                var vertex1 = _vertices[index1];
+                var vertex2 = _vertices[index2];
+                var vertex3 = quad ? _vertices[index3] : Vector3.Zero;
+                var normal0 = _normals[index0];
+                var normal1 = _normals[index1];
+                var normal2 = _normals[index2];
+                var normal3 = quad ? _normals[index3] : Vector3.Zero;
+                // Just a guess.
+                //if (!gouraud && !unitVec.IsZero())
+                //{
+                //    normal0 = normal1 = normal2 = unitVec;
+                //}
+                //else
+                if (normal0.IsZero() || normal1.IsZero() || normal2.IsZero())
                 {
-                    return null;
+                    normal0 = normal1 = normal2 = GeomMath.CalculateNormal(vertex0, vertex1, vertex2);
                 }
 
-                // Groups are observed as consecutive faces that share some similar properties.
-                // They are defined by the fourth uint16 in a face. When non-zero, a new group is started.
-                // A non-zero value specifies how many faces (including this one) remain in the group.
-                // After that many values have passed, either a new group is started, or the end of the face list is reached.
-                // The only similar properties observed in groups is that each face always uses the same texture/quad flags.
-                //var groupRemaining = 0;
+                var renderFlags = RenderFlags.None;
+                uint tPage = 0;
 
-                for (var j = 0; j < countFaces; j++)
+                // We can't actually use UVs yet, since they're likely scaled for the material, and not the whole VRAM page.
+                Vector2 uv0, uv1, uv2, uv3;
+                Color color;
+                if (textured)
                 {
-                    // Not present in MOD files for the PSX.
-                    //var materialName = Encoding.ASCII.GetString(reader.ReadBytes(64));
-
-                    // This vector almost always has a length nearing 1 (more often than the normals list).
-                    // Only two files have been found where the vector length was 0.
-                    // (NEPT00.MOD and NEPTD00.MOD, where flags=0x00)
-                    // 
-                    // My theory is that this is an opportunity to allow using
-                    // a normal that differs from the vertex indices.
-                    var unitVec = ReadVector(reader, normal: true, readPad: false);
-                    var groupLength = reader.ReadUInt16(); // Zero means we're already in a group.
-
-                    var index0 = reader.ReadUInt16();
-                    var index1 = reader.ReadUInt16();
-                    var index2 = reader.ReadUInt16();
-                    var index3 = reader.ReadUInt16();
-                    if (index0 >= countVerts || index1 >= countVerts || index2 >= countVerts || index3 >= countVerts)
+                    //renderFlags |= RenderFlags.Textured; // Not supported yet
+                    tPage = faceInfo & 0xffff;
+                    if (!quad)
                     {
-                        return null;
-                    }
-
-                    var faceInfo = reader.ReadUInt32();
-                    var faceFlags = (faceInfo >> 24) & 0xff;
-                    var texture = ((faceFlags >> 0) & 0x1) == 1;
-                    var quad    = ((faceFlags >> 3) & 0x1) == 1;
-                    var uvFlip  = ((faceFlags >> 4) & 0x1) == 1;
-                    // This is just a guess, and I'm not confident in it.
-                    //var gouraud = ((faceFlags >> 7) & 0x1) == 0;
-                    // All other flag bits have been spotted (set and unset), the most common being 0x80.
-
-                    //if (groupLength != 0)
-                    //{
-                    //    groupRemaining = groupLength;
-                    //}
-                    //else if (groupRemaining <= 0)
-                    //{
-                    //}
-                    //groupRemaining--;
-
-                    var vertex0 = vertices[index0];
-                    var vertex1 = vertices[index1];
-                    var vertex2 = vertices[index2];
-                    var normal0 = normals[index0];
-                    var normal1 = normals[index1];
-                    var normal2 = normals[index2];
-                    // Just a guess.
-                    //if (!gouraud && !unitVec.IsZero())
-                    //{
-                    //    normal0 = normal1 = normal2 = unitVec;
-                    //}
-                    //else
-                    if (normal0.IsZero() || normal1.IsZero() || normal2.IsZero())
-                    {
-                        normal0 = normal1 = normal2 = GeomMath.CalculateNormal(vertex0, vertex1, vertex2);
-                    }
-
-                    var renderFlags = RenderFlags.None;
-                    uint tPage;
-
-                    // We can't actually use UVs yet, since they're likely scaled for the material, and not the whole VRAM page.
-                    Vector2 uv0, uv1, uv2, uv3;
-                    Color color;
-                    if (texture)
-                    {
-                        //renderFlags |= RenderFlags.Textured; // Not supported yet
-                        if (!quad)
-                        {
-                            // Is uvFlip flag ignored for tri? (flag has been observed both set and unset)
-                            uv0 = new Vector2(0, 0);
-                            uv1 = new Vector2(0, 1);
-                            uv2 = new Vector2(1, 0);
-                            uv3 = Vector2.Zero;
-                        }
-                        else
-                        {
-                            if (!uvFlip)
-                            {
-                                uv0 = new Vector2(1, 0);
-                                uv1 = new Vector2(0, 0);
-                                uv2 = new Vector2(1, 1);
-                                uv3 = new Vector2(0, 1);
-                            }
-                            else
-                            {
-                                uv0 = new Vector2(0, 0);
-                                uv1 = new Vector2(1, 0);
-                                uv2 = new Vector2(0, 1);
-                                uv3 = new Vector2(1, 1);
-                            }
-                        }
-
-                        var materialId = faceInfo & 0xffff;
-                        color = Color.Grey;
-
-                        tPage = 0; //todo
+                        // Is uvFlip flag ignored for tri? (flag has been observed both set and unset)
+                        uv0 = new Vector2(0f, 0f);
+                        uv1 = new Vector2(0f, 1f);
+                        uv2 = new Vector2(1f, 0f);
+                        uv3 = Vector2.Zero;
                     }
                     else
                     {
-                        uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
-
-                        var r = ((faceInfo >>  0) & 0xff) / 255f;
-                        var g = ((faceInfo >>  8) & 0xff) / 255f;
-                        var b = ((faceInfo >> 16) & 0xff) / 255f;
-                        color = new Color(r, g, b);
-
-                        tPage = 0;
+                        if (!uvFlip)
+                        {
+                            uv0 = new Vector2(1f, 0f);
+                            uv1 = new Vector2(0f, 0f);
+                            uv2 = new Vector2(1f, 1f);
+                            uv3 = new Vector2(0f, 1f);
+                        }
+                        else
+                        {
+                            uv0 = new Vector2(0f, 0f);
+                            uv1 = new Vector2(1f, 0f);
+                            uv2 = new Vector2(0f, 1f);
+                            uv3 = new Vector2(1f, 1f);
+                        }
                     }
 
-                    AddTriangle(new Triangle
+                    color = Color.Grey;
+                }
+                else
+                {
+                    uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
+
+                    var r = ((faceInfo      ) & 0xff) / 255f;
+                    var g = ((faceInfo >>  8) & 0xff) / 255f;
+                    var b = ((faceInfo >> 16) & 0xff) / 255f;
+                    color = new Color(r, g, b);
+                }
+
+                var triangle1 = new Triangle
+                {
+                    Vertices = new[] { vertex0, vertex1, vertex2 },
+                    Normals = new[] { normal0, normal1, normal2 },
+                    Colors = new[] { color, color, color },
+                    Uv = Triangle.EmptyUv, // Can't use UVs yet
+                    AttachableIndices = Triangle.EmptyAttachableIndices,
+                };
+                if (textured)
+                {
+                    //triangle1.TiledUv = new TiledUV(triangle1.Uv, 0f, 0f, 1f, 1f);
+                    //triangle1.Uv = (Vector2[])triangle1.Uv.Clone();
+                }
+                AddTriangle(triangle1, tPage, renderFlags);
+
+                if (quad)
+                {
+                    // Just a guess.
+                    //if (!gouraud && !unitVec.IsZero())
+                    //{
+                    //    normal1 = normal3 = normal2 = unitVec;
+                    //}
+                    //else
+                    if (normal1.IsZero() || normal3.IsZero() || normal2.IsZero())
                     {
-                        Vertices = new[] { vertex0, vertex1, vertex2 },
-                        Normals = new[] { normal0, normal1, normal2 },
+                        normal1 = normal3 = normal2 = GeomMath.CalculateNormal(vertex1, vertex3, vertex2);
+                    }
+
+                    var triangle2 = new Triangle
+                    {
+                        Vertices = new[] { vertex1, vertex3, vertex2 },
+                        Normals = new[] { normal1, normal3, normal2 },
                         Colors = new[] { color, color, color },
                         Uv = Triangle.EmptyUv, // Can't use UVs yet
                         AttachableIndices = Triangle.EmptyAttachableIndices,
-                    }, tPage, renderFlags);
-                    if (quad)
-                    {
-                        var vertex3 = vertices[index3];
-                        var normal3 = normals[index3];
-                        // Just a guess.
-                        //if (!gouraud && !unitVec.IsZero())
-                        //{
-                        //    normal1 = normal3 = normal2 = unitVec;
-                        //}
-                        //else
-                        if (normal1.IsZero() || normal3.IsZero() || normal2.IsZero())
-                        {
-                            normal1 = normal3 = normal2 = GeomMath.CalculateNormal(vertex1, vertex3, vertex2);
-                        }
-
-                        AddTriangle(new Triangle
-                        {
-                            Vertices = new[] { vertex1, vertex3, vertex2 },
-                            Normals = new[] { normal1, normal3, normal2 },
-                            Colors = new[] { color, color, color },
-                            Uv = Triangle.EmptyUv, // Can't use UVs yet
-                            AttachableIndices = Triangle.EmptyAttachableIndices,
-                        }, tPage, renderFlags);
-                    }
-                }
-
-                if (collision)
-                {
-                    // Skip collision(?) data.
-                    var size1 = reader.ReadUInt16();
-                    var size2 = reader.ReadUInt16();
-                    reader.BaseStream.Seek((size1 + size2) * 44, SeekOrigin.Current);
-                }
-
-                foreach (var kvp in groupedTriangles)
-                {
-                    var renderInfo = kvp.Key;
-                    var triangles = kvp.Value;
-                    var model = new ModelEntity
-                    {
-                        Triangles = triangles.ToArray(),
-                        TexturePage = renderInfo.TexturePage,
-                        RenderFlags = renderInfo.RenderFlags,
-                        MixtureRate = renderInfo.MixtureRate,
-                        TMDID = i + 1, //todo
                     };
-                    models.Add(model);
+                    if (textured)
+                    {
+                        //triangle2.TiledUv = new TiledUV(triangle2.Uv, 0f, 0f, 1f, 1f);
+                        //triangle2.Uv = (Vector2[])triangle2.Uv.Clone();
+                    }
+                    AddTriangle(triangle2, tPage, renderFlags);
                 }
-                groupedTriangles.Clear();
             }
-            if (models.Count > 0)
+
+            if (collision)
             {
-                var entity = new RootEntity();
-                entity.ChildEntities = models.ToArray();
-                entity.ComputeBounds();
-                return entity;
+                // Skip collision(?) data.
+                var size1 = reader.ReadUInt16();
+                var size2 = reader.ReadUInt16();
+                reader.BaseStream.Seek((size1 + size2) * 44, SeekOrigin.Current);
+            }
+
+            FlushModels(modelIndex);
+            return true;
+        }
+
+        private void FlushModels(uint modelIndex)
+        {
+            foreach (var kvp in _groupedTriangles)
+            {
+                var renderInfo = kvp.Key;
+                var triangles = kvp.Value;
+                var model = new ModelEntity
+                {
+                    Triangles = triangles.ToArray(),
+                    TexturePage = 0,
+                    //TextureLookup = CreateTextureLookup(renderInfo),
+                    RenderFlags = renderInfo.RenderFlags,
+                    MixtureRate = renderInfo.MixtureRate,
+                    TMDID = modelIndex + 1,
+                };
+                _models.Add(model);
+            }
+            _groupedTriangles.Clear();
+        }
+
+        private static TextureLookup CreateTextureLookup(RenderInfo renderInfo)
+        {
+            if (renderInfo.RenderFlags.HasFlag(RenderFlags.Textured))
+            {
+                return new TextureLookup
+                {
+                    ID = renderInfo.TexturePage, // Numeric (index?) identifier
+                    //ExpectedFormat = , //todo
+                    UVConversion = TextureUVConversion.TextureSpace,
+                    TiledAreaConversion = TextureUVConversion.TextureSpace,
+                };
             }
             return null;
+        }
+
+        private void AddTriangle(Triangle triangle, uint tPage, RenderFlags renderFlags, MixtureRate mixtureRate = MixtureRate.None)
+        {
+            renderFlags |= RenderFlags.DoubleSided; //todo
+            if (renderFlags.HasFlag(RenderFlags.Textured))
+            {
+                triangle.CorrectUVTearing();
+            }
+            var renderInfo = new RenderInfo(tPage, renderFlags, mixtureRate);
+            if (!_groupedTriangles.TryGetValue(renderInfo, out var triangles))
+            {
+                triangles = new List<Triangle>();
+                _groupedTriangles.Add(renderInfo, triangles);
+            }
+            triangles.Add(triangle);
         }
     }
 }

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -5,461 +5,1085 @@ using System.Drawing;
 using System.IO;
 using System.Text;
 using OpenTK;
+using PSXPrev.Common.Utils;
 
 //Translated from:
 //https://gist.github.com/iamgreaser/2a67f7473d9c48a70946018b73fa1e40
 
 namespace PSXPrev.Common.Parsers
 {
+    // Neversoft's Big Guns engine: .PSX model and texture library format
     public class PSXParser : FileOffsetScanner
     {
-        private PSXModel[] _objectModels;
+        public const string FormatNameConst = "PSX";
+
+        private static readonly ushort MaskMagenta = TexturePalette.FromComponents(248, 0, 248, false);
+
+        // Multiplied by 16 for files with HIER tagged chunk so that humanoids match the map size
+        // Translation divisor is only used for reading objects
+        private float _scaleDivisorTranslation = 1f;
+        private float _scaleDivisor = 1f;
+        private PSXObject[] _objects;
+        //private Coordinate[] _coords; // Same count as _objects (not ready yet)
+        private uint _objectCount;
+        private uint _modelCount;
         private Vector3[] _vertices;
         private Vector3[] _normals;
+        private readonly Color[] _gouraudPalette = new Color[256];
+        private uint _gouraudPaletteSize;
+        private uint[] _textureHashes;
+        private uint _textureHashCount;
+        private readonly Dictionary<uint, PSXClutData> _clutDatas = new Dictionary<uint, PSXClutData>();
+        private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
+        private readonly Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>> _groupedSprites = new Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>>();
+        private readonly Dictionary<uint, uint> _attachableIndices = new Dictionary<uint, uint>();
+        private readonly Dictionary<uint, uint> _attachedIndices = new Dictionary<uint, uint>();
+        private readonly Dictionary<uint, PSXSpriteVertexData> _spriteVertices = new Dictionary<uint, PSXSpriteVertexData>();
+        private readonly List<ModelEntity> _models = new List<ModelEntity>();
+        // Debug:
+        private readonly Dictionary<uint, List<string>> _modelDebugData = new Dictionary<uint, List<string>>();
 
-        public PSXParser(EntityAddedAction entityAdded)
-            : base(entityAdded: entityAdded)
+
+        public PSXParser(EntityAddedAction entityAdded, TextureAddedAction textureAdded)
+            : base(entityAdded: entityAdded, textureAdded: textureAdded)
         {
         }
 
-        public override string FormatName => "PSX";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {
-            var rootEntity = ReadModels(reader);
-            if (rootEntity != null)
+            _scaleDivisor = _scaleDivisorTranslation = Settings.Instance.AdvancedPSXScaleDivisor;
+            _gouraudPaletteSize = 0;
+            _textureHashCount = 0;
+            _clutDatas.Clear();
+            _groupedTriangles.Clear();
+            _groupedSprites.Clear();
+            _models.Clear();
+            _modelDebugData.Clear();
+
+            if (!ReadPSX(reader))
             {
-                EntityResults.Add(rootEntity);
+                foreach (var texture in TextureResults)
+                {
+                    texture.Dispose();
+                }
+                TextureResults.Clear();
             }
         }
 
-        private RootEntity ReadModels(BinaryReader reader)
+        private bool ReadPSX(BinaryReader reader)
         {
-            // (modelIndex, RenderInfo)
-            var groupedTriangles = new Dictionary<Tuple<uint, RenderInfo>, List<Triangle>>();
-
-            void AddTriangle(Triangle triangle, uint modelIndex, uint tPage, RenderFlags renderFlags)
-            {
-                renderFlags |= RenderFlags.DoubleSided; //todo
-                if (renderFlags.HasFlag(RenderFlags.Textured))
-                {
-                    triangle.CorrectUVTearing();
-                }
-                var renderInfo = new RenderInfo(tPage, renderFlags);
-                var tuple = new Tuple<uint, RenderInfo>(modelIndex, renderInfo);
-                if (!groupedTriangles.TryGetValue(tuple, out var triangles))
-                {
-                    triangles = new List<Triangle>();
-                    groupedTriangles.Add(tuple, triangles);
-                }
-                triangles.Add(triangle);
-            }
-
             var version = reader.ReadUInt16();
             var magic   = reader.ReadUInt16();
-            if (version != 0x0004 && version != 0x0003 && version != 0x0006)
+            if (version != 0x0003 && version != 0x0004 && version != 0x0006)
             {
-                return null;
+                return false;
             }
             if (magic != 0x0002)
             {
-                return null;
+                return false;
             }
 
-            var metaPtr = reader.ReadUInt32(); //todo: read meta
-            var objectCount = reader.ReadUInt32();
-            if (objectCount == 0 || objectCount > Limits.MaxPSXObjectCount)
+            // Pointer to tagged chunks, model names, textures
+            var metaTop = reader.ReadUInt32();
+            // Allow zero object count in-case this is a texture library
+            _objectCount = reader.ReadUInt32();
+            if (_objectCount > Limits.MaxPSXObjectCount)
             {
-                return null;
-            }
-            if (_objectModels == null || _objectModels.Length < objectCount)
-            {
-                Array.Resize(ref _objectModels, (int)objectCount);
-            }
-            var objectModels = _objectModels;// new PSXModel[objectCount];
-            for (var i = 0; i < objectCount; i++)
-            {
-                var flags = reader.ReadUInt32();
-                var x = (reader.ReadInt32() / 4096f) / 2.25f;// 4096f;
-                var y = (reader.ReadInt32() / 4096f) / 2.25f;// 4096f;
-                var z = (reader.ReadInt32() / 4096f) / 2.25f;// 4096f;
-                var unk1 = reader.ReadUInt32();
-                var unk2 = reader.ReadUInt16();
-                var modelIndex = reader.ReadUInt16();
-                var tx = reader.ReadUInt16();
-                var ty = reader.ReadUInt16();
-                var unk3 = reader.ReadUInt32();
-                var palTop = reader.ReadUInt32();
-                objectModels[i] = new PSXModel(x, y, z, modelIndex);
+                return false;
             }
 
-            var modelCount = reader.ReadUInt32();
-            if (modelCount == 0 || modelCount > Limits.MaxPSXObjectCount)
+            if (_objects == null || _objects.Length < _objectCount)
             {
-                return null;
+                Array.Resize(ref _objects, (int)_objectCount);
+                //Array.Resize(ref _coords,  (int)_objectCount);
+            }
+            for (uint i = 0; i < _objectCount; i++)
+            {
+                _objects[i] = ReadObject(reader, version, i);
             }
 
-            var modelEntities = new List<ModelEntity>();
-            var attachmentIndex = 0;
-            for (uint i = 0; i < modelCount; i++)
+            // Allow zero model count in-case this is a texture library
+            _modelCount = reader.ReadUInt32();
+            if ((_modelCount == 0) != (_objectCount == 0) || _modelCount > Limits.MaxPSXObjectCount)
+            {
+                return false; // Models or objects are zero, but not both. Or model count is too high
+            }
+
+
+            // Read gouraud palette/vertex divisor from tagged chunks, and texture hashes before reading models
+            var modelsStartPosition = reader.BaseStream.Position;
+            reader.BaseStream.Seek(_offset + metaTop, SeekOrigin.Begin);
+
+            if (!ReadTaggedChunks(reader, version))
+            {
+                return false;
+            }
+
+            //var modelHashes = new uint[_modelCount]; // Hashes of model names, not important
+            var modelHashes = Program.Debug ? new List<string>() : null;
+            for (uint i = 0; i < _modelCount; i++)
+            {
+                var modelHash = reader.ReadUInt32();
+                if (modelHashes != null)
+                {
+                    modelHashes.Add($"0x{modelHash:x08}");
+                }
+            }
+            if (modelHashes != null && modelHashes.Count > 0)
+            {
+                Program.Logger.WriteLine("Model Hashes: " + string.Join(", ", modelHashes));
+            }
+
+            if (!ReadTextures(reader, version))
+            {
+                return false;
+            }
+            reader.BaseStream.Seek(modelsStartPosition, SeekOrigin.Begin);
+
+
+            /*var coords = new Coordinate[_objectCount];
+            Array.Copy(_coords, coords, coords.Length);
+            foreach (var coord in coords)
+            {
+                coord.Coords = coords;
+            }
+            if (Coordinate.FindCircularReferences(coords))
+            {
+                return false;
+            }*/
+
+
+            uint attachmentIndex = 0;
+            for (uint i = 0; i < _modelCount; i++)
             {
                 var modelTop = reader.ReadUInt32();
                 var modelPosition = reader.BaseStream.Position;
                 reader.BaseStream.Seek(_offset + modelTop, SeekOrigin.Begin);
-                var flags = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
-                var vertexCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
-                var planeCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
-                var faceCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
-                var radius = reader.ReadUInt32();
-                var xMax = reader.ReadUInt16();
-                var xMin = reader.ReadUInt16();
-                var yMax = reader.ReadUInt16();
-                var yMin = reader.ReadUInt16();
-                var zMax = reader.ReadUInt16();
-                var zMin = reader.ReadUInt16();
-                if (version == 0x04)
+                if (!ReadModel(reader, version, i, ref attachmentIndex))
                 {
-                    var unk2 = reader.ReadUInt32();
-                }
-
-                var attachedIndices = new Dictionary<uint, uint>();
-                var attachableIndices = new Dictionary<uint, uint>();
-
-                if (_vertices == null || _vertices.Length < vertexCount)
-                {
-                    Array.Resize(ref _vertices, (int)vertexCount);
-                }
-                var vertices = _vertices;// new Vector3[vertexCount];
-                for (uint j = 0; j < vertexCount; j++)
-                {
-                    var x = reader.ReadInt16();
-                    var y = reader.ReadInt16();
-                    var z = reader.ReadInt16();
-                    var pad = reader.ReadUInt16();
-                    vertices[j] = new Vector3(x / 2.25f, y / 2.25f, z / 2.25f);
-
-                    if (pad == 1)
-                    {
-                        attachableIndices.Add(j, (uint)attachmentIndex++);
-                    }
-                    else if (pad == 2)
-                    {
-                        attachedIndices.Add(j, (uint)y);
-                    }
-                }
-
-                if (_normals == null || _normals.Length < planeCount)
-                {
-                    Array.Resize(ref _normals, (int)planeCount);
-                }
-                var normals = _normals;// new Vector3[planeCount];
-                for (uint j = 0; j < planeCount; j++)
-                {
-                    var x = reader.ReadInt16() / 4096f;
-                    var y = reader.ReadInt16() / 4096f;
-                    var z = reader.ReadInt16() / 4096f;
-                    reader.ReadUInt16(); //pad
-                    normals[j] = new Vector3(x, y, z);
-                }
-
-                //uint faceFlags;
-                //uint faceLength;
-                //if (version == 0x03)
-                //{
-                //    faceFlags = reader.ReadUInt16();
-                //    faceLength = reader.ReadUInt16();
-                //}
-                //else
-                //{
-                //    faceFlags = 0;
-                //    faceLength = 0;
-                //}
-                for (uint j = 0; j < faceCount; j++)
-                {
-                    if (version == 0x04)
-                    {
-                        var facePosition = reader.BaseStream.Position;
-                        var faceFlags = reader.ReadUInt16();
-                        var faceLength = reader.ReadUInt16();
-                        var quad = (faceFlags & 0x0010) == 0;
-                        var gouraud = (faceFlags & 0x0800) != 0;
-                        var textured = (faceFlags & 0x0003) != 0;
-                        var invisible = (faceFlags & 0x0080) != 0;
-                        var i0 = reader.ReadByte();
-                        var i1 = reader.ReadByte();
-                        var i2 = reader.ReadByte();
-                        var i3 = reader.ReadByte();
-                        if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount || i3 >= vertexCount)
-                        {
-                            throw new IndexOutOfRangeException("Vertex index out of bounds");
-                        }
-                        var vertex0 = vertices[i0];
-                        var vertex1 = vertices[i1];
-                        var vertex2 = vertices[i2];
-                        var vertex3 = vertices[i3];
-                        Color color0;
-                        Color color1;
-                        Color color2;
-                        Color color3;
-                        var r0 = reader.ReadByte() / 255f;
-                        var g0 = reader.ReadByte() / 255f;
-                        var b0 = reader.ReadByte() / 255f;
-                        var command = reader.ReadByte();
-                        var attachedIndex0 = attachedIndices.TryGetValue(i0, out var index0) ? index0 : Triangle.NoAttachment;
-                        var attachedIndex1 = attachedIndices.TryGetValue(i1, out var index1) ? index1 : Triangle.NoAttachment;
-                        var attachedIndex2 = attachedIndices.TryGetValue(i2, out var index2) ? index2 : Triangle.NoAttachment;
-                        var attachedIndex3 = attachedIndices.TryGetValue(i3, out var index3) ? index3 : Triangle.NoAttachment;
-                        var attachableIndex0 = attachableIndices.TryGetValue(i0, out var attIndex0) ? attIndex0 : Triangle.NoAttachment;
-                        var attachableIndex1 = attachableIndices.TryGetValue(i1, out var attIndex1) ? attIndex1 : Triangle.NoAttachment;
-                        var attachableIndex2 = attachableIndices.TryGetValue(i2, out var attIndex2) ? attIndex2 : Triangle.NoAttachment;
-                        var attachableIndex3 = attachableIndices.TryGetValue(i3, out var attIndex3) ? attIndex3 : Triangle.NoAttachment;
-                        if (gouraud)
-                        {
-                            color0 = color1 = color2 = color3 = Color.Grey; //todo
-                        }
-                        else
-                        {
-                            color0 = color1 = color2 = color3 = new Color(r0, g0, b0);
-                        }
-                        //todo
-                        var planeIndex = reader.ReadUInt16();
-                        var surfFlags = reader.ReadInt16();
-                        if (planeIndex >= planeCount)
-                        {
-                            throw new IndexOutOfRangeException("Normal index out of bounds");
-                        }
-                        var normal0 = normals[planeIndex];
-                        var normal1 = normals[planeIndex];
-                        var normal2 = normals[planeIndex];
-                        var normal3 = normals[planeIndex];
-                        var uv0 = Vector2.Zero;
-                        var uv1 = Vector2.Zero;
-                        var uv2 = Vector2.Zero;
-                        var uv3 = Vector2.Zero;
-                        uint tPage = 0;
-                        var renderFlags = RenderFlags.None;
-                        if (textured)
-                        {
-                            renderFlags |= RenderFlags.Textured;
-                            tPage = reader.ReadUInt32(); //todo
-                            var u0 = reader.ReadByte();
-                            var v0 = reader.ReadByte();
-                            var u1 = reader.ReadByte();
-                            var v1 = reader.ReadByte();
-                            var u2 = reader.ReadByte();
-                            var v2 = reader.ReadByte();
-                            var u3 = reader.ReadByte();
-                            var v3 = reader.ReadByte();
-                            uv0 = GeomMath.ConvertUV(u0, v0);
-                            uv1 = GeomMath.ConvertUV(u1, v1);
-                            uv2 = GeomMath.ConvertUV(u2, v2);
-                            uv3 = GeomMath.ConvertUV(u3, v3);
-                        }
-                        if (!invisible)
-                        {
-                            AddTriangle(new Triangle
-                            {
-                                Vertices = new[] { vertex2, vertex1, vertex0 },
-                                Normals = new[] { normal2, normal1, normal0 },
-                                Uv = new[] { uv2, uv1, uv0 },
-                                Colors = new[] { color2, color1, color0 },
-                                OriginalVertexIndices = new uint[] { i2, i1, i0 },
-                                AttachedIndices = new[] { attachedIndex2, attachedIndex1, attachedIndex0 },
-                                AttachableIndices = new[] { attachableIndex2, attachableIndex1, attachableIndex0 }
-                            }, i, tPage, renderFlags);
-                            if (quad)
-                            {
-                                AddTriangle(new Triangle
-                                {
-                                    Vertices = new[] { vertex1, vertex2, vertex3 },
-                                    Normals = new[] { normal1, normal2, normal3 },
-                                    Uv = new[] { uv1, uv2, uv3 },
-                                    Colors = new[] { color1, color2, color3 },
-                                    OriginalVertexIndices = new uint[] { i1, i2, i3 },
-                                    AttachedIndices = new[] { attachedIndex1, attachedIndex2, attachedIndex3 },
-                                    AttachableIndices = new[] { attachableIndex1, attachableIndex2, attachableIndex3 }
-                                }, i, tPage, renderFlags);
-                            }
-                        }
-                        reader.BaseStream.Seek(facePosition + faceLength, SeekOrigin.Begin);
-                    }
-                    else
-                    {
-                        var facePosition = reader.BaseStream.Position;
-                        var faceFlags = reader.ReadUInt16();
-                        var faceLength = reader.ReadUInt16();
-                        var quad = (faceFlags & 0x0010) == 0;
-                        var gouraud = (faceFlags & 0x0800) != 0;
-                        var textured = (faceFlags & 0x0003) != 0;
-                        var invisible = (faceFlags & 0x0080) != 0;
-                        var i0 = reader.ReadUInt16();
-                        var i1 = reader.ReadUInt16();
-                        var i2 = reader.ReadUInt16();
-                        var i3 = reader.ReadUInt16();
-                        if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount || i3 >= vertexCount)
-                        {
-                            throw new IndexOutOfRangeException("Vertex index out of bounds");
-                        }
-                        var vertex0 = vertices[i0];
-                        var vertex1 = vertices[i1];
-                        var vertex2 = vertices[i2];
-                        var vertex3 = vertices[i3];
-                        Color color0;
-                        Color color1;
-                        Color color2;
-                        Color color3;
-                        var r0 = reader.ReadByte() / 255f;
-                        var g0 = reader.ReadByte() / 255f;
-                        var b0 = reader.ReadByte() / 255f;
-                        var command = reader.ReadByte();
-                        var attachedIndex0 = attachedIndices.TryGetValue(i0, out var index0) ? index0 : Triangle.NoAttachment;
-                        var attachedIndex1 = attachedIndices.TryGetValue(i1, out var index1) ? index1 : Triangle.NoAttachment;
-                        var attachedIndex2 = attachedIndices.TryGetValue(i2, out var index2) ? index2 : Triangle.NoAttachment;
-                        var attachedIndex3 = attachedIndices.TryGetValue(i3, out var index3) ? index3 : Triangle.NoAttachment;
-                        var attachableIndex0 = attachableIndices.TryGetValue(i0, out var attIndex0) ? attIndex0 : Triangle.NoAttachment;
-                        var attachableIndex1 = attachableIndices.TryGetValue(i1, out var attIndex1) ? attIndex1 : Triangle.NoAttachment;
-                        var attachableIndex2 = attachableIndices.TryGetValue(i2, out var attIndex2) ? attIndex2 : Triangle.NoAttachment;
-                        var attachableIndex3 = attachableIndices.TryGetValue(i3, out var attIndex3) ? attIndex3 : Triangle.NoAttachment;
-                        if (gouraud)
-                        {
-                            color0 = color1 = color2 = color3 = Color.Grey; //todo
-                        }
-                        else
-                        {
-                            color0 = color1 = color2 = color3 = new Color(r0, g0, b0);
-                        }
-                        //todo
-                        var planeIndex = reader.ReadUInt16();
-                        var surfFlags = reader.ReadInt16();
-                        if (planeIndex >= planeCount)
-                        {
-                            throw new IndexOutOfRangeException("Normal index out of bounds");
-                        }
-                        var normal0 = normals[planeIndex];
-                        var normal1 = normals[planeIndex];
-                        var normal2 = normals[planeIndex];
-                        var normal3 = normals[planeIndex];
-                        var uv0 = Vector2.Zero;
-                        var uv1 = Vector2.Zero;
-                        var uv2 = Vector2.Zero;
-                        var uv3 = Vector2.Zero;
-                        uint tPage = 0;
-                        var renderFlags = RenderFlags.None;
-                        if (textured)
-                        {
-                            renderFlags |= RenderFlags.Textured;
-                            tPage = reader.ReadUInt32(); //todo
-                            var u0 = reader.ReadByte();
-                            var v0 = reader.ReadByte();
-                            var u1 = reader.ReadByte();
-                            var v1 = reader.ReadByte();
-                            var u2 = reader.ReadByte();
-                            var v2 = reader.ReadByte();
-                            var u3 = reader.ReadByte();
-                            var v3 = reader.ReadByte();
-                            uv0 = GeomMath.ConvertUV(u0, v0);
-                            uv1 = GeomMath.ConvertUV(u1, v1);
-                            uv2 = GeomMath.ConvertUV(u2, v2);
-                            uv3 = GeomMath.ConvertUV(u3, v3);
-                        }
-                        if (!invisible)
-                        {
-                            AddTriangle(new Triangle
-                            {
-                                Vertices = new[] { vertex2, vertex1, vertex0 },
-                                Normals = new[] { normal2, normal1, normal0 },
-                                Uv = new[] { uv2, uv1, uv0 },
-                                Colors = new[] { color2, color1, color0 },
-                                OriginalVertexIndices = new uint[] { i2, i1, i0 },
-                                AttachedIndices = new[] { attachedIndex2, attachedIndex1, attachedIndex0 },
-                                AttachableIndices = new[] { attachableIndex2, attachableIndex1, attachableIndex0 }
-                            }, i, tPage, renderFlags);
-                            if (quad)
-                            {
-                                AddTriangle(new Triangle
-                                {
-                                    Vertices = new[] { vertex1, vertex2, vertex3 },
-                                    Normals = new[] { normal1, normal2, normal3 },
-                                    Uv = new[] { uv1, uv2, uv3 },
-                                    Colors = new[] { color1, color2, color3 },
-                                    OriginalVertexIndices = new uint[] { i1, i2, i3 },
-                                    AttachedIndices = new[] { attachedIndex1, attachedIndex2, attachedIndex3 },
-                                    AttachableIndices = new[] { attachableIndex1, attachableIndex2, attachableIndex3 }
-                                }, i, tPage, renderFlags);
-                            }
-                        }
-                        reader.BaseStream.Seek(facePosition + faceLength, SeekOrigin.Begin);
-                    }
+                    return false;
                 }
                 reader.BaseStream.Seek(modelPosition, SeekOrigin.Begin);
             }
 
-            //var position = reader.BaseStream.Position;
-            //reader.BaseStream.Seek(metaPtr, SeekOrigin.Begin);
-            //for (; ; )
-            //{
-            //    var chunkId = reader.ReadBytes(4);
-            //    if (chunkId[0] == 0xFF && chunkId[1] == 0xFF && chunkId[2] == 0xFF && chunkId[3] == 0xFF)
-            //    {
-            //        break;
-            //    }
-            //    var chunkString = Encoding.ASCII.GetString(chunkId);
-            //    var chunkLength = reader.ReadUInt32();
-            //    var chunkData = reader.ReadBytes((int)chunkLength);
-            //};
-            //reader.BaseStream.Seek(position, SeekOrigin.Begin);
-
-            for (var i = 0; i < objectCount; i++)
+            if (_models.Count > 0)
             {
-                var psxModel = objectModels[i];
-                foreach (var kvp in groupedTriangles)
+                var rootEntity = new RootEntity();
+                rootEntity.ChildEntities = _models.ToArray();
+                //rootEntity.OwnedTextures.AddRange(TextureResults); // todo: need to change how owned textures are handled
+                foreach (var texture in TextureResults)
                 {
-                    if (kvp.Key.Item1 == psxModel.ModelIndex)
+                    texture.OwnerEntity = rootEntity;
+                }
+                rootEntity.ComputeBounds();
+                EntityResults.Add(rootEntity);
+            }
+
+            return true;
+        }
+
+        private bool ReadTaggedChunks(BinaryReader reader, ushort version)
+        {
+            const uint TagStop = 0xffffffff;
+            // Gouraud palette
+            const uint TagRGBs = 'R' | (((uint)'G') << 8) | (((uint)'B') << 16) | (((uint)'s') << 24);
+            // Hierarchy
+            const uint TagHIER = 'H' | (((uint)'I') << 8) | (((uint)'E') << 16) | (((uint)'R') << 24);
+            // Unknown
+            const uint TagChnk = 'C' | (((uint)'h') << 8) | (((uint)'n') << 16) | (((uint)'k') << 24);
+            const uint TagUnknown6  = 0x00000006; //     Very small
+            const uint TagUnknown7  = 0x00000007; //     Medium
+            const uint TagBlockMap  = 0x0000000a; //     Very large (level physics)
+            const uint TagUnknown2C = 0x0000002c; // "," Very large (positional/animation information?)
+            const uint TagUnknown2A = 0x0000002a; // "*" Very small to large (positional/animation information?)
+            const uint TagBits      = 0x00000045; // "E" Medium (Used for bits.psx, aka fonts and common symbols/images/hud/etc.)
+
+
+            uint chunkCount = 0;
+            var chunkTag = reader.ReadUInt32();
+            while (chunkTag != TagStop)
+            {
+                if (++chunkCount > Limits.MaxPSXTaggedChunks)
+                {
+                    return false;
+                }
+
+                var chunkLength = reader.ReadUInt32();
+                var chunkPosition = reader.BaseStream.Position;
+
+                if (Program.Debug)
+                {
+                    var tagStr = new StringBuilder(4);
+                    for (var i = 0; i < 4; i++)
                     {
-                        var triangles = kvp.Value;
-                        var renderInfo = kvp.Key.Item2;
-                        var model = new ModelEntity
-                        {
-                            Triangles = triangles.ToArray(),
-                            TexturePage = renderInfo.TexturePage,
-                            RenderFlags = renderInfo.RenderFlags,
-                            MixtureRate = renderInfo.MixtureRate,
-                            TMDID = psxModel.ModelIndex, //todo
-                            OriginalLocalMatrix = Matrix4.CreateTranslation(psxModel.X, psxModel.Y, psxModel.Z)
-                        };
-                        model.ComputeAttached();
-                        modelEntities.Add(model);
+                        var c = (char)(byte)(chunkTag >> (i * 8));
+                        tagStr.Append(char.IsControl(c) ? ' ' : c);
                     }
+                    Program.Logger.WriteLine($"chunk[{chunkCount-1}]: \"{tagStr}\" 0x{chunkTag:x08} {chunkLength} : {_fileTitle}_{_offset:X} @ 0x{reader.BaseStream.Position:x}");
+                }
+
+                var result = true;
+                switch (chunkTag)
+                {
+                    case TagRGBs:
+                        result = ReadTaggedChunkRGBs(reader, chunkLength);
+                        break;
+                    case TagHIER:
+                        result = ReadTaggedChunkHIER(reader, chunkLength);
+                        break;
+                }
+                if (!result)
+                {
+                    return false;
+                }
+
+                reader.BaseStream.Seek(chunkPosition + chunkLength, SeekOrigin.Begin);
+                chunkTag = reader.ReadUInt32();
+            }
+            return true;
+        }
+
+        private bool ReadTaggedChunkRGBs(BinaryReader reader, uint chunkLength)
+        {
+            // In order to support gouraud color without changing the face structure, RGBMode are changed into
+            // indices that look up a color in the table defined in this chunk.
+            // There is some weird behavior that hasn't quite been nailed down yet. Mainly, if the color black repeats itself,
+            // then the surface has some special color properties (maybe reflectivity/refraction/etc.).
+            // For now, the color is just being changed to gray so the face's texture is visible, but this isn't correct.
+
+            // Palette size can be smaller than 256
+            _gouraudPaletteSize = chunkLength / 4;
+            if (_gouraudPaletteSize > _gouraudPalette.Length)
+            {
+                // Error out if palette size is too large, or should we ignore remaining colors...?
+                return false;
+            }
+            var specialStarted = false;
+            for (uint i = 0; i < _gouraudPaletteSize; i++)
+            {
+                var r = reader.ReadByte();
+                var g = reader.ReadByte();
+                var b = reader.ReadByte();
+                var pad = reader.ReadByte(); //pad
+                if (pad != 0)
+                {
+                    var breakHere = 0;
+                }
+                Color color;
+                if (r == 0 && g == 0 && b == 0)
+                {
+                    if (!specialStarted)
+                    {
+                        specialStarted = true;
+                        color = Color.Black;
+                    }
+                    else
+                    {
+                        // This is NOT correct, however it's better than using black
+                        color = Color.Grey;
+                    }
+                    //color = new Color(i / 255f, i / 255f, i / 255f);
+                }
+                else
+                {
+                    color = new Color(r / 255f, g / 255f, b / 255f);
+                }
+                _gouraudPalette[i] = color;
+            }
+            return true;
+        }
+
+        private bool ReadTaggedChunkHIER(BinaryReader reader, uint chunkLength)
+        {
+            // We can't use Coords yet, the point of them is to handle relative position,
+            // but objects already store absolute position...
+
+            // Models with hierarchy are scaled down by x16.
+            _scaleDivisor = _scaleDivisorTranslation * 16f;
+
+            // Can't rely on chunk length, since it's padded to 4 bytes
+            var count = Math.Min(chunkLength / 2, _objectCount);
+            if (count != _objectCount)
+            {
+                var breakHere = 0;
+            }
+            for (uint i = 0; i < count; i++)
+            {
+                var parentIndex = reader.ReadUInt16();
+                if (parentIndex != i)
+                {
+                    //_coords[i].ParentID = parentIndex;
                 }
             }
-            RootEntity rootEntity;
-            if (modelEntities.Count > 0)
+            return true;
+        }
+
+        private bool ReadTextures(BinaryReader reader, ushort version)
+        {
+            _textureHashCount = reader.ReadUInt32();
+            if (_textureHashCount > Limits.MaxPSXTextureHashes)
             {
-                rootEntity = new RootEntity();
-                rootEntity.ChildEntities = modelEntities.ToArray();
-                rootEntity.ComputeBounds();
+                return false;
+            }
+            if (_textureHashes == null || _textureHashes.Length < _textureHashCount)
+            {
+                Array.Resize(ref _textureHashes, (int)_textureHashCount);
+            }
+            for (uint i = 0; i < _textureHashCount; i++)
+            {
+                _textureHashes[i] = reader.ReadUInt32();
+            }
+
+            var clut16Count = reader.ReadUInt32();
+            if (clut16Count > Limits.MaxPSXTextures)
+            {
+                return false;
+            }
+            for (uint i = 0; i < clut16Count; i++)
+            {
+                var clutHash = reader.ReadUInt32();
+                _clutDatas[clutHash] = new PSXClutData
+                {
+                    ClutTop = (uint)(reader.BaseStream.Position - _offset),
+                    IsClut256 = false,
+                };
+                // Skip clut data for now
+                reader.BaseStream.Seek(2 * 16, SeekOrigin.Current);
+            }
+
+            var clut256Count = reader.ReadUInt32();
+            if (clut256Count > Limits.MaxPSXTextures)
+            {
+                return false;
+            }
+            for (uint i = 0; i < clut256Count; i++)
+            {
+                var clutHash = reader.ReadUInt32();
+                _clutDatas[clutHash] = new PSXClutData
+                {
+                    ClutTop = (uint)(reader.BaseStream.Position - _offset),
+                    IsClut256 = true,
+                };
+                // Skip clut data for now
+                reader.BaseStream.Seek(2 * 256, SeekOrigin.Current);
+            }
+
+            var textureDataCount = reader.ReadUInt32();
+            if (textureDataCount > Limits.MaxPSXTextures)
+            {
+                return false;
+            }
+            for (uint i = 0; i < textureDataCount; i++)
+            {
+                var textureDataTop = reader.ReadUInt32();
+                var textureDataPosition = reader.BaseStream.Position;
+                reader.BaseStream.Seek(_offset + textureDataTop, SeekOrigin.Begin);
+                if (!ReadTextureData(reader, version))
+                {
+                    return false;
+                }
+                reader.BaseStream.Seek(textureDataPosition, SeekOrigin.Begin);
+            }
+
+            return true;
+        }
+
+        private bool ReadTextureData(BinaryReader reader, ushort version)
+        {
+            var maskMode = reader.ReadUInt32();
+            var paletteSize = reader.ReadUInt32();
+            var clutHash = reader.ReadUInt32();
+            var textureIndex = reader.ReadUInt32();
+            if (textureIndex >= _textureHashCount)
+            {
+                return false;
+            }
+            var width  = reader.ReadUInt16();
+            var height = reader.ReadUInt16();
+
+            int bpp;
+            uint pixelFormat = 0, size = 0;
+            switch (paletteSize)
+            {
+                case 16:
+                    bpp = 4;
+                    break;
+                case 256:
+                    bpp = 8;
+                    break;
+                case 0x10000:
+                    bpp = 16;
+                    // todo: Magenta masking not handled for this bit depth
+                    pixelFormat = reader.ReadUInt32();
+                    size        = reader.ReadUInt32();
+                    break;
+
+                default:
+                    return false;
+            }
+
+            var pmode  = TIMParser.GetModeFromBpp(bpp);
+            var stride = TIMParser.GetStride(pmode, width);
+
+            ushort[][] palettes = null, origPalettes = null;
+            bool? hasSemiTransparency = null;
+            Func<ushort, ushort> maskPixel16 = null;
+            if (paletteSize <= 256)
+            {
+                var imagePosition = reader.BaseStream.Position;
+
+                if (!_clutDatas.TryGetValue(clutHash, out var clutData))
+                {
+                    return false;
+                }
+                if ((paletteSize == 256) != clutData.IsClut256)
+                {
+                    return false;
+                }
+                var clutWidth = paletteSize;
+                reader.BaseStream.Seek(_offset + clutData.ClutTop, SeekOrigin.Begin);
+                palettes = TIMParser.ReadPalettes(reader, pmode, clutWidth, 1, out hasSemiTransparency, true, false);
+                if (palettes == null)
+                {
+                    return false;
+                }
+
+                origPalettes = MaskPalette(maskMode == 0, palettes, ref hasSemiTransparency);
+
+                reader.BaseStream.Seek(imagePosition, SeekOrigin.Begin);
             }
             else
             {
-                rootEntity = null;
+                maskPixel16 = MaskPixel;
             }
-            return rootEntity;
+
+            var texture = TIMParser.ReadTexture2(reader, stride, width, height, 0, 0, 0, pmode, 0, palettes, hasSemiTransparency, true, maskPixel16);
+            if (texture == null)
+            {
+                return false;
+            }
+            TextureResults.Add(texture);
+            texture.OriginalPalettes = origPalettes;
+            texture.LookupID = _textureHashes[textureIndex];
+            texture.DebugData = new[] { $"{maskMode}" };
+            return true;
         }
 
-        private struct PSXModel
+        private static ushort MaskPixel(ushort color)
         {
-            public float X { get; }
-            public float Y { get; }
-            public float Z { get; }
-            public ushort ModelIndex { get; }
-
-            public PSXModel(float x, float y, float z, ushort modelIndex)
+            if (TexturePalette.Equals(color, MaskMagenta, true))
             {
-                X = x;
-                Y = y;
-                Z = z;
-                ModelIndex = modelIndex;
+                color = TexturePalette.Transparent;
             }
+            else if (color == TexturePalette.Transparent)
+            {
+                color = TexturePalette.SetStp(color, true);
+            }
+            // todo: What about stp bits for other colors? Is it effected by maskMode?
+            return color;
+        }
+
+        private static ushort[][] MaskPalette(bool blackMaskMode, ushort[][] palettes, ref bool? hasSemiTransparency)
+        {
+            // Stp bits and masking:
+            // So this format decided it needed some overly-complex rules to handle turning the stp bit on,
+            // because the developers couldn't be bothered to do that when saving the image data.
+            //
+            // 1. The color magenta rgb(248,0,248) is ALWAYS masked. It's assumed that stp bit is ignored when checking
+            //    for magenta. It's also assumed that every appearance is masked.
+            //
+            // 2. The color transparent is never masked, except for the one exception in rule #5.
+            //
+            // 3. If magenta is in the palette, then all entries after the first appearance will have their stp bit set.
+            //
+            // 4. If magenta is not in the palette and !blackMaskMode, then ALL entries have their stp bit set.
+            //
+            // 5. If magenta is not in the palette and blackMaskMode, then stp bits will be set after the first appearance
+            //    of transparent. However, index 255 will not have its stp bit set if the color is transparent.
+            var palette = palettes[0];
+            var paletteSize = palette.Length;
+            ushort[][] origPalettes = null;
+            var hasMagenta = false;
+            for (var c = 0; c < paletteSize; c++)
+            {
+                if (TexturePalette.Equals(palette[c], MaskMagenta, true))
+                {
+                    hasMagenta = true;
+                    break;
+                }
+            }
+
+            // All stp bits are set if magenta is missing and !blackMaskMode.
+            var stpStarted = !blackMaskMode && !hasMagenta;
+            for (var c = 0; c < paletteSize; c++)
+            {
+                var color = palette[c];
+                var newColor = color;
+                if (TexturePalette.Equals(color, MaskMagenta, true))
+                {
+                    // Magenta marks the start of stp bit setting
+                    newColor = TexturePalette.Transparent;
+                    stpStarted = true;
+                }
+                else if (color == TexturePalette.Transparent)
+                {
+                    // Transparent can mark the start when blackMaskMode and there's no magenta
+                    if (blackMaskMode && !hasMagenta)
+                    {
+                        stpStarted = true;
+                    }
+                    // Transparent always has stp bit set, with one exception:
+                    // When blackMaskMode and !hasMagenta for last color in palette (but only for clut256)
+                    if (!blackMaskMode || hasMagenta || c != 255)
+                    {
+                        newColor = TexturePalette.SetStp(color, true);
+                        hasSemiTransparency = true;
+                    }
+                }
+                else if (stpStarted)
+                {
+                    // Everything after the masking color has the stp bit set
+                    newColor = TexturePalette.SetStp(color, true);
+                    hasSemiTransparency = true;
+                }
+
+                if (color != newColor)
+                {
+                    if (origPalettes == null)
+                    {
+                        origPalettes = new ushort[][] { (ushort[])palette.Clone() };
+                    }
+                    palette[c] = newColor;
+                }
+            }
+
+            return origPalettes ?? palettes;
+        }
+
+        private PSXObject ReadObject(BinaryReader reader, ushort version, uint objectIndex)
+        {
+            var objectFlags = reader.ReadUInt32();
+            // Translation is in absolute world coordinates, not coordinates relative to hierarchy.
+            var x = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
+            var y = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
+            var z = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
+            var unk1 = reader.ReadUInt32();
+            var unk2 = reader.ReadUInt16();
+            // Index of model in the models list. If multiple objects have the same model,
+            // then multiple models are created, which theoretically can be used for
+            // having the same props in different positions.
+            var modelIndex = reader.ReadUInt16();
+            // When non-zero, observed as multiples of 2, tx and/or ty can be non-zero.
+            var tx = reader.ReadInt16();
+            var ty = reader.ReadInt16();
+            var unk3 = reader.ReadUInt32();
+            // Generally every object uses the same palette top, not sure what this palette is used for though.
+            // This can also be null.
+            var paletteTop = reader.ReadUInt32();
+
+            /*_coords[objectIndex] = new Coordinate
+            {
+                OriginalLocalMatrix = Matrix4.CreateTranslation(x, y, z),
+                OriginalTranslation = new Vector3(x, y, z),
+                ID = objectIndex,
+                //ParentID = Coordinate.NoID, // Assigned later
+                //Coords = coords, // Assigned later on success
+            };*/
+
+            _modelDebugData[modelIndex] = new List<string> {
+                $"objectFlags: 0x{objectFlags:x08}",
+                $"unk1: 0x{unk1:x08}",
+                $"unk2: 0x{unk2:x04}",
+                $"unk3: 0x{unk3:x08}",
+                $"tx,ty: {tx}, {ty}",
+                $"paletteTop: 0x{paletteTop:x08}",
+            };
+            return new PSXObject
+            {
+                Translation = new Vector3(x, y, z),
+                ModelIndex = modelIndex,
+            };
+        }
+
+        private bool ReadModel(BinaryReader reader, ushort version, uint modelIndex, ref uint attachmentIndex)
+        {
+            _modelDebugData.TryGetValue(modelIndex, out var modelDebugData);
+            var modelFlags  = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            var vertexCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            var normalCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            var faceCount   = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            modelDebugData?.Add($"modelFlags: 0x{modelFlags:x08}");
+
+            if (vertexCount > Limits.MaxPSXVertices || normalCount > Limits.MaxPSXVertices)
+            {
+                return false;
+            }
+            if (faceCount > Limits.MaxPSXFaces)
+            {
+                return false;
+            }
+
+            var radius = reader.ReadUInt32() / (4096f * _scaleDivisor);
+            var xMax = reader.ReadInt16() / _scaleDivisor;
+            var xMin = reader.ReadInt16() / _scaleDivisor;
+            var yMax = reader.ReadInt16() / _scaleDivisor;
+            var yMin = reader.ReadInt16() / _scaleDivisor;
+            var zMax = reader.ReadInt16() / _scaleDivisor;
+            var zMin = reader.ReadInt16() / _scaleDivisor;
+            if (version == 0x04)
+            {
+                var unk2 = reader.ReadUInt32();
+                modelDebugData?.Add($"modelUnk2: 0x{unk2:x08}");
+            }
+
+            _attachableIndices.Clear();
+            _attachedIndices.Clear();
+            _spriteVertices.Clear();
+
+            if (_vertices == null || _vertices.Length < vertexCount)
+            {
+                Array.Resize(ref _vertices, (int)vertexCount);
+            }
+            for (uint j = 0; j < vertexCount; j++)
+            {
+                // Vertex coding:
+                // pad =  0: Normal vertex
+                // pad =  1: Attachable vertex, file-wide counter as the index
+                // pad =  2: Attached vertex,   Y is the index of the attachable (not vertex index)
+                //                              X and Z are zero
+                // pad =  4: Unknown            X, Y, and Z are not indexes, and may be negative
+                // pad = 16: Sprite vertex,     X is a byte offset to the sprite center vertex (always 0,8,16,24)
+                //                              Y is a byte offset to a vertex (usually 16,16,0,0, rarely 24,24,8,8)
+                //                              Z value is the width of the sprite with some awkward behavior, not fully understood
+                var x = reader.ReadInt16();
+                var y = reader.ReadInt16();
+                var z = reader.ReadInt16();
+                var pad = reader.ReadUInt16();
+                _vertices[j] = new Vector3(x / _scaleDivisor, y / _scaleDivisor, z / _scaleDivisor);
+
+                if (pad == 1)
+                {
+                    _attachableIndices[j] = attachmentIndex++;
+                }
+                else if (pad == 2)
+                {
+                    _attachedIndices[j] = (uint)y;
+                }
+                else if (pad == 4)
+                {
+                    // Observed in Apocalypse, not sure what to do with this
+                }
+                else if (pad == 16)
+                {
+                    var indexB = (uint)x / 8;
+                    var indexA = (uint)y / 8;
+                    if ((uint)x % 8 != 0 || (uint)y % 8 != 0 || indexA >= vertexCount || indexB >= vertexCount)
+                    {
+                        return false;
+                    }
+                    _spriteVertices[j] = new PSXSpriteVertexData
+                    {
+                        IndexA = indexA,
+                        IndexB = indexB,
+                        Width = z / _scaleDivisor,
+                    };
+                }
+                else if (pad != 0)
+                {
+                    var breakHere = 0;
+                }
+            }
+
+            if (_normals == null || _normals.Length < normalCount)
+            {
+                Array.Resize(ref _normals, (int)normalCount);
+            }
+            for (uint j = 0; j < normalCount; j++)
+            {
+                var x = reader.ReadInt16() / 4096f;
+                var y = reader.ReadInt16() / 4096f;
+                var z = reader.ReadInt16() / 4096f;
+                var pad = reader.ReadUInt16(); //pad
+                if (pad != 0)
+                {
+                    var breakHere = 0;
+                }
+                _normals[j] = new Vector3(x, y, z);
+            }
+
+            // I've seen version 0x03 in Apocalypse, and there didn't seem to be fields like this before the faces.
+            // Leaving in-case this exists somewhere else...
+            //uint faceFlags  = 0;
+            //uint faceLength = 0;
+            //if (version == 0x03)
+            //{
+            //    faceFlags  = reader.ReadUInt16();
+            //    faceLength = reader.ReadUInt16();
+            //}
+            for (uint j = 0; j < faceCount; j++)
+            {
+                var facePosition = reader.BaseStream.Position;
+
+                var renderFlags = RenderFlags.None;
+                var mixtureRate = MixtureRate.None;
+
+                var faceFlags  = reader.ReadUInt16();
+                var faceLength = reader.ReadUInt16();
+                var quad      = (faceFlags & 0x0010) == 0;
+                var gouraud   = (faceFlags & 0x0800) != 0;
+                var textured  = (faceFlags & 0x0003) != 0;
+                var semiTrans = (faceFlags & 0x01c0) >> 6;
+                //var subdivision = (faceFlags & 0x1000) != 0;
+
+                var i0 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+                var i1 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+                var i2 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+                var i3 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+                if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount || (quad && i3 >= vertexCount))
+                {
+                    return false; //throw new IndexOutOfRangeException("Vertex index out of bounds");
+                }
+                var vertex0 = _vertices[i0];
+                var vertex1 = _vertices[i1];
+                var vertex2 = _vertices[i2];
+                var vertex3 = quad ? _vertices[i3] : Vector3.Zero;
+
+                Vector3? spriteCenter = null;
+                var hasSpr0 = _spriteVertices.TryGetValue(i0, out var spr0);
+                var hasSpr1 = _spriteVertices.TryGetValue(i1, out var spr1);
+                var hasSpr2 = _spriteVertices.TryGetValue(i2, out var spr2);
+                var hasSpr3 = _spriteVertices.TryGetValue(i3, out var spr3);
+                if (hasSpr0 && hasSpr1 && hasSpr2 && (!quad || hasSpr3))
+                {
+                    // Not really sure how to properly use IndexA vs. IndexB...
+                    var avertex0 = _vertices[spr0.IndexA];
+                    var bvertex0 = _vertices[spr0.IndexB];
+                    var avertex1 = _vertices[spr1.IndexA];
+                    var bvertex1 = _vertices[spr1.IndexB];
+                    var avertex2 = _vertices[spr2.IndexA];
+                    var bvertex2 = _vertices[spr2.IndexB];
+                    var avertex3 = quad ? _vertices[spr3.IndexA] : Vector3.Zero;
+                    var bvertex3 = quad ? _vertices[spr3.IndexB] : Vector3.Zero;
+                    bool Check(Vector3 va, Vector3 vb)
+                    {
+                        return va.X != 0f || va.Z != 0f || vb.X != 0f || vb.Z != 0f;
+                    }
+                    if (Check(avertex0, bvertex0) || Check(avertex1, bvertex1) || Check(avertex2, bvertex2) || (quad && Check(avertex3, bvertex3)))
+                    {
+                        var breakHere = 0;
+                    }
+
+                    spriteCenter = (avertex0 + avertex1 + avertex2 + (quad ? avertex3 : Vector3.Zero));
+                    spriteCenter /= (quad ? 4 : 3);
+
+                    var scale = 1.5f;
+                    // Remember that Y-up is negative, so height values are negated compared to what we set for UVs.
+                    // Note that these vertex coordinates also assume the default orientation of the view is (0, 0, -1).
+                    // These numbers are kind of fudged, but it's the only way I
+                    // could get the sprites working purely from the values given.
+                    vertex0 = avertex0 + new Vector3(-spr0.Width * scale, 0f, 0f);
+                    vertex1 = avertex1 + new Vector3(-spr1.Width * scale, 0f, 0f);
+                    vertex2 = avertex2 + new Vector3(spr2.Width * scale, 0f, 0f);
+                    vertex3 = avertex3 + new Vector3(spr3.Width * scale, 0f, 0f);
+
+                    // todo: Double-sided sprites until this is less jank.
+                    // I've encountered sprites that were backwards.
+                    // Known places where this fails without double-sided:
+                    // * THPS2, CD.WAD_1B36000 courtyard trees
+                    renderFlags |= RenderFlags.SpriteNoPitch | RenderFlags.DoubleSided;
+                }
+                else if (hasSpr0 || hasSpr1 || hasSpr2 || (quad && hasSpr3))
+                {
+                    var breakHere = 0;
+                }
+
+                uint a; // temp variable for assigning attached/attachable indices
+                var attachedIndex0 = _attachedIndices.TryGetValue(i0, out a) ? a : Triangle.NoAttachment;
+                var attachedIndex1 = _attachedIndices.TryGetValue(i1, out a) ? a : Triangle.NoAttachment;
+                var attachedIndex2 = _attachedIndices.TryGetValue(i2, out a) ? a : Triangle.NoAttachment;
+                var attachedIndex3 = quad && _attachedIndices.TryGetValue(i3, out a) ? a : Triangle.NoAttachment;
+                var attachableIndex0 = _attachableIndices.TryGetValue(i0, out a) ? a : Triangle.NoAttachment;
+                var attachableIndex1 = _attachableIndices.TryGetValue(i1, out a) ? a : Triangle.NoAttachment;
+                var attachableIndex2 = _attachableIndices.TryGetValue(i2, out a) ? a : Triangle.NoAttachment;
+                var attachableIndex3 = quad && _attachableIndices.TryGetValue(i3, out a) ? a : Triangle.NoAttachment;
+
+                Color color0, color1, color2, color3;
+                var r = reader.ReadByte();
+                var g = reader.ReadByte();
+                var b = reader.ReadByte();
+                var mode = reader.ReadByte();
+                if (!gouraud)
+                {
+                    color0 = color1 = color2 = color3 = new Color(r / 255f, g / 255f, b / 255f);
+                }
+                else if (r < _gouraudPaletteSize && g < _gouraudPaletteSize && b < _gouraudPaletteSize && (!quad || mode < _gouraudPaletteSize))
+                {
+                    // R/G/B/Mode are treated as indices into gouraud palette table
+                    color0 = _gouraudPalette[r];
+                    color1 = _gouraudPalette[g];
+                    color2 = _gouraudPalette[b];
+                    color3 = quad ? _gouraudPalette[mode] : Color.Grey;
+                }
+                else
+                {
+                    // Gouraud but no (or too small) palette table, this shouldn't happen
+                    //color0 = color1 = color2 = color3 = Color.Grey;
+                    return false;
+                }
+
+                var normalIndex = reader.ReadUInt16();
+                var surfFlags = reader.ReadInt16(); // How the player can interact with this surface, not important
+                if (normalIndex >= normalCount)
+                {
+                    return false; //throw new IndexOutOfRangeException("Normal index out of bounds");
+                }
+                var normal0 = _normals[normalIndex];
+                var normal1 = _normals[normalIndex];
+                var normal2 = _normals[normalIndex];
+                var normal3 = quad ? _normals[normalIndex] : Vector3.Zero;
+
+                var invisible = false;
+                switch (semiTrans)
+                {
+                    case 0x0: // Opaque
+                        break;
+                    case 0x1:
+                        renderFlags |= RenderFlags.SemiTransparent;
+                        mixtureRate = MixtureRate.Back50_Poly50;
+                        invisible = false;
+                        break;
+                    case 0x2: // Invisible, likely for map triggers and behavioral objects
+                        invisible = true;
+                        break;
+                    case 0x3:
+                        renderFlags |= RenderFlags.SemiTransparent;
+                        mixtureRate = MixtureRate.Back100_Poly100;
+                        invisible = false;
+                        break;
+                    case 0x4: // Never observed, effect unknown
+                        break;
+                    case 0x5:
+                        renderFlags |= RenderFlags.SemiTransparent;
+                        mixtureRate = MixtureRate.Back100_PolyM100;
+                        invisible = false;
+                        break;
+                    case 0x6: // Never observed, effect unknown
+                        break;
+                    case 0x7:
+                        renderFlags |= RenderFlags.SemiTransparent;
+                        mixtureRate = MixtureRate.Back100_Poly25;
+                        invisible = false;
+                        break;
+                }
+
+                uint tPage = 0;
+                Vector2 uv0, uv1, uv2, uv3;
+                if (textured)
+                {
+                    renderFlags |= RenderFlags.Textured;
+                    var textureIndex = reader.ReadUInt32();
+                    if (textureIndex < _textureHashCount)
+                    {
+                        tPage = _textureHashes[textureIndex];
+                    }
+                    var u0 = reader.ReadByte();
+                    var v0 = reader.ReadByte();
+                    var u1 = reader.ReadByte();
+                    var v1 = reader.ReadByte();
+                    var u2 = reader.ReadByte();
+                    var v2 = reader.ReadByte();
+                    var u3 = reader.ReadByte();
+                    var v3 = reader.ReadByte();
+                    uv0 = GeomMath.ConvertUV(u0, v0);
+                    uv1 = GeomMath.ConvertUV(u1, v1);
+                    uv2 = GeomMath.ConvertUV(u2, v2);
+                    uv3 = GeomMath.ConvertUV(u3, v3);
+                }
+                else
+                {
+                    uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
+                }
+
+                if (!invisible || Settings.Instance.AdvancedPSXIncludeInvisible)
+                {
+                    var extraLength = faceLength - (reader.BaseStream.Position - facePosition);
+                    var triangle1DebugData = new List<string>
+                    {
+                        $"faceFlags: 0x{faceFlags:x04}",
+                        $"surfFlags: 0x{surfFlags:x04}",
+                        $"extraLength: {extraLength}",
+                        $"Position: 0x{reader.BaseStream.Position:x}",
+                    };
+                    var triangle2DebugData = new List<string>(triangle1DebugData);
+
+                    var triangle1 = new Triangle
+                    {
+                        Vertices = new[] { vertex0, vertex1, vertex2 },
+                        Normals = new[] { normal0, normal1, normal2 },
+                        Uv = new[] { uv0, uv1, uv2 },
+                        Colors = new[] { color0, color1, color2 },
+                        OriginalVertexIndices = new uint[] { i0, i1, i2 },
+                        // Use helper functions to avoid allocating an array if all are "no attachment"
+                        AttachedIndices = Triangle.CreateAttachedIndices(attachedIndex0, attachedIndex1, attachedIndex2),
+                        AttachableIndices = Triangle.CreateAttachableIndices(attachableIndex0, attachableIndex1, attachableIndex2),
+                        DebugData = triangle1DebugData.ToArray(),
+                    };
+                    if (textured)
+                    {
+                        triangle1.TiledUv = new TiledUV(triangle1.Uv, 0f, 0f, 1f, 1f);
+                        triangle1.Uv = (Vector2[])triangle1.Uv.Clone();
+                    }
+                    AddTriangle(triangle1, spriteCenter, tPage, renderFlags, mixtureRate);
+
+                    if (quad)
+                    {
+                        var triangle2 = new Triangle
+                        {
+                            Vertices = new[] { vertex1, vertex3, vertex2 },
+                            Normals = new[] { normal1, normal3, normal2 },
+                            Uv = new[] { uv1, uv3, uv2 },
+                            Colors = new[] { color1, color3, color2 },
+                            OriginalVertexIndices = new uint[] { i1, i3, i2 },
+                            // Use helper functions to avoid allocating an array if all are "no attachment"
+                            AttachedIndices = Triangle.CreateAttachedIndices(attachedIndex1, attachedIndex3, attachedIndex2),
+                            AttachableIndices = Triangle.CreateAttachableIndices(attachableIndex1, attachableIndex3, attachableIndex2),
+                            DebugData = triangle2DebugData.ToArray(),
+                        };
+                        if (textured)
+                        {
+                            triangle2.TiledUv = new TiledUV(triangle2.Uv, 0f, 0f, 1f, 1f);
+                            triangle2.Uv = (Vector2[])triangle2.Uv.Clone();
+                        }
+                        AddTriangle(triangle2, spriteCenter, tPage, renderFlags, mixtureRate);
+                    }
+                }
+
+                reader.BaseStream.Seek(facePosition + faceLength, SeekOrigin.Begin);
+            }
+
+            FlushModels(modelIndex);
+            return true;
+        }
+
+        private void FlushModels(uint modelIndex)
+        {
+            for (uint i = 0; i < _objectCount; i++)
+            {
+                var psxObject = _objects[i];
+                if (psxObject.ModelIndex == modelIndex)
+                {
+                    //var coord = _coords[i];
+                    //var localMatrix = coord.WorldMatrix;
+                    var localMatrix = Matrix4.CreateTranslation(psxObject.Translation);
+                    foreach (var kvp in _groupedTriangles)
+                    {
+                        var renderInfo = kvp.Key;
+                        var triangles = kvp.Value;
+                        _modelDebugData.TryGetValue(modelIndex, out var modelDebugData);
+                        var model = new ModelEntity
+                        {
+                            Triangles = triangles.ToArray(),
+                            TexturePage = 0,
+                            TextureLookup = CreateTextureLookup(renderInfo),
+                            RenderFlags = renderInfo.RenderFlags,
+                            MixtureRate = renderInfo.MixtureRate,
+                            TMDID = modelIndex + 1u,
+                            OriginalLocalMatrix = localMatrix,
+                            DebugData = modelDebugData?.ToArray(),
+                        };
+                        model.ComputeAttached();
+                        _models.Add(model);
+                    }
+                    foreach (var kvp in _groupedSprites)
+                    {
+                        var spriteCenter = kvp.Key.Item1;
+                        var renderInfo = kvp.Key.Item2;
+                        var triangles = kvp.Value;
+                        _modelDebugData.TryGetValue(modelIndex, out var modelDebugData);
+                        var model = new ModelEntity
+                        {
+                            Triangles = triangles.ToArray(),
+                            TexturePage = 0,
+                            TextureLookup = CreateTextureLookup(renderInfo),
+                            RenderFlags = renderInfo.RenderFlags,
+                            MixtureRate = renderInfo.MixtureRate,
+                            SpriteCenter = spriteCenter,
+                            TMDID = modelIndex + 1u,
+                            OriginalLocalMatrix = localMatrix,
+                            DebugData = modelDebugData?.ToArray(),
+                        };
+                        model.ComputeAttached();
+                        _models.Add(model);
+                    }
+                }
+            }
+            _groupedTriangles.Clear();
+            _groupedSprites.Clear();
+        }
+
+        private static TextureLookup CreateTextureLookup(RenderInfo renderInfo)
+        {
+            if (renderInfo.RenderFlags.HasFlag(RenderFlags.Textured))
+            {
+                return new TextureLookup
+                {
+                    ID = renderInfo.TexturePage, // Unknown-type hash of name
+                    ExpectedFormat = PSXParser.FormatNameConst,
+                    UVConversion = TextureUVConversion.Absolute,
+                    TiledAreaConversion = TextureUVConversion.TextureSpace,
+                };
+            }
+            return null;
+        }
+
+        private void AddTriangle(Triangle triangle, Vector3? spriteCenter, uint tPage, RenderFlags renderFlags, MixtureRate mixtureRate)
+        {
+            if (renderFlags.HasFlag(RenderFlags.Textured))
+            {
+                triangle.CorrectUVTearing();
+            }
+            var renderInfo = new RenderInfo(tPage, renderFlags, mixtureRate);
+            if (!spriteCenter.HasValue)
+            {
+                if (!_groupedTriangles.TryGetValue(renderInfo, out var triangles))
+                {
+                    triangles = new List<Triangle>();
+                    _groupedTriangles.Add(renderInfo, triangles);
+                }
+                triangles.Add(triangle);
+            }
+            else
+            {
+                var tuple = new Tuple<Vector3, RenderInfo>(spriteCenter.Value, renderInfo);
+                if (!_groupedSprites.TryGetValue(tuple, out var triangles))
+                {
+                    triangles = new List<Triangle>();
+                    _groupedSprites.Add(tuple, triangles);
+                }
+                triangles.Add(triangle);
+            }
+        }
+
+
+        private struct PSXObject
+        {
+            public Vector3 Translation;
+            public ushort ModelIndex;
+        }
+
+        private struct PSXClutData
+        {
+            public uint ClutTop;
+            public bool IsClut256;
+        }
+
+        private struct PSXSpriteVertexData
+        {
+            public uint IndexA;
+            public uint IndexB;
+            public float Width;
         }
     }
 }

--- a/Common/RenderInfo.cs
+++ b/Common/RenderInfo.cs
@@ -19,7 +19,8 @@ namespace PSXPrev.Common
         // Also known as VibRibbon (only use Vertex0 and Vertex1).
         Line              = (1 << 16),
         // Always face the camera (assumes direction is (0, 0, -1), so X and Y components should be used for size).
-        Sprite            = (1 << 17), // WIP
+        Sprite            = (1 << 17),
+        SpriteNoPitch     = (1 << 18), // WIP
 
         // Not PlayStation render flags
         NoAmbient         = (1 << 28),
@@ -44,7 +45,7 @@ namespace PSXPrev.Common
         // Use this mask when separating meshes by render info.
         public const RenderFlags SupportedFlags = RenderFlags.DoubleSided | RenderFlags.Unlit |
                                                   RenderFlags.SemiTransparent | RenderFlags.Textured |
-                                                  RenderFlags.Line | RenderFlags.Sprite;
+                                                  RenderFlags.Line | RenderFlags.Sprite | RenderFlags.SpriteNoPitch;
 
         public uint TexturePage { get; }
         public RenderFlags RenderFlags { get; }

--- a/Common/Renderer/LineMeshBuilder.cs
+++ b/Common/Renderer/LineMeshBuilder.cs
@@ -88,17 +88,14 @@ namespace PSXPrev.Common.Renderer
             {
                 triangles[i] = Lines[i].ToTriangle();
             }
-            return new ModelEntity
+            var model = new ModelEntity
             {
-                TexturePage = TexturePage,
-                RenderFlags = RenderFlags | RenderFlags.Line,
-                MixtureRate = MixtureRate,
-                SpriteCenter = SpriteCenter,
-                Visible = Visible,
-                DebugMeshRenderInfo = new MeshRenderInfo(this),
                 Triangles = triangles,
                 OriginalLocalMatrix = modelMatrix ?? Matrix4.Identity,
             };
+            CopyTo(model);
+            model.RenderFlags |= RenderFlags.Line;
+            return model;
         }
 
         internal RootEntity CreateRootEntity(Matrix4? modelMatrix = null, string rootEntityName = null)

--- a/Common/Renderer/MeshRenderInfo.cs
+++ b/Common/Renderer/MeshRenderInfo.cs
@@ -28,7 +28,10 @@ namespace PSXPrev.Common.Renderer
         public Color AmbientColor { get; set; } // Overrides Scene's or MeshBatch's ambient color
         public Color SolidColor { get; set; } // Overrides Mesh's vertex colors
         public Vector3 SpriteCenter { get; set; }
+        public Vector2 TextureAnimation { get; set; } // Animation speed of texture in UV units per second
+        public bool MissingTexture { get; set; }
         public bool Visible { get; set; } = true;
+
 
         public bool IsTextured => RenderFlags.HasFlag(RenderFlags.Textured);
 
@@ -46,6 +49,24 @@ namespace PSXPrev.Common.Renderer
             CopyFrom(fromRenderInfo);
         }
 
+        public void CopyTo(ModelEntity modelEntity)
+        {
+            if (modelEntity.DebugMeshRenderInfo == null)
+            {
+                modelEntity.DebugMeshRenderInfo = new MeshRenderInfo();
+            }
+            modelEntity.DebugMeshRenderInfo.CopyFrom(this);
+
+            // Always use the settings built into ModelEntity over MeshRenderInfo.
+            modelEntity.TexturePage = TexturePage;
+            modelEntity.RenderFlags = RenderFlags;
+            modelEntity.MixtureRate = MixtureRate;
+            modelEntity.SpriteCenter = SpriteCenter;
+            modelEntity.TextureAnimation = TextureAnimation;
+            //modelEntity.MissingTexture = MissingTexture; // Read-only property
+            modelEntity.Visible = Visible;
+        }
+
         public void CopyFrom(ModelEntity modelEntity)
         {
             if (modelEntity.DebugMeshRenderInfo != null)
@@ -57,7 +78,17 @@ namespace PSXPrev.Common.Renderer
             RenderFlags = modelEntity.RenderFlags;
             MixtureRate = modelEntity.MixtureRate;
             SpriteCenter = modelEntity.SpriteCenter;
-            Visible     = modelEntity.Visible;
+            var uvConverter = modelEntity.TextureLookup;
+            if (uvConverter != null)
+            {
+                TextureAnimation = uvConverter.ConvertUV(modelEntity.TextureAnimation, true);
+            }
+            else
+            {
+                TextureAnimation = modelEntity.TextureAnimation;
+            }
+            MissingTexture = modelEntity.MissingTexture;
+            Visible = modelEntity.Visible;
         }
 
         public void CopyFrom(MeshRenderInfo renderInfo)
@@ -72,6 +103,8 @@ namespace PSXPrev.Common.Renderer
             AmbientColor = renderInfo.AmbientColor;
             SolidColor = renderInfo.SolidColor;
             SpriteCenter = renderInfo.SpriteCenter;
+            TextureAnimation = renderInfo.TextureAnimation;
+            MissingTexture = renderInfo.MissingTexture;
             Visible = renderInfo.Visible;
         }
     }

--- a/Common/Renderer/TriangleMeshBuilder.cs
+++ b/Common/Renderer/TriangleMeshBuilder.cs
@@ -119,17 +119,13 @@ namespace PSXPrev.Common.Renderer
         // Debug functions for testing built models in the PSXPrev scene viewer.
         internal ModelEntity CreateModelEntity(Matrix4? modelMatrix = null)
         {
-            return new ModelEntity
+            var model = new ModelEntity
             {
-                TexturePage = TexturePage,
-                RenderFlags = RenderFlags,
-                MixtureRate = MixtureRate,
-                SpriteCenter = SpriteCenter,
-                Visible = Visible,
-                DebugMeshRenderInfo = new MeshRenderInfo(this),
                 Triangles = Triangles.ToArray(),
                 OriginalLocalMatrix = modelMatrix ?? Matrix4.Identity,
             };
+            CopyTo(model);
+            return model;
         }
 
         internal RootEntity CreateRootEntity(Matrix4? modelMatrix = null, string rootEntityName = null)

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -19,6 +19,12 @@ namespace PSXPrev.Common
         [DisplayName("Format"), ReadOnly(true)]
         public string FormatName { get; set; }
 
+        [Browsable(false)]
+        public long FileOffset { get; set; }
+
+        [Browsable(false)]
+        public int ResultIndex { get; set; }
+
         [DisplayName("Total Triangles"), ReadOnly(false)]
         public int TotalTriangles
         {

--- a/Common/TexturePalette.cs
+++ b/Common/TexturePalette.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Drawing;
+
+namespace PSXPrev.Common
+{
+    public static class TexturePalette
+    {
+        public const ushort Transparent = 0;
+        public const ushort Black = 0x8000;
+
+
+        public static int ToArgb(ushort color, bool noTransparent = false)
+        {
+            var r = ((color      ) & 0x1f) << 3;
+            var g = ((color >>  5) & 0x1f) << 3;
+            var b = ((color >> 10) & 0x1f) << 3;
+            var a = (!noTransparent && color == 0 ? 0 : 255); // Black color masking
+            return (a << 24) | (r << 16) | (g << 8) | b;
+        }
+
+        public static System.Drawing.Color ToColor(ushort color, bool noTransparent = false)
+        {
+            return System.Drawing.Color.FromArgb(ToArgb(color, noTransparent));
+        }
+
+
+        public static void ToComponents(ushort color, out byte r, out byte g, out byte b)
+        {
+            ToComponents(color, out r, out g, out b, out _);
+        }
+
+        public static void ToComponents(ushort color, out byte r, out byte g, out byte b, out bool stp)
+        {
+            r = (byte)(((color) & 0x1f) << 3);
+            g = (byte)(((color >>  5) & 0x1f) << 3);
+            b = (byte)(((color >> 10) & 0x1f) << 3);
+            stp = (color & 0x8000) != 0; // Semi-transparency: 0-Off, 1-On
+        }
+
+        public static ushort FromComponents(int r, int g, int b, bool stp = false)
+        {
+            ushort color;
+            color  = (ushort)(((r >> 3) & 0x1f));
+            color |= (ushort)(((g >> 3) & 0x1f) <<  5);
+            color |= (ushort)(((b >> 3) & 0x1f) << 10);
+            color |= (ushort)(stp ? 0x8000 : 0);
+            return color;
+        }
+
+        public static bool GetStp(ushort color)
+        {
+            return (color & 0x8000) != 0;
+        }
+
+        public static ushort SetStp(ushort color, bool stp)
+        {
+            return (ushort)((color & ~0x8000) | (stp ? 0x8000 : 0));
+        }
+
+        public static void SetStp(ref ushort color, bool stp)
+        {
+            color = SetStp(color, stp);
+        }
+
+        public static ushort ToggleStp(ushort color)
+        {
+            return (ushort)(color ^ 0x8000);
+        }
+
+        public static void ToggleStp(ref ushort color)
+        {
+            color = ToggleStp(color);
+        }
+
+        public static bool Equals(ushort colorA, ushort colorB, bool ignoreStp = false)
+        {
+            if (ignoreStp)
+            {
+                // XOR to get non-zero bits that don't match, mask out stp bit, then check if zero.
+                return ((colorA ^ colorB) & ~0x8000) == 0;
+            }
+            else
+            {
+                return (colorA == colorB);
+            }
+        }
+
+        public static bool Equals(ushort[] paletteA, ushort[] paletteB, bool ignoreStp = false)
+        {
+            if (paletteA.Length == paletteB.Length)
+            {
+                var paletteSize = paletteA.Length;
+                for (var c = 0; c < paletteSize; c++)
+                {
+                    if (!Equals(paletteA[c], paletteB[c], ignoreStp))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        public static bool MaskColors(ushort[][] palettes, ushort[] masks, bool ignoreStp, bool unmaskBlack)
+        {
+            var semiTransparencySet = false;
+            var palettesCount = palettes.Length;
+            var paletteSize = palettes[0].Length;
+            var maskCount = masks.Length;
+            for (var p = 0; p < palettesCount; p++)
+            {
+                var palette = palettes[p];
+                for (var c = 0; c < paletteSize; c++)
+                {
+                    var color = palette[c];
+                    var masked = false;
+                    for (var m = 0; m < maskCount; m++)
+                    {
+                        if (Equals(color, masks[m], ignoreStp))
+                        {
+                            palette[c] = Transparent;
+                            masked = true;
+                            break;
+                        }
+                    }
+                    if (!masked && color == Transparent && unmaskBlack)
+                    {
+                        palette[c] = Black;
+                        semiTransparencySet = true;
+                    }
+                }
+            }
+            return semiTransparencySet;
+        }
+
+        public static bool MaskColor(ushort[][] palettes, ushort mask, bool ignoreStp, bool unmaskBlack)
+        {
+            var semiTransparencySet = false;
+            var palettesCount = palettes.Length;
+            var paletteSize = palettes[0].Length;
+            for (var p = 0; p < palettesCount; p++)
+            {
+                var palette = palettes[p];
+                for (var c = 0; c < paletteSize; c++)
+                {
+                    var color = palette[c];
+                    if (Equals(color, mask, ignoreStp))
+                    {
+                        palette[c] = Transparent;
+                    }
+                    else if (color == Transparent && unmaskBlack)
+                    {
+                        palette[c] = Black;
+                        semiTransparencySet = true;
+                    }
+                }
+            }
+            return semiTransparencySet;
+        }
+
+        public static bool UnmaskBlack(ushort[][] palettes)
+        {
+            var semiTransparencySet = false;
+            var palettesCount = palettes.Length;
+            var paletteSize = palettes[0].Length;
+            for (var p = 0; p < palettesCount; p++)
+            {
+                var palette = palettes[p];
+                for (var c = 0; c < paletteSize; c++)
+                {
+                    if (palette[c] == Transparent)
+                    {
+                        palette[c] = Black;
+                        semiTransparencySet = true;
+                    }
+                }
+            }
+            return semiTransparencySet;
+        }
+    }
+}

--- a/Common/TiledUV.cs
+++ b/Common/TiledUV.cs
@@ -1,10 +1,13 @@
-﻿using OpenTK;
+﻿using System;
+using OpenTK;
 
 namespace PSXPrev.Common
 {
     public interface IUVConverter
     {
-        Vector2 ConvertUV(Vector2 uv);
+        Vector2 ConvertUV(Vector2 uv, bool tiled);
+
+        Vector4 ConvertTiledArea(Vector4 tiledArea);
     }
 
     public class TiledUV : IUVConverter
@@ -70,7 +73,12 @@ namespace PSXPrev.Common
             return uv;
         }
 
-        public Vector2 ConvertUV(Vector2 uv) => ConvertUV(uv, X, Y, Width, Height);
+        public Vector2 ConvertUV(Vector2 uv, bool tiled)
+        {
+            return ConvertUV(uv, tiled ? 0f : X, tiled ? 0f : Y, Width, Height);
+        }
+
+        Vector4 IUVConverter.ConvertTiledArea(Vector4 tiledArea) => throw new NotImplementedException();
 
 
         public static Vector2 ConvertUV(Vector2 uv, float x, float y, float width, float height)

--- a/Common/Triangle.cs
+++ b/Common/Triangle.cs
@@ -115,6 +115,14 @@ namespace PSXPrev.Common
         [Browsable(false)]
         public float IntersectionDistance { get; set; }
 
+#if DEBUG
+        [DisplayName("Debug Data"), ReadOnly(true)]
+#else
+        [Browsable(false)]
+#endif
+        public string[] DebugData { get; set; }
+
+
         public Triangle()
         {
 
@@ -213,6 +221,26 @@ namespace PSXPrev.Common
 #endif
             }
             return this;
+        }
+
+        // Shorthand for returning an array, but only if there are indices with attachments.
+        public static uint[] CreateAttachedIndices(uint attachedIndex0, uint attachedIndex1, uint attachedIndex2)
+        {
+            if (attachedIndex0 != NoAttachment || attachedIndex1 != NoAttachment || attachedIndex2 != NoAttachment)
+            {
+                return new[] { attachedIndex0, attachedIndex1, attachedIndex2 };
+            }
+            return null;
+        }
+
+        // Shorthand for returning an array, but only if there are indices that are attachable.
+        public static uint[] CreateAttachableIndices(uint attachableIndex0, uint attachableIndex1, uint attachableIndex2)
+        {
+            if (attachableIndex0 != NoAttachment || attachableIndex1 != NoAttachment || attachableIndex2 != NoAttachment)
+            {
+                return new[] { attachableIndex0, attachableIndex1, attachableIndex2 };
+            }
+            return EmptyAttachableIndices;
         }
     }
 }

--- a/Common/Utils/CollectionExtensions.cs
+++ b/Common/Utils/CollectionExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PSXPrev.Common.Utils
+{
+    public static class CollectionExtensions
+    {
+        public static void AddToCounter<TKey>(this IDictionary<TKey, int> dictionary, TKey key, int inc = 1)
+        {
+            dictionary.TryGetValue(key, out var count);
+            dictionary[key] = count + inc;
+        }
+
+        public static string DictionaryToString<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, Func<TKey, string> keyToString = null, Func<TValue, string> valueToString = null, IComparer<TKey> orderBy = null, bool padKey = true)
+        {
+            if (!dictionary.Any())
+            {
+                return string.Empty;
+            }
+            var str = new StringBuilder();
+            var maxLength = 0;
+            if (padKey)
+            {
+                maxLength = dictionary.Select(kvp => (keyToString?.Invoke(kvp.Key) ?? kvp.Key.ToString()).Length).Max();
+            }
+            var items = dictionary;
+            if (orderBy != null)
+            {
+                items = items.OrderBy(kvp => kvp.Key, orderBy);
+            }
+            var first = true;
+            foreach (var kvp in items)
+            {
+                if (!first)
+                {
+                    str.AppendLine();
+                }
+                first = false;
+                var key   = (keyToString?.Invoke(kvp.Key)     ?? kvp.Key.ToString());
+                var value = (valueToString?.Invoke(kvp.Value) ?? kvp.Value.ToString());
+                str.Append($"{key.PadLeft(maxLength)}: {value}");
+            }
+            return str.ToString();
+        }
+    }
+}

--- a/Forms/ScannerForm.Designer.cs
+++ b/Forms/ScannerForm.Designer.cs
@@ -224,7 +224,7 @@
             this.checkPSXCheckBox.Size = new System.Drawing.Size(47, 17);
             this.checkPSXCheckBox.TabIndex = 4;
             this.checkPSXCheckBox.Text = "PSX";
-            this.toolTip.SetToolTip(this.checkPSXCheckBox, "Tony Hawk\'s Pro Scater / Apocalypse / Spiderman");
+            this.toolTip.SetToolTip(this.checkPSXCheckBox, "Tony Hawk\'s Pro SKater / Apocalypse / Spiderman");
             this.checkPSXCheckBox.UseVisualStyleBackColor = true;
             // 
             // checkMODCheckBox

--- a/Forms/TMDBindingsForm.cs
+++ b/Forms/TMDBindingsForm.cs
@@ -82,7 +82,7 @@ namespace PSXPrev.Forms
         }
 
         private void pasteBindingsToolStripMenuItem_Click(object sender, EventArgs e)
-        {;
+        {
             if (_clipboard is Dictionary<uint, uint> dataObject)
             {
                 _currentAnimation.TMDBindings.Clear();

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;ENABLE_CLIPBOARD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>1</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -120,7 +120,9 @@
     <Compile Include="Common\Renderer\Scene.cs" />
     <Compile Include="Common\Renderer\TextureBinder.cs" />
     <Compile Include="Common\Renderer\VRAM.cs" />
+    <Compile Include="Common\TexturePalette.cs" />
     <Compile Include="Common\Utils\BinaryReaderExtensions.cs" />
+    <Compile Include="Common\Utils\CollectionExtensions.cs" />
     <Compile Include="Common\Utils\DrawingExtensions.cs" />
     <Compile Include="Common\Utils\FInt.cs" />
     <Compile Include="Common\Utils\JsonStringColorConverter.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -990,7 +990,7 @@ namespace PSXPrev
             }
             if (_options.CheckAll || _options.CheckPSX)
             {
-                parsers.Add(() => new PSXParser(AddEntity));
+                parsers.Add(() => new PSXParser(AddEntity, AddTexture));
             }
             // SPT produces too many false positives to be enabled by default
             if (/*_options.CheckAll ||*/ _options.CheckSPT)
@@ -1059,7 +1059,6 @@ namespace PSXPrev
             {
                 return ProcessCDContents(cdReader, filter, parsers, false);
             }
-            return false;
         }
 
         private static bool ProcessBINContents(string binPath, string filter, List<Func<FileOffsetScanner>> parsers)

--- a/Settings.cs
+++ b/Settings.cs
@@ -152,6 +152,9 @@ namespace PSXPrev
         [JsonProperty("showUVsInVRAM")]
         public bool ShowUVsInVRAM { get; set; } = true;
 
+        [JsonProperty("showMissingTextures")]
+        public bool ShowMissingTextures { get; set; } = true;
+
         [JsonProperty("autoDrawModelTextures")]
         public bool AutoDrawModelTextures { get; set; } = false;
 
@@ -194,8 +197,25 @@ namespace PSXPrev
         [JsonProperty("logExceptionPrefixColor"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
         public ConsoleColor LogExceptionPrefixColor { get; set; } = ConsoleColor.DarkGray;
 
-        [JsonProperty("scanOptionsShowAdvanced")]
-        public bool ShowAdvancedScanOptions { get; set; } = false;
+
+        [JsonProperty("advancedBFFSpriteScale")]
+        public float AdvancedBFFSpriteScale { get; set; } = 2.5f;
+
+        // Unknown what the real divisor is, but the default setting creates very large models.
+        [JsonProperty("advancedBFFScaleDivisor")]
+        public float AdvancedBFFScaleDivisor { get; set; } = 1.0f;
+
+        // The real divisor is supposedly 4096f, but that creates VERY SMALL models.
+        [JsonProperty("advancedMODScaleDivisor")]
+        public float AdvancedMODScaleDivisor { get; set; } = 16.0f;
+
+        // The real divisor is supposedly 4096f, but that creates VERY SMALL models.
+        [JsonProperty("advancedPSXScaleDivisor")]
+        public float AdvancedPSXScaleDivisor { get; set; } = 2.25f;
+
+        [JsonProperty("advancedPSXIncludeInvisible")]
+        public bool AdvancedPSXIncludeInvisible { get; set; } = false;
+
 
         [JsonProperty("scanProgressFrequency")]
         public float ScanProgressFrequency { get; set; } = 1f / 60f; // 1 frame (60FPS)
@@ -203,8 +223,8 @@ namespace PSXPrev
         [JsonProperty("scanPopulateFrequency")]
         public float ScanPopulateFrequency { get; set; } = 4f; // 4 seconds
 
-        [JsonProperty("debugBFFSpriteScale")]
-        public float DebugBFFSpriteScale { get; set; } = 2.5f;
+        [JsonProperty("scanOptionsShowAdvanced")]
+        public bool ShowAdvancedScanOptions { get; set; } = false;
 
         [JsonProperty("scanOptions")]
         public ScanOptions ScanOptions { get; set; } = new ScanOptions();
@@ -309,16 +329,27 @@ namespace PSXPrev
             CurrentCLUTIndex  = ValidateClamp(CurrentCLUTIndex,  Defaults.CurrentCLUTIndex, 0, 255);
             AnimationLoopMode = ValidateEnum( AnimationLoopMode, Defaults.AnimationLoopMode);
             AnimationSpeed    = ValidateClamp(AnimationSpeed,    Defaults.AnimationSpeed, 0.01f, 100f);
+
             LogStandardColor        = ValidateEnum(LogStandardColor,        Defaults.LogStandardColor);
             LogPositiveColor        = ValidateEnum(LogPositiveColor,        Defaults.LogPositiveColor);
             LogWarningColor         = ValidateEnum(LogWarningColor,         Defaults.LogWarningColor);
             LogErrorColor           = ValidateEnum(LogErrorColor,           Defaults.LogErrorColor);
             LogExceptionPrefixColor = ValidateEnum(LogExceptionPrefixColor, Defaults.LogExceptionPrefixColor);
+
+            AdvancedBFFSpriteScale  = ValidateMax(AdvancedBFFSpriteScale,  Defaults.AdvancedBFFSpriteScale,  0.000001f);
+            AdvancedBFFScaleDivisor = ValidateMax(AdvancedBFFScaleDivisor, Defaults.AdvancedBFFScaleDivisor, 0.000001f);
+            AdvancedMODScaleDivisor = ValidateMax(AdvancedMODScaleDivisor, Defaults.AdvancedMODScaleDivisor, 0.000001f);
+            AdvancedPSXScaleDivisor = ValidateMax(AdvancedPSXScaleDivisor, Defaults.AdvancedPSXScaleDivisor, 0.000001f);
+
             ScanProgressFrequency = ValidateMax(ScanProgressFrequency, Defaults.ScanProgressFrequency, 0f);
             ScanPopulateFrequency = ValidateMax(ScanPopulateFrequency, Defaults.ScanPopulateFrequency, 0f);
 
             // Clamp multisampling to power of two
-            if (Multisampling >= 8)
+            if (Multisampling >= 16)
+            {
+                Multisampling = 16;
+            }
+            else if (Multisampling >= 8)
             {
                 Multisampling = 8;
             }

--- a/Shaders/Shader.frag
+++ b/Shaders/Shader.frag
@@ -17,6 +17,7 @@ uniform vec3 lightDirection;
 uniform vec3 maskColor;
 uniform vec3 ambientColor;
 uniform vec3 solidColor;
+uniform vec2 uvOffset;
 uniform int lightMode;
 uniform int colorMode;
 uniform int textureMode;
@@ -24,46 +25,97 @@ uniform int semiTransparentPass;
 uniform float lightIntensity;
 uniform sampler2D mainTex;
 
+const vec3 BlackMask = vec3(0.0, 0.0, 0.0);
+
+const vec4 OutOfBoundsTexture_Color1 = vec4(1.0, 0.05, 0.0, 1.0); // Red with slight Orange
+const vec4 MissingTexture_Color1     = vec4(1.0, 0.0, 1.0, 1.0); // Magenta
+const vec4 InvalidTexture_Color2     = vec4(0.0, 0.0, 0.0, 1.0); // Black
+const vec4 InvalidTexture_StpColor2  = vec4(0.5, 0.5, 0.5, 1.0); // Gray
+const float InvalidTexture_Step = 8.0 / 256.0;
+
+const int LightMode_AmbientDirectional = 0;
+const int LightMode_Ambient            = 1;
+const int LightMode_Directional        = 2;
+const int LightMode_None               = 3;
+
+const int ColorMode_VertexColor = 0;
+const int ColorMode_SolidColor  = 1;
+
+const int TextureMode_Enabled        = 0;
+const int TextureMode_Disabled       = 1;
+const int TextureMode_MissingTexture = 2;
+
+const int RenderPass_Pass1Opaque                      = 0;
+const int RenderPass_Pass2SemiTransparentOpaquePixels = 1;
+const int RenderPass_Pass3SemiTransparent             = 2;
+
+
+vec3 calcUV(vec2 uv) {
+	// X,Y is tiled U,V offset and Z,W is tiled U,V wrap size.
+	if (pass_TiledArea.z != 0.0) {
+		uv.x = pass_TiledArea.x + mod(uv.x, pass_TiledArea.z);
+	}
+	if (pass_TiledArea.w != 0.0) {
+		uv.y = pass_TiledArea.y + mod(uv.y, pass_TiledArea.w);
+	}
+	float outOfBounds = ((uv.x < 0.0 || uv.y < 0.0 || uv.x > 1.0 || uv.y > 1.0) ? 1.0 : 0.0);
+	return vec3(uv.x, uv.y, outOfBounds);
+}
+
+vec4 calcInvalidTexture(vec3 uv) {
+	bool invalidX = (mod(uv.x, InvalidTexture_Step * 2) >= InvalidTexture_Step);
+	bool invalidY = (mod(uv.y, InvalidTexture_Step * 2) >= InvalidTexture_Step);
+	if (invalidX == invalidY) {
+		// Primary color for even squares
+		return (uv.z == 0 ? MissingTexture_Color1 : OutOfBoundsTexture_Color1);
+	} else {
+		// Secondary color for odd squares
+		// Change black squares to gray, so that they show up with semi-transparency
+		return (semiTransparentPass != 2 ? InvalidTexture_Color2 : InvalidTexture_StpColor2);
+	}
+}
+
+
 void main(void) {
+	// Process vertex shader discarding:
 	if (discardPixel > 0.0) {
 		discard;
 	}
 
-	// Process texture UVs and stp bit
+	// Process texture UVs and stp bit:
+	vec3 uv = calcUV(pass_Uv); // uv.z is non-zero when out-of-bounds
 	vec4 tex2D;
-	int stp;
-	if (textureMode == 0) {
-		vec2 uv = pass_Uv;
-		// X,Y is tiled U,V offset and Z,W is tiled U,V wrap size.
-		if (pass_TiledArea.z != 0.0) {
-			uv.x = pass_TiledArea.x + mod(pass_Uv.x, pass_TiledArea.z);
-		}
-		if (pass_TiledArea.w != 0.0) {
-			uv.y = pass_TiledArea.y + mod(pass_Uv.y, pass_TiledArea.w);
-		}
-
+	bool stp;
+	if (textureMode == 0 && uv.z == 0.0) {
+		// Note: I read a comment stating the result of texture() can be undefined
+		// when inside an if statement. If issues arise, then try moving this outside.
 		tex2D      = texture(mainTex, vec2(uv.x * 0.5,       uv.y));
 		vec4 stp2D = texture(mainTex, vec2(uv.x * 0.5 + 0.5, uv.y));
-		stp = (stp2D.x == 0.0 ? 0 : 1);
-	} else {
+		stp = (stp2D.x != 0.0);
+	} else if (textureMode == 1) {
+		// Use vertex color only
 		tex2D = vec4(1.0, 1.0, 1.0, 1.0);
-		stp = 1; // Untextured always treats stp bit as set.
+		stp = true; // Untextured always treats stp bit as set.
+	} else {
+		// Use missing/out-of-bounds texture checkered pattern
+		tex2D = calcInvalidTexture(uv);
+		stp = true; // Show semi-transparency and avoid black masking
 	}
 
-	// Process semi-transparency discarding
-	if (stp == 0 && tex2D.xyz == maskColor) {
+	// Process semi-transparency discarding:
+	if (!stp && tex2D.xyz == maskColor) {
 		discard; // Black surfaces are transparent when stp bit is unset.
 	} else if (semiTransparentPass == 1) {
-		if (stp != 0) {
+		if (stp) {
 			discard; // Semi-transparent surface during no-stp bit pass.
 		}
 	} else if (semiTransparentPass == 2) {
-		if (stp == 0) {
+		if (!stp) {
 			discard; // Opaque surface during stp bit pass.
 		}
 	}
 
-	// Process lighting and final color
+	// Process lighting and final color:
 	vec4 finalColor = tex2D * pass_Color;
 	if (lightMode == 0) {
 		finalColor *= (pass_Ambient + pass_NormalDotLight);
@@ -72,5 +124,6 @@ void main(void) {
 	} else if (lightMode == 2) {
 		finalColor *= (pass_NormalDotLight);
 	}
+	// No extra logic for lightMode == 3
 	out_Color = finalColor;
 }

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -20,6 +20,7 @@ uniform vec3 lightDirection;
 uniform vec3 maskColor;
 uniform vec3 ambientColor;
 uniform vec3 solidColor;
+uniform vec2 uvOffset;
 uniform int lightMode;
 uniform int colorMode;
 uniform int textureMode;
@@ -29,14 +30,17 @@ uniform sampler2D mainTex;
 
 const float discardValue = 100000000;
 
+const int ColorMode_VertexColor = 0;
+const int ColorMode_SolidColor  = 1;
+
 void main(void) {
-	// Check for discarded vertices (coordinates match discardValue)
+	// Check for discarded vertices (coordinates match discardValue):
 	discardPixel = step(discardValue, in_Position.x);
 
-	// Process position
+	// Process position:
 	gl_Position = mvpMatrix * vec4(in_Position, 1.0);
 
-	// Process normal and directional lighting
+	// Process normal and directional lighting:
 	pass_NormalLength = length(in_Normal);
 	vec3 normal = normalMatrix * in_Normal;
 	if (dot(normal, normal) != 0.0) {
@@ -46,11 +50,11 @@ void main(void) {
 	}
 	pass_NormalDotLight = clamp(dot(normal, lightDirection), 0.0, 1.0) * lightIntensity;
 
-	// Process UVs
-	pass_Uv = in_Uv;
+	// Process UVs:
+	pass_Uv = in_Uv + uvOffset;
 	pass_TiledArea = in_TiledArea;
 
-	// Process color
+	// Process color:
 	pass_Ambient = vec4(ambientColor, 1.0);
 	if (colorMode == 0) {
 		pass_Color = vec4(in_Color, 1.0);


### PR DESCRIPTION
### PSXParser
* PSXParser can now read textures, and also read PSX files that ONLY have textures.
* PSX textures automatically handle their own masking (no longer need to set Magenta mask color) and setting of certain stp bits. There are a lot of convoluted rules on how masking/stp-setting works.
* PSX textures are the same as SPT, and must be packed before usage. Unlike SPT, UV coordinates are absolute. PSX UV coordinates are tiled around the texture size, this is why absolute coordinates are used.
* Added support for all (observed) semi-transparency flags. It turns out the invisible flag is only invisible when 0x2 in a set of 3 bits. Everything else is either opaque, semi-transparent, or unobserved.
* Gouraud palette is now parsed in RGBs tagged chunk. It turns out the chunk can be less than 256 entries. If black repeats itself in the palette, then it has special properties and isn't really black. For now, these special blacks are changed to default gray.
* When HIER (hierarchy) tagged chunks are present, vertices have their values divided by 16.0. This fixes many humanoid models looking incomprihensible, but doesn't solve everything entirely. It also fixes these models being incredibly large in comparison to the world. Now their size is accurate.
* PSX now flushes triangles after each model is parsed (so we don't need to iterate through objectCount x modelCount sets of grouped triangles every time). This also means all models are now listed in TMDID order.
* PSX TMDIDs are now 1-indexed, like everything else usually is.
* Added SpriteNoPitch render flag, which is used for sprites that face the camera, but only via yaw rotation. PSX models use these sprites, signaled by vertex pad 16.
* Added advanced settings.json option to include invisible faces in PSX models.

### Other
* Added advanced settings.json options to control the scale divisor for each of the following formats: BFF, MOD, PSX.
* Added settings.json option (no UI item yet) to show missing textures when a texture could not be looked up or packed.
* Textures now show orange/black missing texture pattern if UVs go out of bounds (when not tiled). This should never happen, since UVs are always read as bytes, but it's a debugging measure in case something is broken.
* Some refactoring to BFF and MOD formats to follow the same changes to PSX.
* Fixed typo for PSX format tooltip in scanner window.
* Added preprocessor define ENABLE_CLIPBOARD (currently only used in debug builds) to enable using Ctrl+C to copy the scene, or texture/VRAM preview.
* Added pixel getter functions to Texture.
* Changed palette storage to ushort in the native 5/5/5/stp format. This means we no longer need a separate palette for semi-transparency. It also means storage usage goes down by a lot. Added TexturePalette static class to make it easier to manage these palette colors.
* All scan results now store their original file offset.
* All scan results now store the index of their result type in the current match.
* Added debug-toggleable mode to mark pixel semi-transparency in the texure/VRAM preview.
* Added debug-toggleable mode to preview a texture's palette instead of the texture.
* Added debug-toggleable mode to select models via triangle collision instead of bounds collision.
* Added GC.Collect() to ClearScanResults, so that memory is freed up ASAP.
* Texture packing now only happens in UpdateSelectedEntity if updateMeshData is true (to reduce lag from small updates).
* Changed GL.ClearColor to use alpha of 1.0, so that calling GL.ReadPixels won't return gray for the back color.

![image](https://github.com/rickomax/psxprev/assets/9752430/adb86abd-a4ef-4e57-a22d-d4e98e34f184)
