### PR TITLE
PSI skinned actor and animation support

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -14,6 +14,7 @@ namespace PSXPrev.Common.Animator
         MatrixDiff,
         AxisDiff,
         HMD, // Multiple methods of interpolation that can change between frames.
+        PSI,
     }
 
     public static class AnimationTypeExtensions
@@ -23,6 +24,7 @@ namespace PSXPrev.Common.Animator
             switch (animationType)
             {
                 case AnimationType.HMD:
+                case AnimationType.PSI:
                     return true;
 
                 default:

--- a/Common/Animator/AnimationFrame.cs
+++ b/Common/Animator/AnimationFrame.cs
@@ -23,6 +23,9 @@ namespace PSXPrev.Common.Animator
         public Quaternion? Rotation { get; set; }
 
         [Browsable(false)]
+        public Quaternion? FinalRotation { get; set; }
+
+        [Browsable(false)]
         public Vector3? EulerRotation { get; set; }
         // HMD: 
         [Browsable(false)]

--- a/Common/Parsers/BFFParser.cs
+++ b/Common/Parsers/BFFParser.cs
@@ -29,8 +29,8 @@ namespace PSXPrev.Common.Parsers
         private readonly HashSet<uint> _usedModelHashes = new HashSet<uint>();
         private readonly List<long> _postProcessPositions = new List<long>();
 
-        public BFFParser(EntityAddedAction entityAdded)
-            : base(entityAdded: entityAdded)
+        public BFFParser(EntityAddedAction entityAdded, AnimationAddedAction animationAdded)
+            : base(entityAdded: entityAdded, animationAdded: animationAdded)
         {
         }
 

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -1195,8 +1195,6 @@ namespace PSXPrev.Common.Parsers
             animation.FPS = 1f;
             animation.AssignObjects(animationObjects, true, false);
             return animation;
-
-            return null;
         }
 
         private Animation ProcessMIMeVertexNormalData(Dictionary<RenderInfo, List<Triangle>> groupedTriangles, BinaryReader reader, uint driver, uint primitiveType, uint primitiveHeaderPointer, uint dataCount, bool normal, bool reset, uint blockCount)

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -16,8 +16,8 @@
         public static ulong MaxBFFTextureHashes = 10000;
         public static ulong MaxBFFModels = 1000;
         public static ulong MaxBFFEntries = 10000;
-        public static ulong MaxBFFKeys = 1000;
-        public static ulong MaxBFFAnimations = 1000;
+        public static ulong MaxBFFKeys = 1024;
+        public static ulong MaxBFFAnimations = 2048;
 
         public static ulong MaxHMDBlockCount = 1024;
         public static ulong MaxHMDCoordCount = 1024; // Same as BlockCount, because they're related

--- a/Common/Renderer/LineMeshBuilder.cs
+++ b/Common/Renderer/LineMeshBuilder.cs
@@ -305,7 +305,6 @@ namespace PSXPrev.Common.Renderer
             var vertexLast = center + direction * radius;
 
             Matrix4 matrixValue;
-            Matrix4 invMatrixValue;
             if (matrix.HasValue)
             {
                 matrixValue = matrix.Value;
@@ -315,7 +314,6 @@ namespace PSXPrev.Common.Renderer
             else
             {
                 matrixValue = new Matrix4();
-                invMatrixValue = new Matrix4();
             }
 
             for (var i = 1; i <= sides; i++)

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -463,7 +463,6 @@ namespace PSXPrev.Common
 
         public static bool CheckPalettesForStp(ushort[][] palettes)
         {
-            var found = false;
             var palettesCount = palettes.Length;
             var paletteSize = palettes[0].Length;
             for (var p = 0; p < palettesCount; p++)

--- a/Common/TexturePalette.cs
+++ b/Common/TexturePalette.cs
@@ -40,7 +40,7 @@ namespace PSXPrev.Common
             r = (byte)(((color      ) & 0x1f) << 3);
             g = (byte)(((color >>  5) & 0x1f) << 3);
             b = (byte)(((color >> 10) & 0x1f) << 3);
-            stp = (color & 0x8000) != 0; // Semi-transparency: 0-Off, 1-On
+            stp = (color & 0x8000u) != 0; // Semi-transparency: 0-Off, 1-On
         }
 
         public static void ToComponents8(ushort color, out byte r, out byte g, out byte b, out bool stp)
@@ -48,7 +48,7 @@ namespace PSXPrev.Common
             r = (byte)((color      ) & 0x1f);
             g = (byte)((color >>  5) & 0x1f);
             b = (byte)((color >> 10) & 0x1f);
-            stp = (color & 0x8000) != 0; // Semi-transparency: 0-Off, 1-On
+            stp = (color & 0x8000u) != 0; // Semi-transparency: 0-Off, 1-On
         }
 
         public static ushort FromComponents(int r, int g, int b, bool stp = false)
@@ -57,7 +57,7 @@ namespace PSXPrev.Common
             color  = (ushort)((((uint)r >> 3) & 0x1f)      );
             color |= (ushort)((((uint)g >> 3) & 0x1f) <<  5);
             color |= (ushort)((((uint)b >> 3) & 0x1f) << 10);
-            color |= (ushort)(stp ? 0x8000 : 0);
+            color |= (ushort)(stp ? 0x8000u : 0);
             return color;
         }
 
@@ -67,18 +67,18 @@ namespace PSXPrev.Common
             color  = (ushort)(((uint)r & 0x1f)      );
             color |= (ushort)(((uint)g & 0x1f) <<  5);
             color |= (ushort)(((uint)b & 0x1f) << 10);
-            color |= (ushort)(stp ? 0x8000 : 0);
+            color |= (ushort)(stp ? 0x8000u : 0);
             return color;
         }
 
         public static bool GetStp(ushort color)
         {
-            return (color & 0x8000) != 0;
+            return (color & 0x8000u) != 0;
         }
 
         public static ushort SetStp(ushort color, bool stp)
         {
-            return (ushort)((color & ~0x8000u) | (stp ? 0x8000 : 0));
+            return (ushort)((color & ~0x8000u) | (stp ? 0x8000u : 0u));
         }
 
         public static void SetStp(ref ushort color, bool stp)
@@ -88,7 +88,7 @@ namespace PSXPrev.Common
 
         public static ushort ToggleStp(ushort color)
         {
-            return (ushort)(color ^ 0x8000);
+            return (ushort)(color ^ 0x8000u);
         }
 
         public static void ToggleStp(ref ushort color)
@@ -120,7 +120,7 @@ namespace PSXPrev.Common
             {
                 return true;
             }
-            else if (!ignoreStp && ((color ^ colorOther) & 0x8000) != 0)
+            else if (!ignoreStp && ((color ^ colorOther) & 0x8000u) != 0)
             {
                 return false;
             }
@@ -137,7 +137,7 @@ namespace PSXPrev.Common
             {
                 return true;
             }
-            else if (!ignoreStp && ((color ^ colorOther) & 0x8000) != 0)
+            else if (!ignoreStp && ((color ^ colorOther) & 0x8000u) != 0)
             {
                 return false;
             }
@@ -159,7 +159,7 @@ namespace PSXPrev.Common
         {
             // If we're not ignoring stp, then check to make sure both stps aren't in the range,
             // If they're not, then compare stp ahead of time.
-            if (!ignoreStp && ((colorMin ^ colorMax) & 0x8000) == 0 && ((color ^ colorMin) & 0x8000) != 0)
+            if (!ignoreStp && ((colorMin ^ colorMax) & 0x8000u) == 0 && ((color ^ colorMin) & 0x8000u) != 0)
             {
                 return false;
             }

--- a/Forms/ScannerForm.cs
+++ b/Forms/ScannerForm.cs
@@ -626,7 +626,7 @@ namespace PSXPrev.Forms
         }
 
 
-        public static ScanOptions Show(IWin32Window owner)
+        public static new ScanOptions Show(IWin32Window owner)
         {
             using (var form = new ScannerForm())
             {

--- a/Program.cs
+++ b/Program.cs
@@ -353,7 +353,6 @@ namespace PSXPrev
                 case "-databin":
                     options.ReadBINSectorData = true;
                     break;
-                    break;
                 case "-binsector":
                     parameterCount++;
                     if (index + 1 < args.Length)
@@ -1012,7 +1011,7 @@ namespace PSXPrev
             }
             if (_options.CheckAll || _options.CheckBFF)
             {
-                parsers.Add(() => new BFFParser(AddEntity));
+                parsers.Add(() => new BFFParser(AddEntity, AddAnimation));
             }
             if (_options.CheckAll || _options.CheckHMD)
             {
@@ -1025,7 +1024,7 @@ namespace PSXPrev
             if (_options.CheckAll || _options.CheckBFF)
             {
                 // For now we're sharing the BFF option, since the same inner format can appear in both (and its the same devs)
-                parsers.Add(() => new PILParser(AddEntity));
+                parsers.Add(() => new PILParser(AddEntity, AddAnimation));
             }
             if (_options.CheckAll || _options.CheckPMD)
             {


### PR DESCRIPTION
* PSI skinned actors now look correct.
* PSI animations are now read alongside PSI models.
* Fixed FPS display to show framerate of renderer painting, and not framerate of timers (which was useless). The FPS counter is now hidden when in a tab that doesn't show the renderer.
* Cleaned up some Release build warnings.