### PR TITLE
glTF2 skin support and PSI parser fixes

### DIFF
--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -188,6 +188,10 @@ namespace PSXPrev.Common
                 for (var i = 0; i < value.Length; i++)
                 {
                     value[i].EntityName = "Sub-Model " + i;
+                    if (value[i] is ModelEntity model && !string.IsNullOrEmpty(model.MeshName))
+                    {
+                        model.EntityName += " " + model.MeshName;
+                    }
                     value[i].ParentEntity = this;
                 }
                 _childEntities = value;
@@ -298,7 +302,7 @@ namespace PSXPrev.Common
             return $"{name} Children={ChildCount}";
         }
 
-        public virtual void FixConnections()
+        public virtual void FixConnections(bool transform = true)
         {
             if (ChildEntities == null)
             {
@@ -306,7 +310,7 @@ namespace PSXPrev.Common
             }
             foreach (var child in ChildEntities)
             {
-                child.FixConnections();
+                child.FixConnections(transform);
             }
         }
 

--- a/Common/Exporters/glTF2Exporter.Schema.cs
+++ b/Common/Exporters/glTF2Exporter.Schema.cs
@@ -224,6 +224,8 @@ namespace PSXPrev.Common.Exporters.glTF2Schema
         public int? NORMAL;
         public int? COLOR_0;
         public int? TEXCOORD_0;
+        public int? JOINTS_0;
+        public int? WEIGHTS_0;
     }
 
     internal enum mesh_primitive_mode

--- a/Common/Parsers/PILParser.cs
+++ b/Common/Parsers/PILParser.cs
@@ -407,7 +407,17 @@ namespace PSXPrev.Common.Parsers
                 ReadPrimitives(reader, skinned, d2m, GPU_COM_TG4, gt4Top, gt4Count);
                 ReadPrimitives(reader, skinned, d2m, GPU_COM_TF4SPR, sprTop, sprCount);
 
-                FlushModels(skinned, 0, null, null);
+                // Do what HMD does, and assign identity transform to attached limbs
+                //FlushModels(skinned, (uint)_psiMeshes.Count, null, null);
+                //FlushModels(skinned, 0, null, null);
+
+                for (uint i = 0; i < _psiMeshes.Count; i++)
+                {
+                    var psiMesh = _psiMeshes[(int)i];
+                    var coord = coords[i];
+
+                    FlushModels(skinned, i, psiMesh, coord);
+                }
             }
 
             // We may have a non-zero model count, but a zero triangle count. Check to make sure.
@@ -503,11 +513,11 @@ namespace PSXPrev.Common.Parsers
             // A non-zero value has never been observed, so for now this isn't handled.
             var scale = reader.ReadInt32();
 
-#if DEBUG
+//#if DEBUG
             var meshName = ReadCString(reader, 16);
-#else
-            //reader.BaseStream.Seek(16, SeekOrigin.Current);
-#endif
+//#else
+//            reader.BaseStream.Seek(16, SeekOrigin.Current);
+//#endif
 
             var childTop = reader.ReadUInt32();
             var nextTop  = reader.ReadUInt32();
@@ -676,9 +686,9 @@ namespace PSXPrev.Common.Parsers
                 //NormalCount = meshNormalCount,
                 AttachableVertices = attachableVertices,
                 AttachableNormals  = attachableNormals,
-#if DEBUG
+//#if DEBUG
                 MeshName = meshName,
-#endif
+//#endif
                 ScaleValue = scaleValue, // Not sure if this is used or not...
                 Center = center, // Seems to not be used for translation...
                 ScaleKeys = scaleKeys,
@@ -1303,8 +1313,8 @@ namespace PSXPrev.Common.Parsers
         {
             var localMatrix = coord?.WorldMatrix ?? Matrix4.Identity;
 
-            var attachableVertices = psiMesh.AttachableVertices;
-            var attachableNormals  = psiMesh.AttachableNormals;
+            var attachableVertices = psiMesh?.AttachableVertices;
+            var attachableNormals  = psiMesh?.AttachableNormals;
 
 #if DEBUG
             var debugData = psiMesh != null ? new[] { $"meshName: \"{psiMesh.MeshName}\"" } : null;
@@ -1321,6 +1331,7 @@ namespace PSXPrev.Common.Parsers
                     RenderFlags = renderInfo.RenderFlags,
                     MixtureRate = renderInfo.MixtureRate,
                     TMDID = modelIndex + 1u,
+                    MeshName = psiMesh?.MeshName,
                     OriginalLocalMatrix = localMatrix,
 #if DEBUG
                     DebugData = debugData,
@@ -1353,6 +1364,7 @@ namespace PSXPrev.Common.Parsers
                     MixtureRate = renderInfo.MixtureRate,
                     SpriteCenter = spriteCenter,
                     TMDID = modelIndex + 1u,
+                    MeshName = psiMesh?.MeshName,
                     OriginalLocalMatrix = localMatrix,
 #if DEBUG
                     DebugData = debugData,
@@ -1367,6 +1379,7 @@ namespace PSXPrev.Common.Parsers
                     Triangles = new Triangle[0],
                     TexturePage = 0,
                     TMDID = modelIndex + 1u,
+                    MeshName = psiMesh?.MeshName,
                     OriginalLocalMatrix = localMatrix,
                     AttachableVertices = attachableVertices,
                     AttachableNormals  = attachableNormals,
@@ -1644,7 +1657,7 @@ namespace PSXPrev.Common.Parsers
             {
                 animation.AnimationType = AnimationType.PSI;
                 // Action Man works better with 60f, but Frogger 2 and Chicken Run work better with 30f or lower.
-                animation.FPS = 30f;
+                animation.FPS = Settings.Instance.AdvancedBFFFrameRate;
                 animation.FormatName = "PSI";
                 animation.AssignObjects(animationObjects, true, false);
                 _animations.Add(animation);
@@ -1666,9 +1679,9 @@ namespace PSXPrev.Common.Parsers
             //public uint VertexCount;
             //public uint NormalStart;
             //public uint NormalCount;
-#if DEBUG
+//#if DEBUG
             public string MeshName;
-#endif
+//#endif
             public float ScaleValue;
             public Vector3 Center;
 

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -1012,7 +1012,7 @@ namespace PSXPrev.Common.Parsers
                             TextureLookup = CreateTextureLookup(renderInfo),
                             RenderFlags = renderInfo.RenderFlags,
                             MixtureRate = renderInfo.MixtureRate,
-                            TMDID = modelIndex + 1u,
+                            TMDID = i + 1u,
                             OriginalLocalMatrix = localMatrix,
 #if DEBUG
                             DebugData = modelDebugData?.ToArray(),
@@ -1034,7 +1034,7 @@ namespace PSXPrev.Common.Parsers
                             RenderFlags = renderInfo.RenderFlags,
                             MixtureRate = renderInfo.MixtureRate,
                             SpriteCenter = spriteCenter,
-                            TMDID = modelIndex + 1u,
+                            TMDID = i + 1u,
                             OriginalLocalMatrix = localMatrix,
 #if DEBUG
                             DebugData = modelDebugData?.ToArray(),

--- a/Settings.cs
+++ b/Settings.cs
@@ -198,6 +198,10 @@ namespace PSXPrev
         public ConsoleColor LogExceptionPrefixColor { get; set; } = ConsoleColor.DarkGray;
 
 
+        // 30f for Frogger 2 and Chicken Run, 60f for Action Man 2.
+        [JsonProperty("advancedBFFFrameRate")]
+        public float AdvancedBFFFrameRate { get; set; } = 30f;
+
         [JsonProperty("advancedBFFSpriteScale")]
         public float AdvancedBFFSpriteScale { get; set; } = 2.5f;
 
@@ -409,6 +413,7 @@ namespace PSXPrev
             LogErrorColor           = ValidateEnum(LogErrorColor,           Defaults.LogErrorColor);
             LogExceptionPrefixColor = ValidateEnum(LogExceptionPrefixColor, Defaults.LogExceptionPrefixColor);
 
+            AdvancedBFFFrameRate    = ValidateMax(AdvancedBFFFrameRate,    Defaults.AdvancedBFFFrameRate,    0.000001f);
             AdvancedBFFSpriteScale  = ValidateMax(AdvancedBFFSpriteScale,  Defaults.AdvancedBFFSpriteScale,  0.000001f);
             AdvancedBFFScaleDivisor = ValidateMax(AdvancedBFFScaleDivisor, Defaults.AdvancedBFFScaleDivisor, 0.000001f);
             AdvancedMODScaleDivisor = ValidateMax(AdvancedMODScaleDivisor, Defaults.AdvancedMODScaleDivisor, 0.000001f);


### PR DESCRIPTION
* Fixed PSI failing to parse in release builds because of a commented out line.
* Fixed PSI\x01 models failing to load, and also failing to handle skinning.
* PSI sub-models now append their mesh name in the tree view.
* Fixed packed textures not being exported correctly when attach limbs was turned off.
* glTF2 now supports exporting skinned models with animation (using joints/skins).
* Fixed glTF2 error that could occur when exporting HMD models with shared vertices.
* Fixed attachable vertices not always exporting correctly if they were assigned to an empty model.
* PSX TMD IDs are now assigned based on the object ID and not the model index (which should be more correct, considering hierarchy uses object indices too). This means TMD IDs can be assigned out of order again. :/
* PSI default frame rate can now be changed in settings.json using "advancedBFFFrameRate". The default is 30, which works for Frogger 2 and Chicken Run. The other recommended value is 60, which works for Action Man 2.