### PR TITLE
Improved exporter grouping support, and glTF2 coordinate support

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -16,6 +16,50 @@ namespace PSXPrev.Common.Animator
         HMD, // Multiple methods of interpolation that can change between frames.
     }
 
+    public static class AnimationTypeExtensions
+    {
+        public static bool IsCoordinateBased(this AnimationType animationType)
+        {
+            switch (animationType)
+            {
+                case AnimationType.HMD:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsTransformBased(this AnimationType animationType)
+        {
+            switch (animationType)
+            {
+                case AnimationType.Common:
+                case AnimationType.RPYDiff:
+                case AnimationType.MatrixDiff:
+                case AnimationType.AxisDiff:
+                //case AnimationType.HMD:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsVertexBased(this AnimationType animationType)
+        {
+            switch (animationType)
+            {
+                case AnimationType.VertexDiff:
+                case AnimationType.NormalDiff:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+
     public class Animation
     {
         private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);

--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -264,7 +264,7 @@ namespace PSXPrev.Common.Animator
         {
             // Reset coordinate matrices in-case a frame requires the last state of the matrix.
             // This is important because there's no guarantee the animation won't skip a frame due to lag.
-            if (_animation.RootAnimationObject == animationObject && _animation.AnimationType == AnimationType.HMD)
+            if (_animation.RootAnimationObject == animationObject && _animation.AnimationType.IsCoordinateBased())
             {
                 ResetAnimationCoords(animationObject, selectedRootEntity);
             }
@@ -536,7 +536,7 @@ namespace PSXPrev.Common.Animator
             }
 
             // HMD: Update the temporary matrices of all models, now that the coordinate system has been updated.
-            if (_animation.RootAnimationObject == animationObject && _animation.AnimationType == AnimationType.HMD)
+            if (_animation.RootAnimationObject == animationObject && _animation.AnimationType.IsCoordinateBased())
             {
                 var coords = selectedRootEntity?.Coords;
                 if (coords != null)

--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -78,13 +78,13 @@ namespace PSXPrev.Common
         {
             get
             {
-                var matrix = Matrix4.Identity;
-                var entity = this;
-                do
+                var matrix = LocalMatrix;
+                var entity = ParentEntity;
+                while (entity != null)
                 {
                     matrix *= entity.LocalMatrix;
                     entity = entity.ParentEntity;
-                } while (entity != null);
+                }
                 return matrix;
             }
         }

--- a/Common/Exporters/ExportModelOptions.cs
+++ b/Common/Exporters/ExportModelOptions.cs
@@ -1,9 +1,19 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
+using PSXPrev.Common.Utils;
 
 namespace PSXPrev.Common.Exporters
 {
+    public enum ExportModelGrouping
+    {
+        Default,
+        //SplitAllSubModels,
+        SplitSubModelsByTMDID,
+        GroupAllModels,
+    }
+
     [JsonObject]
-    public class ExportModelOptions
+    public class ExportModelOptions : IEquatable<ExportModelOptions>
     {
         public const string DefaultFormat = OBJ;
 
@@ -11,6 +21,38 @@ namespace PSXPrev.Common.Exporters
         public const string PLY = "PLY";
         public const string DAE = "DAE";
         public const string GLTF2 = "glTF2";
+
+
+        // Equality checking and optimization.
+        [JsonIgnore]
+        private string _equalityString;
+        [JsonIgnore]
+        private int _equalityStringHashCode;
+        [JsonIgnore]
+        private bool _isReadOnly;
+        // Set to true to claim that fields will not be changed. Used to optimize equality checks.
+        [JsonIgnore]
+        public bool IsReadOnly
+        {
+            get => _isReadOnly;
+            set
+            {
+                _isReadOnly = value;
+                if (!_isReadOnly)
+                {
+                    _equalityString = null;
+                    _equalityStringHashCode = 0;
+                }
+            }
+        }
+
+        // Optional display name to assign to history
+        [JsonProperty("displayName", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string DisplayName { get; set; } = null;
+        // Optionally prevent this from being removed from the history list
+        [JsonProperty("bookmarked", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsBookmarked { get; set; } = false;
+
 
         // These settings are only present for loading and saving purposes.
         // File path:
@@ -20,7 +62,7 @@ namespace PSXPrev.Common.Exporters
         public string Name { get; set; } = string.Empty;
         // Format:
         [JsonProperty("format")]
-        public string Format { get; set; } = OBJ;
+        public string Format { get; set; } = DefaultFormat;
 
         // Textures:
         [JsonProperty("exportTextures")]
@@ -30,13 +72,13 @@ namespace PSXPrev.Common.Exporters
         [JsonProperty("tiledTextures")]
         public bool TiledTextures { get; set; } = true;
         [JsonProperty("redrawModelTextures")]
-        public bool RedrawTextures { get; set; } = false; // Redraw textures owned by models to VRAM pages before export (HMD)
+        public bool RedrawTextures { get; set; } = false; // Redraw textures owned by models to VRAM pages before export (HMD, BFF, PIL, PSX)
         [JsonProperty("singleTexture")]
         public bool SingleTexture { get; set; } = false; // Combine all textures into a single image
 
         // Options:
-        [JsonProperty("mergeModels")]
-        public bool MergeEntities { get; set; } = false;
+        [JsonProperty("modelGrouping"), JsonConverter(typeof(JsonStringEnumIgnoreCaseConverter))]
+        public ExportModelGrouping ModelGrouping { get; set; } = ExportModelGrouping.Default;
         [JsonProperty("attachLimbs")]
         public bool AttachLimbs { get; set; } = true;
         [JsonProperty("vertexIndexReuse")]
@@ -49,8 +91,8 @@ namespace PSXPrev.Common.Exporters
         public bool ExperimentalOBJVertexColor { get; set; } = true;
 
         // Animations:
-        [JsonIgnore]
-        public bool ExportTickedAnimations { get; set; }
+        //[JsonIgnore]
+        //public bool ExportTickedAnimations { get; set; }
         [JsonProperty("exportAnimations")]
         public bool ExportAnimations { get; set; }
 
@@ -90,6 +132,59 @@ namespace PSXPrev.Common.Exporters
         public ExportModelOptions Clone()
         {
             return (ExportModelOptions)MemberwiseClone();
+        }
+
+        // Normalize settings for equality checks
+        private void Normalize()
+        {
+            DisplayName = null;
+            IsBookmarked = false;
+
+            Path = Path?.ToLower();
+            Name = Name?.Trim()?.ToLower();
+        }
+
+        // It's easier to manage equality by *not* having to update it every time settings are changed.
+        // This is a lazy solution, but requires near-zero maintenance.
+        private string GetEqualityString(out int? hashCode)
+        {
+            string equalityString;
+            hashCode = null;
+            if (_equalityString != null)
+            {
+                equalityString = _equalityString;
+                hashCode = _equalityStringHashCode;
+            }
+            else
+            {
+                var options = Clone();
+                options.Normalize();
+
+                // Use settings to reduce the size of the string
+                var jsonSettings = new JsonSerializerSettings
+                {
+                    Formatting = Formatting.None,
+                    NullValueHandling = NullValueHandling.Ignore,
+                    DefaultValueHandling = DefaultValueHandling.Ignore,
+                };
+                equalityString = JsonConvert.SerializeObject(options, jsonSettings);// Formatting.None);
+
+                if (_isReadOnly)
+                {
+                    hashCode = equalityString.GetHashCode();
+                    _equalityString = equalityString;
+                    _equalityStringHashCode = hashCode.Value;
+                }
+            }
+            return equalityString;
+        }
+
+        public bool Equals(ExportModelOptions other)
+        {
+            var str      = GetEqualityString(out var hashCode);
+            var strOther = other.GetEqualityString(out var hashCodeOther);
+            // If both equalities are cached, then we can compare hash codes first to save time
+            return (!hashCode.HasValue || !hashCodeOther.HasValue || hashCode == hashCodeOther) && str == strOther;
         }
     }
 }

--- a/Common/ModelEntity.cs
+++ b/Common/ModelEntity.cs
@@ -201,10 +201,19 @@ namespace PSXPrev.Common
         {
             get
             {
+                var needsTextureLookup = NeedsTextureLookup;
                 foreach (var triangle in Triangles)
                 {
-                    if (triangle.NeedsTiled)
-                        return true;
+                    if (needsTextureLookup)
+                    {
+                        if (triangle.IsTiled)
+                            return true;
+                    }
+                    else
+                    {
+                        if (triangle.NeedsTiled)
+                            return true;
+                    }
                 }
                 return false;
             }

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -61,6 +61,9 @@ namespace PSXPrev.Common
             : base(fromRootEntity)
         {
             Coords = fromRootEntity.Coords;
+            FormatName = fromRootEntity.FormatName;
+            FileOffset = fromRootEntity.FileOffset;
+            ResultIndex = fromRootEntity.ResultIndex;
         }
 
 

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -52,6 +52,8 @@ namespace PSXPrev.Common
             IsVRAMPage = fromTexture.IsVRAMPage;
             TextureName = fromTexture.TextureName;
             FormatName = fromTexture.FormatName;
+            FileOffset = fromTexture.FileOffset;
+            ResultIndex = fromTexture.ResultIndex;
             try
             {
                 // Preserve format only needs to do something special if we're paletted

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -47,7 +47,6 @@ namespace PSXPrev.Forms
                 }
             }
         }
-        public AnimationBatch AnimationBatch { get; private set; }
 
         public ExportModelOptions Options { get; private set; }
 
@@ -161,7 +160,7 @@ namespace PSXPrev.Forms
                 RedrawTextures = optionRedrawTexturesCheckBox.Checked,
                 SingleTexture = texturesSingleRadioButton.Checked,
 
-                MergeEntities = optionMergeModelsCheckBox.Checked,
+                ModelGrouping = optionMergeModelsCheckBox.Checked ? ExportModelGrouping.GroupAllModels : ExportModelGrouping.Default,
                 AttachLimbs = optionAttachLimbsCheckBox.Checked,
                 ExperimentalOBJVertexColor = optionExperimentalVertexColorCheckBox.Checked,
 
@@ -225,7 +224,7 @@ namespace PSXPrev.Forms
             optionRedrawTexturesCheckBox.Checked = options.RedrawTextures;
 
             // Update Options check boxes
-            optionMergeModelsCheckBox.Checked = options.MergeEntities;
+            optionMergeModelsCheckBox.Checked = (options.ModelGrouping == ExportModelGrouping.GroupAllModels);
             optionAttachLimbsCheckBox.Checked = options.AttachLimbs;
             optionExperimentalVertexColorCheckBox.Checked = options.ExperimentalOBJVertexColor;
 
@@ -258,7 +257,7 @@ namespace PSXPrev.Forms
         }
 
 
-        public static void Export(ExportModelOptions options, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
+        public static void Export(ExportModelOptions options, RootEntity[] entities, Animation[] animations = null)
         {
             switch (options.Format)
             {
@@ -272,7 +271,7 @@ namespace PSXPrev.Forms
                     break;
                 case ExportModelOptions.GLTF2:
                     var glTF2Exporter = new glTF2Exporter();
-                    glTF2Exporter.Export(options, entities, animations, animationBatch);
+                    glTF2Exporter.Export(options, entities, animations);
                     break;
                 case ExportModelOptions.DAE:
                     var daeExporter = new DAEExporter();
@@ -281,13 +280,12 @@ namespace PSXPrev.Forms
             }
         }
 
-        public static ExportModelOptions Show(IWin32Window owner, RootEntity[] entities, Animation[] animations = null, AnimationBatch animationBatch = null)
+        public static ExportModelOptions Show(IWin32Window owner, RootEntity[] entities, Animation[] animations = null)
         {
             using (var form = new ExportModelsForm())
             {
                 form.Entities = entities;
                 form.Animations = animations;
-                form.AnimationBatch = animationBatch;
                 if (form.ShowDialog(owner) == DialogResult.OK)
                 {
                     return form.Options;

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -2331,10 +2331,10 @@ namespace PSXPrev.Forms
             EnterDialog();
             try
             {
-                var options = ExportModelsForm.Show(this, entities, animations, _animationBatch);
+                var options = ExportModelsForm.Show(this, entities, animations);
                 if (options != null)
                 {
-                    ExportModelsForm.Export(options, entities, animations, _animationBatch);
+                    ExportModelsForm.Export(options, entities, animations);
                     ShowMessageBox($"{entities.Length} models exported", "PSXPrev", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }


### PR DESCRIPTION
* Exported HMD animations now have correct coordinate handling, so interpolation will work as expected.
* glTF2 and DAE exporters now support entity merging (even with animations).
* Although not available in the UI yet, support for splitting up exported models by TMDID has been added.
* Basic fixes for exporting models that use packed textures. The textures will look correct, but auto packing is not available yet.