### PR TITLE
Shader-time joints system

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -66,7 +66,7 @@ namespace PSXPrev.Common.Animator
     {
         private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
 
-        [DisplayName("Animation Name")]
+        [DisplayName("Name")]
         public string AnimationName { get; set; }
 
         [DisplayName("Format"), ReadOnly(true)]
@@ -102,7 +102,7 @@ namespace PSXPrev.Common.Animator
         [Browsable(false)]
         public AnimationObject RootAnimationObject { get; set; }
 
-        [DisplayName("Animation Type")]
+        [DisplayName("Animation Type"), ReadOnly(true)]
         public AnimationType AnimationType { get; set; }
 
         // The owner model that created this animation (if any).

--- a/Common/Animator/AnimationObject.cs
+++ b/Common/Animator/AnimationObject.cs
@@ -7,6 +7,9 @@ namespace PSXPrev.Common.Animator
     {
         [DisplayName("Frames")]
         public Dictionary<uint, AnimationFrame> AnimationFrames { get; set; }
+
+        [Browsable(false)]
+        public string ObjectName { get; set; }
         
         [Browsable(false)]
         public AnimationObject Parent { get; set; }

--- a/Common/Coordinate.cs
+++ b/Common/Coordinate.cs
@@ -12,8 +12,13 @@ namespace PSXPrev.Common
         private Matrix4 _originalLocalMatrix;
         private Vector3 _originalTranslation;
         private Vector3 _originalRotation;
-        
-        public Matrix4 LocalMatrix { get; set; }
+
+        private Matrix4 _localMatrix;
+        public Matrix4 LocalMatrix
+        {
+            get => _localMatrix;
+            set => _localMatrix = value;
+        }
         public Matrix4 OriginalLocalMatrix
         {
             get => _originalLocalMatrix;
@@ -51,13 +56,13 @@ namespace PSXPrev.Common
         {
             get
             {
-                var matrix = Matrix4.Identity;
-                var coord = this;
-                do
+                var matrix = _localMatrix;
+                var coord = Parent;
+                while (coord != null)
                 {
-                    matrix *= coord.LocalMatrix;
+                    Matrix4.Mult(ref matrix, ref coord._localMatrix, out matrix);
                     coord = coord.Parent;
-                } while (coord != null);
+                }
                 return matrix;
             }
         }

--- a/Common/Line.cs
+++ b/Common/Line.cs
@@ -31,7 +31,6 @@ namespace PSXPrev.Common
                 Normals = Triangle.EmptyNormals,
                 Uv = Triangle.EmptyUv,
                 Colors = new[] { Colors[0], Colors[1], Colors[1] },
-                AttachableIndices = Triangle.EmptyAttachableIndices,
             };
         }
     }

--- a/Common/Parsers/BFFParser.cs
+++ b/Common/Parsers/BFFParser.cs
@@ -532,7 +532,7 @@ namespace PSXPrev.Common.Parsers
             reader.BaseStream.Seek(_offset2 + vertsTop, SeekOrigin.Begin);
             if (_vertices == null || _vertices.Length < _vertexCount)
             {
-                Array.Resize(ref _vertices, (int)_vertexCount);
+                _vertices = new Vector3[_vertexCount];
             }
             for (var i = 0; i < _vertexCount; i++)
             {
@@ -554,7 +554,7 @@ namespace PSXPrev.Common.Parsers
             reader.BaseStream.Seek(_offset2 + textureHashesTop, SeekOrigin.Begin);
             if (_textureHashes == null || _textureHashes.Length < _textureHashCount)
             {
-                Array.Resize(ref _textureHashes, (int)_textureHashCount);
+                _textureHashes = new uint[_textureHashCount];
             }
             for (var i = 0; i < _textureHashCount; i++)
             {
@@ -864,7 +864,6 @@ namespace PSXPrev.Common.Parsers
                 Normals = Triangle.EmptyNormals,
                 Colors = new[] { color, color, color },
                 Uv = new[] { uv2, uv1, uv0 },
-                AttachableIndices = Triangle.EmptyAttachableIndices,
             };
             triangle1.TiledUv = new TiledUV(triangle1.Uv, 0f, 0f, 1f, 1f);
             triangle1.Uv = (Vector2[])triangle1.Uv.Clone();
@@ -877,7 +876,6 @@ namespace PSXPrev.Common.Parsers
                 Normals = Triangle.EmptyNormals,
                 Colors = new[] { color, color, color },
                 Uv = new[] { uv2, uv3, uv1 },
-                AttachableIndices = Triangle.EmptyAttachableIndices,
             };
             triangle2.TiledUv = new TiledUV(triangle2.Uv, 0f, 0f, 1f, 1f);
             triangle2.Uv = (Vector2[])triangle2.Uv.Clone();
@@ -970,7 +968,6 @@ namespace PSXPrev.Common.Parsers
                 Normals = Triangle.EmptyNormals,
                 Colors = new[] { color2, color1, color0 },
                 Uv = new[] { uv2, uv1, uv0 },
-                AttachableIndices = Triangle.EmptyAttachableIndices,
             };
             if (textured)
             {
@@ -1005,14 +1002,13 @@ namespace PSXPrev.Common.Parsers
                     _modelHashes.Add(nameCRC, models);
                 }
                 models.Add(model);
-                //_models.Add(model);
             }
             foreach (var kvp in _groupedSprites)
             {
                 var spriteCenter = kvp.Key.Item1;
                 var renderInfo = kvp.Key.Item2;
                 var triangles = kvp.Value;
-                var model = new ModelEntity
+                var spriteModel = new ModelEntity
                 {
                     Triangles = triangles.ToArray(),
                     TexturePage = 0,
@@ -1028,8 +1024,7 @@ namespace PSXPrev.Common.Parsers
                     models = new List<ModelEntity>();
                     _modelHashes.Add(nameCRC, models);
                 }
-                models.Add(model);
-                //_models.Add(model);
+                models.Add(spriteModel);
             }
             _groupedTriangles.Clear();
             _groupedSprites.Clear();

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -105,8 +105,8 @@ namespace PSXPrev.Common.Parsers
             }
             if (_vertices == null || _vertices.Length < vertexCount)
             {
-                Array.Resize(ref _vertices, (int)vertexCount);
-                Array.Resize(ref _normals,  (int)vertexCount);
+                _vertices = new Vector3[vertexCount];
+                _normals = new Vector3[vertexCount];
             }
             for (var j = 0; j < vertexCount; j++)
             {
@@ -256,7 +256,6 @@ namespace PSXPrev.Common.Parsers
                     Normals = new[] { normal0, normal1, normal2 },
                     Colors = new[] { color, color, color },
                     Uv = Triangle.EmptyUv, // Can't use UVs yet
-                    AttachableIndices = Triangle.EmptyAttachableIndices,
                 };
                 if (textured)
                 {
@@ -284,7 +283,6 @@ namespace PSXPrev.Common.Parsers
                         Normals = new[] { normal1, normal3, normal2 },
                         Colors = new[] { color, color, color },
                         Uv = Triangle.EmptyUv, // Can't use UVs yet
-                        AttachableIndices = Triangle.EmptyAttachableIndices,
                     };
                     if (textured)
                     {

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -183,10 +183,10 @@ namespace PSXPrev.Common.Parsers
             EndModel:
             if (models.Count > 0)
             {
-                var entity = new RootEntity();
-                entity.ChildEntities = models.ToArray();
-                entity.ComputeBounds();
-                return entity;
+                var rootEntity = new RootEntity();
+                rootEntity.ChildEntities = models.ToArray();
+                rootEntity.ComputeBounds();
+                return rootEntity;
             }
             return null;
         }
@@ -818,7 +818,6 @@ namespace PSXPrev.Common.Parsers
                 Normals = new[] { normal0, normal1, normal2 },
                 Colors = new[] { color0, color1, color2 },
                 Uv = new[] { uv0, uv1, uv2 },
-                AttachableIndices = Triangle.EmptyAttachableIndices,
             };
 
             return triangle;

--- a/Common/Renderer/Mesh.cs
+++ b/Common/Renderer/Mesh.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTK;
 using OpenTK.Graphics.OpenGL;
@@ -15,21 +14,22 @@ namespace PSXPrev.Common.Renderer
 
     public class Mesh : MeshRenderInfo, IDisposable
     {
-        private const int BufferCount = 5;
-
         private readonly uint _meshId;
-        private readonly uint[] _ids = new uint[BufferCount];
-
-        private uint _positionBuffer;
-        private uint _colorBuffer;
-        private uint _normalBuffer;
-        private uint _uvBuffer;
-        private uint _tiledAreaBuffer;
+        private readonly uint[] _bufferIds = new uint[Scene.JointsSupported ? 6 : 5];
+        private readonly uint _positionBufferId;
+        private readonly uint _colorBufferId;
+        private readonly uint _normalBufferId;
+        private readonly uint _uvBufferId;
+        private readonly uint _tiledAreaBufferId;
+        private readonly uint _jointBufferId;
 
         private MeshDataType _meshDataType;
-        private int _numElements; // Number of elements assigned during SetData
+        private int _elementCount; // Number of elements assigned during SetData
 
-        private int VerticesPerElement
+        public MeshDataType MeshDataType => _meshDataType;
+        public int VertexCount => _elementCount;
+        public int PrimitiveCount => _elementCount / VerticesPerElement;
+        public int VerticesPerElement
         {
             get
             {
@@ -47,58 +47,69 @@ namespace PSXPrev.Common.Renderer
         }
 
         public Matrix4 WorldMatrix { get; set; } = Matrix4.Identity;
-        public uint Texture { get; set; } // Texture assinged by TextureBinder
+        public uint TextureID { get; set; } // Texture ID assinged by TextureBinder
+        public Skin Skin { get; set; } // Skin used for joint matrices
 
         public Mesh(uint meshId)
         {
             _meshId = meshId;
-            GenBuffer();
+            GL.GenBuffers(_bufferIds.Length, _bufferIds);
+            _positionBufferId  = _bufferIds[0];
+            _colorBufferId     = _bufferIds[1];
+            _normalBufferId    = _bufferIds[2];
+            _uvBufferId        = _bufferIds[3];
+            _tiledAreaBufferId = _bufferIds[4];
+            _jointBufferId     = Scene.JointsSupported ? _bufferIds[5] : 0u;
         }
 
         public void Dispose()
         {
-            GL.DeleteBuffers(BufferCount, _ids);
+            GL.DeleteBuffers(_bufferIds.Length, _bufferIds);
         }
 
-        private void GenBuffer()
-        {
-            GL.GenBuffers(BufferCount, _ids);
-            _positionBuffer  = _ids[0];
-            _colorBuffer     = _ids[1];
-            _normalBuffer    = _ids[2];
-            _uvBuffer        = _ids[3];
-            _tiledAreaBuffer = _ids[4];
-        }
-
-        public void Draw(TextureBinder textureBinder = null, bool drawFaces = true, bool drawWireframe = false, bool drawVertices = false, float wireframeSize = 1f, float vertexSize = 1f)
+        public int Draw(TextureBinder textureBinder = null, bool drawFaces = true, bool drawWireframe = false, bool drawVertices = false, float wireframeSize = 1f, float vertexSize = 1f)
         {
             // Bind buffers
             GL.BindVertexArray(_meshId);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBufferId);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexPosition);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexPosition, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _normalBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _normalBufferId);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexNormal);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexNormal, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _colorBuffer);
+            // True argument normalizes normals
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _colorBufferId);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexColor);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexColor, 3, VertexAttribPointerType.Float, true, 0, IntPtr.Zero);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBufferId);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexUv);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexUv, 2, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, _tiledAreaBuffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _tiledAreaBufferId);
             GL.EnableVertexAttribArray((uint)Scene.AttributeIndexTiledArea);
             GL.VertexAttribPointer((uint)Scene.AttributeIndexTiledArea, 4, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
 
-            // Bind texture
-            if (textureBinder != null && Texture != 0)
+            if (Scene.JointsSupported)
             {
-                textureBinder.BindTexture(Texture);
+                GL.BindBuffer(BufferTarget.ArrayBuffer, _jointBufferId);
+                GL.EnableVertexAttribArray((uint)Scene.AttributeIndexJoint);
+                GL.VertexAttribIPointer((uint)Scene.AttributeIndexJoint, 2, VertexAttribIntegerType.UnsignedInt, 0, IntPtr.Zero);
+            }
+
+            // Bind joint matrices
+            if (Scene.JointsSupported && Skin != null)
+            {
+                Skin.Bind();
+            }
+
+            // Bind texture
+            if (textureBinder != null && TextureID != 0)
+            {
+                textureBinder.BindTexture(TextureID);
             }
 
             // Setup point size and/or line width
@@ -119,6 +130,8 @@ namespace PSXPrev.Common.Renderer
                 GL.LineWidth(drawWireframe ? wireframeSize : Thickness);
             }
 
+            var drawCalls = 0;
+
             // Draw geometry
             switch (_meshDataType)
             {
@@ -126,18 +139,21 @@ namespace PSXPrev.Common.Renderer
                     if (drawFaces)
                     {
                         GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
-                        GL.DrawArrays(PrimitiveType.Triangles, 0, _numElements);
+                        GL.DrawArrays(PrimitiveType.Triangles, 0, _elementCount);
+                        drawCalls++;
                     }
                     if (drawWireframe)
                     {
                         GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Line);
-                        GL.DrawArrays(PrimitiveType.Triangles, 0, _numElements);
+                        GL.DrawArrays(PrimitiveType.Triangles, 0, _elementCount);
+                        drawCalls++;
                         GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
                     }
                     if (drawVertices)
                     {
                         //GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Point);
-                        //GL.DrawArrays(PrimitiveType.Triangles, 0, _numElements);
+                        //GL.DrawArrays(PrimitiveType.Triangles, 0, _elementCount);
+                        //drawCalls++;
                         //GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
                         goto case MeshDataType.Point;
                     }
@@ -146,12 +162,14 @@ namespace PSXPrev.Common.Renderer
                 case MeshDataType.Line:
                     if (drawFaces || drawWireframe)
                     {
-                        GL.DrawArrays(PrimitiveType.Lines, 0, _numElements);
+                        GL.DrawArrays(PrimitiveType.Lines, 0, _elementCount);
+                        drawCalls++;
                     }
                     if (drawVertices)
                     {
                         //GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Point);
-                        //GL.DrawArrays(PrimitiveType.Lines, 0, _numElements);
+                        //GL.DrawArrays(PrimitiveType.Lines, 0, _elementCount);
+                        //drawCalls++;
                         //GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode.Fill);
                         goto case MeshDataType.Point;
                     }
@@ -160,7 +178,8 @@ namespace PSXPrev.Common.Renderer
                 case MeshDataType.Point:
                     if (drawFaces || drawWireframe || drawVertices)
                     {
-                        GL.DrawArrays(PrimitiveType.Points, 0, _numElements);
+                        GL.DrawArrays(PrimitiveType.Points, 0, _elementCount);
+                        drawCalls++;
                     }
                     break;
             }
@@ -176,45 +195,102 @@ namespace PSXPrev.Common.Renderer
             }
 
             // Unbind texture
-            if (textureBinder != null && Texture != 0)
+            if (textureBinder != null && TextureID != 0)
             {
                 textureBinder.Unbind();
+            }
+
+            // Unbind joint matrices
+            if (Scene.JointsSupported && Skin != null)
+            {
+                Skin.Unbind();
             }
 
             // Unbind buffers
             GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
             GL.BindVertexArray(0);
+
+            return drawCalls;
         }
 
-        public void SetData(MeshDataType meshType, int numElements, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList = null)
+        public void SetData(MeshDataType meshDataType, int elementCount, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList, uint[] jointList)
         {
-            _meshDataType = meshType;
-            _numElements = numElements;
+            _meshDataType = meshDataType;
+            _elementCount = elementCount;
 
-            BufferData(_positionBuffer,  positionList,  3);
-            BufferData(_normalBuffer,    normalList,    3);
-            BufferData(_colorBuffer,     colorList,     3);
-            BufferData(_uvBuffer,        uvList,        2);
-            BufferData(_tiledAreaBuffer, tiledAreaList, 4);
+            BufferData(_positionBufferId,  positionList,  3); // Vector3
+            BufferData(_normalBufferId,    normalList,    3); // Vector3
+            BufferData(_colorBufferId,     colorList,     3); // Vector3 (Color)
+            BufferData(_uvBufferId,        uvList,        2); // Vector2
+            BufferData(_tiledAreaBufferId, tiledAreaList, 4); // Vector4
+            if (Scene.JointsSupported)
+            {
+                BufferData(_jointBufferId,     jointList,     2); // uint[2]
+            }
         }
 
         // Passing null for list will fill the data with zeros.
-        private void BufferData(uint buffer, float[] list, int elementSize)
+        private void BufferData<T>(uint bufferId, T[] list, int elementSize) where T : struct
         {
-            var length = _numElements * elementSize;
+            var length = _elementCount * elementSize;
             if (list == null)
             {
-                list = new float[length]; // Treat null as zeroed data.
+                list = new T[length]; // Treat null as zeroed data.
             }
             else
             {
-                //Debug.Assert(list.Length >= length, "BufferData cannot use list that's smaller than expected length");
+                Trace.Assert(list.Length >= length, "BufferData cannot use list that's smaller than expected length");
             }
-            var size = (IntPtr)(length * sizeof(float));
+            var size = (IntPtr)(length * 4);// sizeof(T));
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, buffer);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, bufferId);
             GL.BufferData(BufferTarget.ArrayBuffer, size, list, BufferUsageHint.StaticDraw);
             GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        }
+
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector2(float[] data, int baseIndex, ref Vector2 vector)
+        {
+            var index = baseIndex * 2;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector3(float[] data, int baseIndex, ref Vector3 vector)
+        {
+            var index = baseIndex * 3;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+            data[index++] = vector.Z;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector4(float[] data, int baseIndex, ref Vector4 vector)
+        {
+            var index = baseIndex * 4;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+            data[index++] = vector.Z;
+            data[index++] = vector.W;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignColor(float[] data, int baseIndex, Color color)
+        {
+            var index = baseIndex * 3;
+            data[index++] = color.R;
+            data[index++] = color.G;
+            data[index++] = color.B;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignJoint(uint[] data, int baseIndex, uint? vertexJoint, uint? normalJoint)
+        {
+            var index = baseIndex * 2;
+            data[index++] = (vertexJoint ?? Triangle.NoJoint) + 1u;
+            data[index++] = (normalJoint ?? Triangle.NoJoint) + 1u;
         }
     }
 }

--- a/Common/Renderer/Skin.cs
+++ b/Common/Renderer/Skin.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Diagnostics;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
+
+namespace PSXPrev.Common.Renderer
+{
+    // Represents a list of joint matrices that allow vertices to attach to other models
+    public class Skin : IDisposable
+    {
+        private readonly uint _jointMatrixBufferId;
+        private int _elementCount; // Number of elements assigned during SetData
+
+        public int JointCount => _elementCount;
+
+        public Skin()
+        {
+            _jointMatrixBufferId = (uint)GL.GenBuffer();
+        }
+
+        public void Dispose()
+        {
+            GL.DeleteBuffer(_jointMatrixBufferId);
+        }
+
+        public void SetData(int elementCount, float[] jointMatrixList)
+        {
+            _elementCount = elementCount;
+
+            BufferData(_jointMatrixBufferId, jointMatrixList, 32); // Matrix4[2]
+        }
+
+        // Passing null for list will fill the data with zeros.
+        private void BufferData<T>(uint bufferId, T[] list, int elementSize) where T : struct
+        {
+            var length = _elementCount * elementSize;
+            if (list == null)
+            {
+                list = new T[length]; // Treat null as zeroed data.
+            }
+            else
+            {
+                Trace.Assert(list.Length >= length, "BufferData cannot use list that's smaller than expected length");
+            }
+            var size = (IntPtr)(length * 4);// sizeof(float));
+
+            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, bufferId);
+            GL.BufferData(BufferTarget.ShaderStorageBuffer, size, list, BufferUsageHint.DynamicDraw); //.StaticDraw);
+            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, 0);
+        }
+
+        public void Bind()
+        {
+            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, _jointMatrixBufferId);
+            GL.BindBufferBase(BufferTarget.ShaderStorageBuffer, (uint)Scene.BufferIndexJoints, _jointMatrixBufferId);
+        }
+
+        public void Unbind()
+        {
+            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, 0);
+            // todo: Is this necessary?
+            GL.BindBufferBase(BufferTarget.ShaderStorageBuffer, (uint)Scene.BufferIndexJoints, 0);
+        }
+
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignModelMatrix(float[] data, int baseIndex, ref Matrix4 matrix)
+        {
+            var index = baseIndex * 32 + 0;
+            data[index++] = matrix.Row0.X;
+            data[index++] = matrix.Row0.Y;
+            data[index++] = matrix.Row0.Z;
+            data[index++] = matrix.Row0.W;
+
+            data[index++] = matrix.Row1.X;
+            data[index++] = matrix.Row1.Y;
+            data[index++] = matrix.Row1.Z;
+            data[index++] = matrix.Row1.W;
+
+            data[index++] = matrix.Row2.X;
+            data[index++] = matrix.Row2.Y;
+            data[index++] = matrix.Row2.Z;
+            data[index++] = matrix.Row2.W;
+
+            data[index++] = matrix.Row3.X;
+            data[index++] = matrix.Row3.Y;
+            data[index++] = matrix.Row3.Z;
+            data[index++] = matrix.Row3.W;
+        }
+
+        // This function handles transposing the normal matrix.
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignNormalMatrix(float[] data, int baseIndex, ref Matrix3 matrix)
+        {
+            var index = baseIndex * 32 + 16;
+            /*data[index++] = matrix.Row0.X;
+            data[index++] = matrix.Row0.Y;
+            data[index++] = matrix.Row0.Z;
+            index++;
+
+            data[index++] = matrix.Row1.X;
+            data[index++] = matrix.Row1.Y;
+            data[index++] = matrix.Row1.Z;
+            index++;
+
+            data[index++] = matrix.Row2.X;
+            data[index++] = matrix.Row2.Y;
+            data[index++] = matrix.Row2.Z;*/
+
+            // Transpose here, since it's cheaper
+            data[index++] = matrix.Row0.X;
+            data[index++] = matrix.Row1.X;
+            data[index++] = matrix.Row2.X;
+            index++;
+
+            data[index++] = matrix.Row0.Y;
+            data[index++] = matrix.Row1.Y;
+            data[index++] = matrix.Row2.Y;
+            index++;
+
+            data[index++] = matrix.Row0.Z;
+            data[index++] = matrix.Row1.Z;
+            data[index++] = matrix.Row2.Z;
+        }
+    }
+}

--- a/Common/Renderer/TextureBinder.cs
+++ b/Common/Renderer/TextureBinder.cs
@@ -6,26 +6,26 @@ namespace PSXPrev.Common.Renderer
 {
     public class TextureBinder : IDisposable
     {
-        private readonly uint[] _textures = new uint[VRAM.PageCount];
+        private readonly uint[] _textureIds = new uint[VRAM.PageCount];
 
         public TextureBinder()
         {
-            GL.GenTextures(VRAM.PageCount, _textures);
+            GL.GenTextures(VRAM.PageCount, _textureIds);
         }
 
         public void Dispose()
         {
-            GL.DeleteTextures(VRAM.PageCount, _textures);
+            GL.DeleteTextures(VRAM.PageCount, _textureIds);
         }
 
-        public uint GetTexture(int index)
+        public uint GetTextureID(int index)
         {
-            return _textures[index];
+            return _textureIds[index];
         }
 
         public uint UpdateTexture(Bitmap bitmap, int index)
         {
-            var texture = _textures[index];
+            var texture = _textureIds[index];
             GL.BindTexture(TextureTarget.Texture2D, texture);
 
             var bitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), System.Drawing.Imaging.ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
@@ -39,11 +39,11 @@ namespace PSXPrev.Common.Renderer
             return texture;
         }
 
-        public void BindTexture(uint texture)
+        public void BindTexture(uint textureId)
         {
             GL.ActiveTexture(TextureUnit.Texture0);
-            GL.BindTexture(TextureTarget.Texture2D, texture);
-            GL.Uniform1(Scene.AttributeIndexTexture, texture);
+            GL.BindTexture(TextureTarget.Texture2D, textureId);
+            GL.Uniform1(Scene.AttributeIndexTexture, textureId);
         }
 
         public void Unbind()

--- a/Common/Renderer/TriangleMeshBuilder.cs
+++ b/Common/Renderer/TriangleMeshBuilder.cs
@@ -42,6 +42,8 @@ namespace PSXPrev.Common.Renderer
 
         public List<Triangle> Triangles { get; }
 
+        public Matrix4[] JointMatrices { get; set; }
+
         public int Count => Triangles.Count;
 
         public int Capacity

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -16,6 +16,97 @@ namespace PSXPrev.Common
         [Browsable(false)]
         public Coordinate[] Coords { get; set; }
 
+        [Browsable(false)]
+        public ModelEntity[] Joints { get; set; }
+
+        // Gets world joint transform matrices
+        private Matrix4[] _jointMatrices;
+        [Browsable(false)]
+        public Matrix4[] JointMatrices
+        {
+            get
+            {
+                if (Joints != null)
+                {
+                    if (_jointMatrices == null)
+                    {
+                        _jointMatrices = new Matrix4[Joints.Length];
+                    }
+                    for (var i = 0; i < Joints.Length; i++)
+                    {
+                        _jointMatrices[i] = Joints[i]?.WorldMatrix ?? Matrix4.Identity;
+                    }
+                    return _jointMatrices;
+                }
+                return null;
+            }
+        }
+
+        // Gets animated world joint transform matrices, without the root entity's animated transform
+        private Matrix4[] _relativeAnimatedJointMatrices;
+        [Browsable(false)]
+        public Matrix4[] RelativeAnimatedJointMatrices
+        {
+            get
+            {
+                if (Joints != null)
+                {
+                    if (_relativeAnimatedJointMatrices == null)
+                    {
+                        _relativeAnimatedJointMatrices = new Matrix4[Joints.Length];
+                    }
+                    for (var i = 0; i < Joints.Length; i++)
+                    {
+                        _relativeAnimatedJointMatrices[i] = Joints[i]?.TempWorldMatrix ?? Matrix4.Identity;
+                    }
+                    return _relativeAnimatedJointMatrices;
+                }
+                return null;
+            }
+        }
+
+        // Gets animated world joint transform matrices, including the root entity's animated transform
+        private Matrix4[] _absoluteAnimatedJointMatrices;
+        [Browsable(false)]
+        public Matrix4[] AbsoluteAnimatedJointMatrices
+        {
+            get
+            {
+                if (Joints != null)
+                {
+                    if (_absoluteAnimatedJointMatrices == null)
+                    {
+                        _absoluteAnimatedJointMatrices = new Matrix4[Joints.Length];
+                    }
+                    var rootTempMatrix = TempMatrix;
+                    for (var i = 0; i < Joints.Length; i++)
+                    {
+                        var model = Joints[i];
+                        if (model == null)
+                        {
+                            _absoluteAnimatedJointMatrices[i] = TempWorldMatrix;
+                        }
+                        else
+                        {
+                            var modelTempWorldMatrix = model.TempWorldMatrix;
+                            Matrix4.Mult(ref rootTempMatrix, ref modelTempWorldMatrix, out _absoluteAnimatedJointMatrices[i]);
+                        }
+                    }
+                    return _absoluteAnimatedJointMatrices;
+                }
+                return null;
+            }
+        }
+
+        [Browsable(false)]
+        public Matrix4[] JointMatricesCache => _jointMatrices ?? JointMatrices;
+
+        [Browsable(false)]
+        public Matrix4[] RelativeAnimatedJointMatricesCache => _relativeAnimatedJointMatrices ?? RelativeAnimatedJointMatrices;
+
+        [Browsable(false)]
+        public Matrix4[] AbsoluteAnimatedJointMatricesCache => _absoluteAnimatedJointMatrices ?? AbsoluteAnimatedJointMatrices;
+
         [DisplayName("Format"), ReadOnly(true)]
         public string FormatName { get; set; }
 
@@ -67,14 +158,18 @@ namespace PSXPrev.Common
         }
 
 
-        public override void ComputeBounds()
+        public override void ComputeBounds(AttachJointsMode attachJointsMode = AttachJointsMode.Hide, Matrix4[] jointMatrices = null)
         {
-            base.ComputeBounds();
+            if (jointMatrices == null)
+            {
+                jointMatrices = JointMatrices;
+            }
+            base.ComputeBounds(attachJointsMode, jointMatrices);
             var bounds = new BoundingBox();
             foreach (var entity in ChildEntities)
             {
                 // Not yet, there are some issues with this, like models that are only made of attached vertices.
-                if (entity is ModelEntity model && (model.Triangles.Length == 0 || (model.AttachedOnly && !model.IsAttached)))
+                if (entity is ModelEntity model && (model.Triangles.Length == 0 || (model.AttachedOnly && attachJointsMode == AttachJointsMode.Hide)))
                 {
                     continue; // Don't count empty models in bounds, since they'll always be at (0, 0, 0).
                 }
@@ -85,6 +180,96 @@ namespace PSXPrev.Common
                 bounds.AddPoint(WorldMatrix.ExtractTranslation());
             }
             Bounds3D = bounds;
+        }
+
+        private static void PrepareTriangleJoints(Dictionary<uint, uint> jointMapping, uint[] joints, uint modelJointID, ref int attachedCount)
+        {
+            for (var j = 0; j < 3; j++)
+            {
+                var jointID = joints[j];
+                if (jointID != Triangle.NoJoint)
+                {
+                    if (jointID == modelJointID)
+                    {
+                        joints[j] = Triangle.NoJoint;
+                    }
+                    else
+                    {
+                        if (!jointMapping.TryGetValue(jointID, out var mappedJointID))
+                        {
+                            mappedJointID = (uint)jointMapping.Count;
+                            jointMapping.Add(jointID, mappedJointID);
+                        }
+                        joints[j] = mappedJointID;
+                        attachedCount++;
+                    }
+                }
+            }
+        }
+
+        // Must be called before ComputeBounds or FixConnections
+        public void PrepareJoints(bool hasJoints = true)
+        {
+            var jointMapping = new Dictionary<uint, uint>();
+            if (hasJoints)
+            {
+                foreach (ModelEntity model in ChildEntities)
+                {
+                    var attachedVertexCount = 0;
+                    var attachedNormalCount = 0;
+                    foreach (var triangle in model.Triangles)
+                    {
+                        if (triangle.VertexJoints != null)
+                        {
+                            PrepareTriangleJoints(jointMapping, triangle.VertexJoints, model.JointID, ref attachedVertexCount);
+                        }
+                        // Make sure the same array isn't being used for normal and vertex joints.
+                        // If it is being reused then it's already remapped, and attempting to remap it again would be bad.
+                        if (triangle.NormalJoints != null && triangle.NormalJoints != triangle.VertexJoints)
+                        {
+                            PrepareTriangleJoints(jointMapping, triangle.NormalJoints, model.JointID, ref attachedNormalCount);
+                        }
+                    }
+                    var vertexCount = model.Triangles.Length * 3;
+                    model.HasAttached = attachedVertexCount > 0 || attachedNormalCount > 0;
+                    model.AttachedOnly = vertexCount > 0 && attachedVertexCount == vertexCount;// && attachedNormalCount == vertexCount;
+                }
+            }
+
+            var joints = jointMapping.Count > 0 ? new ModelEntity[jointMapping.Count] : null;
+            foreach (ModelEntity model in ChildEntities)
+            {
+                if (jointMapping.TryGetValue(model.JointID, out var mappedJointID))
+                {
+                    jointMapping.Remove(model.JointID); // Remove from mapping so that models with the same joint ID are not used
+                    model.JointID = mappedJointID;
+                    joints[mappedJointID] = model;
+                }
+                else
+                {
+                    model.JointID = Triangle.NoJoint;
+                }
+            }
+#if DEBUG
+            if (jointMapping.Count > 0)
+            {
+                var breakHere = 0;
+            }
+#endif
+            Joints = joints;
+        }
+
+        public override void FixConnections(bool? bake = null, Matrix4[] tempJointMatrices = null)
+        {
+            if (!bake.HasValue)
+            {
+                bake = !Renderer.Scene.JointsSupported;
+            }
+            if (!bake.Value && tempJointMatrices == null)
+            {
+                tempJointMatrices = RelativeAnimatedJointMatrices;
+            }
+            base.FixConnections(bake, tempJointMatrices);
         }
 
         public List<ModelEntity> GetModelsWithTMDID(uint id)

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -106,7 +106,6 @@ namespace PSXPrev.Forms
                 }*/
                 texturesIndividualRadioButton.Enabled = _format != ExportModelOptions.PLY && _format != ExportModelOptions.DAE;
 
-                optionMergeModelsCheckBox.Enabled = _format != ExportModelOptions.GLTF2 && _format != ExportModelOptions.DAE;
                 optionExperimentalVertexColorCheckBox.Enabled = _format == ExportModelOptions.OBJ;
 
                 animationsGroupBox.Enabled = _format == ExportModelOptions.GLTF2;

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -1463,7 +1463,9 @@ namespace PSXPrev.Forms
             this.autoAttachLimbsToolStripMenuItem.Name = "autoAttachLimbsToolStripMenuItem";
             this.autoAttachLimbsToolStripMenuItem.Size = new System.Drawing.Size(225, 22);
             this.autoAttachLimbsToolStripMenuItem.Text = "Auto Attach Limbs";
+            this.autoAttachLimbsToolStripMenuItem.Click += new System.EventHandler(this.autoAttachLimbsToolStripMenuItem_Click);
             this.autoAttachLimbsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.autoAttachLimbsToolStripMenuItem_CheckedChanged);
+            this.autoAttachLimbsToolStripMenuItem.CheckStateChanged += new System.EventHandler(this.autoAttachLimbsToolStripMenuItem_CheckStateChanged);
             // 
             // toolStripSeparator14
             // 

--- a/Forms/TMDBindingsForm.Designer.cs
+++ b/Forms/TMDBindingsForm.Designer.cs
@@ -50,6 +50,7 @@
             this.bindingPropertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
             this.bindingPropertyGrid.Location = new System.Drawing.Point(0, 0);
             this.bindingPropertyGrid.Name = "bindingPropertyGrid";
+            this.bindingPropertyGrid.PropertySort = System.Windows.Forms.PropertySort.NoSort;
             this.bindingPropertyGrid.Size = new System.Drawing.Size(274, 351);
             this.bindingPropertyGrid.TabIndex = 0;
             this.bindingPropertyGrid.ToolbarVisible = false;
@@ -152,7 +153,6 @@
             this.Name = "TMDBindingsForm";
             this.Text = "TMD Bindings";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.TMDBindingForm_FormClosed);
-            this.Load += new System.EventHandler(this.TMDBindingForm_Load);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.splitContainer1.Panel1.ResumeLayout(false);

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Common\Renderer\Mesh.cs" />
     <Compile Include="Common\Renderer\MeshBatch.cs" />
     <Compile Include="Common\Renderer\MeshRenderInfo.cs" />
+    <Compile Include="Common\Renderer\Skin.cs" />
     <Compile Include="Common\Renderer\TriangleMeshBuilder.cs" />
     <Compile Include="Common\Renderer\Scene.cs" />
     <Compile Include="Common\Renderer\TextureBinder.cs" />

--- a/Shaders/Shader.frag
+++ b/Shaders/Shader.frag
@@ -6,7 +6,7 @@ in vec4 pass_Color;
 
 in float pass_NormalDotLight;
 in float pass_NormalLength;
-in float discardPixel;
+in float pass_DiscardPixel;
 
 out vec4 out_Color;
 
@@ -78,7 +78,7 @@ vec4 calcInvalidTexture(vec3 uv) {
 
 void main(void) {
 	// Process vertex shader discarding:
-	if (discardPixel > 0.0) {
+	if (pass_DiscardPixel > 0.0) {
 		discard;
 	}
 

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -1,9 +1,20 @@
-﻿#version 150
+﻿#version 430
+//FALLBACK_VERSION 150
+#define JOINTS_SUPPORTED
+
 in vec3 in_Position;
 in vec3 in_Color;
 in vec3 in_Normal;
 in vec2 in_Uv;
 in vec4 in_TiledArea;
+#ifdef JOINTS_SUPPORTED
+in uvec2 in_Joint;
+
+layout(std140, binding = 0) buffer jointBuffer
+{
+	mat4 joints[]; // vertex,normal joint pairs
+};
+#endif
 
 out vec2 pass_Uv;
 out vec4 pass_TiledArea;
@@ -11,16 +22,19 @@ out vec4 pass_Ambient;
 out vec4 pass_Color;
 out float pass_NormalDotLight;
 out float pass_NormalLength;
-out float discardPixel;
+out float pass_DiscardPixel;
 
 uniform mat3 normalMatrix;
 uniform mat4 modelMatrix;
 uniform mat4 mvpMatrix;
+uniform mat4 viewMatrix;
+uniform mat4 projectionMatrix;
 uniform vec3 lightDirection;
 uniform vec3 maskColor;
 uniform vec3 ambientColor;
 uniform vec3 solidColor;
 uniform vec2 uvOffset;
+uniform int jointMode;
 uniform int lightMode;
 uniform int colorMode;
 uniform int textureMode;
@@ -28,21 +42,52 @@ uniform int semiTransparentPass;
 uniform float lightIntensity;
 uniform sampler2D mainTex;
 
-const float discardValue = 100000000;
+const float DISCARD_VALUE = 100000000;
+const uint NO_JOINT = 0u;
 
 const int ColorMode_VertexColor = 0;
 const int ColorMode_SolidColor  = 1;
 
+const int JointMode_Enabled  = 0;
+const int JointMode_Disabled = 1;
+
+mat4 getModelMatrix() {
+	#ifdef JOINTS_SUPPORTED
+	if (jointMode == 0 && in_Joint.x != NO_JOINT) {
+		return joints[(in_Joint.x - 1) * 2];
+	}
+	#endif
+	return modelMatrix;
+}
+
+mat3 getNormalMatrix() {
+	#ifdef JOINTS_SUPPORTED
+	if (jointMode == 0 && in_Joint.y != NO_JOINT) {
+		return mat3(joints[(in_Joint.y - 1) * 2 + 1]);
+	}
+	#endif
+	return normalMatrix;
+}
+
 void main(void) {
-	// Check for discarded vertices (coordinates match discardValue):
-	discardPixel = step(discardValue, in_Position.x);
+	// Check for discarded vertices (coordinates match DISCARD_VALUE):
+	pass_DiscardPixel = step(DISCARD_VALUE, in_Position.x);
 
 	// Process position:
+	#ifdef JOINTS_SUPPORTED
+	mat4 jointModelMatrix = getModelMatrix();
+	vec4 worldPosition = jointModelMatrix * vec4(in_Position, 1.0);
+	vec4 cameraPosition = viewMatrix * worldPosition;
+	gl_Position = projectionMatrix * cameraPosition;
+	#else
+	// Skip combining matrices and just use pre-defined mvpMatrix when joints aren't in use
 	gl_Position = mvpMatrix * vec4(in_Position, 1.0);
+	#endif
 
 	// Process normal and directional lighting:
+	mat3 jointNormalMatrix = getNormalMatrix();
 	pass_NormalLength = length(in_Normal);
-	vec3 normal = normalMatrix * in_Normal;
+	vec3 normal = jointNormalMatrix * in_Normal;
 	if (dot(normal, normal) != 0.0) {
 		normal = normalize(normal);
 		// todo: Should we preserve original normal length?


### PR DESCRIPTION
* Replaced attachments system with Joints. Instead of vertices trying to attach to vertices of a given ID, they now try to attach to a model joint with the given ID. These joints then have their matrices precomputed and dumped into an SSBO where the shader can look up the transform. This means you can now animate and display large models with attachments enabled without any lag. Because SSBOs require GLSL version 430. Checks have been put into place to see if its supported, and if its not, the program will fallback to baking connections like it used to.
* To use the new joints system, RootEntity.PrepareJoints MUST be called after the model is setup (only if triangles have non-NoJoint joint values). Models must be assigned a joint ID that is referenced by a vertex/normal. Many models can share the same joint ID, but only the first will be used. Joint IDs (in the model and in the triangles) are remapped by RootEntity.PrepareJoints, so that only models that are needed as joints are put into the list.
* glTF2 no longer exports joint nodes when it doesn't need to, now that what joints are needed are known ahead of time.
* glTF2 now exports 1 skin per root entity, and not per the entire file.
* Fixed Merge Models check box being disabled for glTF2 and DAE, even though support was added for it.
* Changed scene.AutoAttach to AttachJointsMode, which can either be Hide (false), DontAttach (new), or Attach (true). Currently DontAttach cannot be enabled in the UI yet.
* Fixed Neversoft PSX model joints not working with actor models. It turns out actors (for some insane reason) use the index of the model for the objects table to get the transform, when really the object matching the model index should be used. Currently this is detected by the presence of the BlockMap tagged chunk, and has had no issues with any games tested against.
* Also fixed Neversoft PSX attachments not handling cases where an attachable vertex isn't used in a visible triangle.

Other changes:
* Fixed entity picking always using triangles, instead of defaulting to bounds intersection.
* Fixed entity picking triangle mode only using the first triangle intersection, meaning the closest entity wasn't always picked.
* FPS label now also shows triangles, meshes, ~~and skins (with shader-time-joints)~~ drawn.
* Fixed vertex/wireframe size control visibility not changing if the Scene.Draw function was taking too long.
* Checking a root entity tree node now automatically handles fixing connections.
* About window now shows the GLSL (OpenGL Shader) version number, and whether joints are shader-time or pre-computed.
* AnimationType is now readonly, because changing this can potentially crash the program.
* AnimationBatch no longer updates the models mesh batch every frame when paused.
* Added TMD Bindings support to PSI/HMD animations.
* TMD Bindings form is no longer 0-indexed for the binding values. It also now shows a display names (with optional animation object names) for each ID. Additionally, properties are no longer sorted, meaning you won't get 1, 10, 11, 2, 3...
* Replaced the many pointless instances of Array.Resize with new[]. Because for some reason I thought it made sense to resize the array when reusing it (even though the old values weren't needed)...