### PR TITLE
PSX LOD support and animation 0x2a subtype 0

### DIFF
--- a/Common/Animator/Animation.cs
+++ b/Common/Animator/Animation.cs
@@ -40,7 +40,6 @@ namespace PSXPrev.Common.Animator
                 case AnimationType.RPYDiff:
                 case AnimationType.MatrixDiff:
                 case AnimationType.AxisDiff:
-                //case AnimationType.HMD:
                     return true;
 
                 default:
@@ -67,7 +66,7 @@ namespace PSXPrev.Common.Animator
         private readonly WeakReference<RootEntity> _ownerEntity = new WeakReference<RootEntity>(null);
 
         [DisplayName("Name")]
-        public string AnimationName { get; set; }
+        public string Name { get; set; }
 
         [DisplayName("Format"), ReadOnly(true)]
         public string FormatName { get; set; }
@@ -116,6 +115,31 @@ namespace PSXPrev.Common.Animator
         // TOD TMD bindings
         public Dictionary<uint, uint> TMDBindings = new Dictionary<uint, uint>();
 
+        [DisplayName("Total Key Frames"), ReadOnly(true)]
+        public int TotalKeyFrames
+        {
+            get
+            {
+                var count = 0;
+                var queue = new Queue<AnimationObject>();
+                queue.Enqueue(RootAnimationObject);
+                while (queue.Count > 0)
+                {
+                    var animationObject = queue.Dequeue();
+                    count += animationObject.AnimationFrames.Count;
+
+                    foreach (var child in animationObject.Children)
+                    {
+                        if (child.Children.Count > 0 || child.AnimationFrames.Count > 0)
+                        {
+                            queue.Enqueue(child);
+                        }
+                    }
+                }
+                return count;
+            }
+        }
+
         // When animation objects have their own frame counts/speeds, they will become unsynced as the animation loops.
         [DisplayName("Unsynced Objects")]
         public bool HasUnsyncedObjects
@@ -145,7 +169,7 @@ namespace PSXPrev.Common.Animator
 
         public override string ToString()
         {
-            var name = AnimationName ?? nameof(Animation);
+            var name = Name ?? nameof(Animation);
             return $"{name} Frames={FrameCount} Objects={ObjectCount}";
         }
 

--- a/Common/Animator/AnimationBatch.cs
+++ b/Common/Animator/AnimationBatch.cs
@@ -351,7 +351,7 @@ namespace PSXPrev.Common.Animator
                                 }
                                 if (animationFrame.Matrix != null)
                                 {
-                                    frameMatrix = Matrix4.CreateFromQuaternion(animationFrame.Matrix.Value.ExtractRotation()) * Matrix4.CreateScale(animationFrame.Matrix.Value.ExtractScale()) * Matrix4.CreateTranslation(animationFrame.Transfer.GetValueOrDefault());
+                                    frameMatrix = Matrix4.CreateFromQuaternion(animationFrame.Matrix.Value.ExtractRotationSafe()) * Matrix4.CreateScale(animationFrame.Matrix.Value.ExtractScale()) * Matrix4.CreateTranslation(animationFrame.Transfer.GetValueOrDefault());
                                 }
                                 if (!animationFrame.AbsoluteMatrix)
                                 {

--- a/Common/Coordinate.cs
+++ b/Common/Coordinate.cs
@@ -44,12 +44,14 @@ namespace PSXPrev.Common
         
         public uint ID { get; set; } = NoID;
         public uint ParentID { get; set; } = NoID;
+        public bool IsAbsolute { get; set; } // True if parents do not affect WorldMatrix
 
         public Coordinate[] Coords { get; set; }
 
         public uint TMDID => ID + 1;
 
         public bool HasParent => ParentID != NoID && ParentID != ID;
+        public bool HasTransformParent => HasParent && !IsAbsolute;
         public Coordinate Parent => (HasParent ? Coords?[ParentID] : null);
         
         public Matrix4 WorldMatrix
@@ -57,11 +59,14 @@ namespace PSXPrev.Common
             get
             {
                 var matrix = _localMatrix;
-                var coord = Parent;
-                while (coord != null)
+                if (!IsAbsolute)
                 {
-                    Matrix4.Mult(ref matrix, ref coord._localMatrix, out matrix);
-                    coord = coord.Parent;
+                    var coord = Parent;
+                    while (coord != null)
+                    {
+                        Matrix4.Mult(ref matrix, ref coord._localMatrix, out matrix);
+                        coord = coord.Parent;
+                    }
                 }
                 return matrix;
             }
@@ -89,6 +94,7 @@ namespace PSXPrev.Common
 
             ID = fromCoordinate.ID;
             ParentID = fromCoordinate.ParentID;
+            IsAbsolute = fromCoordinate.IsAbsolute;
 
             Coords = coords;
         }

--- a/Common/EntityBase.cs
+++ b/Common/EntityBase.cs
@@ -14,7 +14,7 @@ namespace PSXPrev.Common
         private Vector3 _scale;
 
         [DisplayName("Name")]
-        public string EntityName { get; set; }
+        public string Name { get; set; }
 
 #if DEBUG
         [DisplayName("Debug Data"), ReadOnly(true)]
@@ -187,10 +187,10 @@ namespace PSXPrev.Common
             {
                 for (var i = 0; i < value.Length; i++)
                 {
-                    value[i].EntityName = "Sub-Model " + i;
+                    value[i].Name = "Sub-Model " + i;
                     if (value[i] is ModelEntity model && !string.IsNullOrEmpty(model.MeshName))
                     {
-                        model.EntityName += " " + model.MeshName;
+                        model.Name += " " + model.MeshName;
                     }
                     value[i].ParentEntity = this;
                 }
@@ -223,7 +223,7 @@ namespace PSXPrev.Common
 
         protected EntityBase(EntityBase fromEntity)
         {
-            EntityName = fromEntity.EntityName;
+            Name = fromEntity.Name;
             ParentEntity = fromEntity.ParentEntity;
             Bounds3D = fromEntity.Bounds3D;
             TempMatrix = fromEntity.TempMatrix;
@@ -300,7 +300,7 @@ namespace PSXPrev.Common
 
         public override string ToString()
         {
-            var name = EntityName ?? GetType().Name;
+            var name = Name ?? GetType().Name;
             return $"{name} Children={ChildEntities?.Length ?? 0}";
         }
 

--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -392,7 +392,7 @@ namespace PSXPrev.Common.Exporters
                     {
                         // A copy doesn't exist yet, create one.
                         vramTexture = new Texture(texture, true);
-                        vramTexture.TextureName = $"{texture.TextureName ?? nameof(Texture)} Copy";
+                        vramTexture.Name = $"{texture.Name ?? nameof(Texture)} Copy";
                         _copiedVRAMPages[texturePage] = vramTexture;
                     }
                     texture = vramTexture;
@@ -737,7 +737,7 @@ namespace PSXPrev.Common.Exporters
                     try
                     {
                         SingleTexture = new Texture(bitmap, 0, 0, 32, 0, 0, null, null);
-                        SingleTexture.TextureName = $"Single[{_countX}x{_countY}]";
+                        SingleTexture.Name = $"Single[{_countX}x{_countY}]";
                         //SingleTexture.SemiTransparentMap = VRAM.ConvertSingleTexture(_packedTextures, _countX, _countY, true);
                     }
                     catch
@@ -905,8 +905,8 @@ namespace PSXPrev.Common.Exporters
                     try
                     {
                         TiledTexture = new Texture(bitmap, 0, 0, 32, TexturePage, 0, null, null);
-                        //TiledTexture.TextureName = $"Tiled[{srcX},{srcY} {srcWidth}x{srcHeight}]";
-                        TiledTexture.TextureName = $"Tiled[{_repeatX}x{_repeatY}]";
+                        //TiledTexture.Name = $"Tiled[{srcX},{srcY} {srcWidth}x{srcHeight}]";
+                        TiledTexture.Name = $"Tiled[{_repeatX}x{_repeatY}]";
                         //TiledTexture.SemiTransparentMap = VRAM.ConvertTiledTexture(OriginalTexture, srcRect, _repeatX, _repeatY, fullWidth, fullHeight, true);
                     }
                     catch

--- a/Common/Exporters/glTF2Exporter.cs
+++ b/Common/Exporters/glTF2Exporter.cs
@@ -112,7 +112,7 @@ namespace PSXPrev.Common.Exporters
                 // "nodes:" [
                 //  {
                 //   "mesh": {i},
-                //   "name": "{model.EntityName}",
+                //   "name": "{model.Name}",
                 //   "translation": [ {model.WorldMatrix.ExtractTranslation()} ],
                 //   "rotation": [ {model.WorldMatrix.ExtractRotationSafe()} ],
                 //   "scale": [ {model.WorldMatrix.ExtractScale()} ]
@@ -121,10 +121,10 @@ namespace PSXPrev.Common.Exporters
                 //  {
                 //   "mesh": {i},
                 //   "skin": 0,
-                //   "name": "Mesh {model.EntityName}"
+                //   "name": "Mesh {model.Name}"
                 //  },
                 //  {
-                //   "name": "Joint {model.EntityName}",
+                //   "name": "Joint {model.Name}",
                 //   "translation": [ {model.WorldMatrix.ExtractTranslation()} ],
                 //   "rotation": [ {model.WorldMatrix.ExtractRotationSafe()} ],
                 //   "scale": [ {model.WorldMatrix.ExtractScale()} ]
@@ -141,7 +141,7 @@ namespace PSXPrev.Common.Exporters
                     _root.scenes[0].nodes.Add(_root.nodes.Count); // Add root nodes
                     _root.nodes.Add(new node
                     {
-                        name = $"{entity.EntityName}: Root",
+                        name = $"{entity.Name}: Root",
                         translation = WriteVector3(matrix.ExtractTranslation(), true),
                         rotation = WriteQuaternion(matrix.ExtractRotationSafe(), true),
                         scale = WriteVector3(matrix.ExtractScale(), false),
@@ -182,8 +182,8 @@ namespace PSXPrev.Common.Exporters
                             matrix = model.LocalMatrix;
                         }
 
-                        var meshName = $"{entity.EntityName}: Mesh {model.EntityName}";
-                        var jointName = $"{entity.EntityName}: Joint {model.EntityName}";
+                        var meshName = $"{entity.Name}: Mesh {model.Name}";
+                        var jointName = $"{entity.Name}: Joint {model.Name}";
 
                         var isJoint = _options.AttachLimbs && model.IsJoint;
                         var needsJoints = NeedsJoints(model);
@@ -252,7 +252,7 @@ namespace PSXPrev.Common.Exporters
                             coordNodes.Add(coord, _root.nodes.Count);
                             _root.nodes.Add(new node
                             {
-                                name = $"{entity.EntityName}: Coord-{j}",
+                                name = $"{entity.Name}: Coord-{j}",
                                 translation = WriteVector3(matrix.ExtractTranslation(), true),
                                 rotation = WriteQuaternion(matrix.ExtractRotationSafe(), true),
                                 scale = WriteVector3(matrix.ExtractScale(), false),
@@ -273,7 +273,7 @@ namespace PSXPrev.Common.Exporters
                         foreach (var coord in entity.Coords)
                         {
                             node parentNode;
-                            if (coord.HasParent)
+                            if (coord.HasParent && !coord.IsAbsolute)
                             {
                                 parentNode = _root.nodes[coordNodes[coord.Parent]];
                             }
@@ -671,7 +671,7 @@ namespace PSXPrev.Common.Exporters
                 // Write Meshes
                 // "meshes": [
                 //  {
-                //   "name": "{model.EntityName}",
+                //   "name": "{model.Name}",
                 //   "primitives": [
                 //    {
                 //     "attributes": {
@@ -698,7 +698,7 @@ namespace PSXPrev.Common.Exporters
                     }
                     _root.meshes.Add(new mesh
                     {
-                        name = model.EntityName,
+                        name = model.Name,
                         primitives = new List<mesh_primitive>
                         {
                             new mesh_primitive

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -164,6 +164,12 @@ namespace PSXPrev.Common
         }
 
         // Avoid getting NaN quaternions when any matrix scale dimension is 0.
+        public static Quaternion ExtractRotationSafe(this Matrix3 matrix)
+        {
+            var rotation = matrix.ExtractRotation();
+            return float.IsNaN(rotation.X) ? Quaternion.Identity : rotation;
+        }
+
         public static Quaternion ExtractRotationSafe(this Matrix4 matrix)
         {
             var rotation = matrix.ExtractRotation();

--- a/Common/ModelEntity.cs
+++ b/Common/ModelEntity.cs
@@ -350,7 +350,7 @@ namespace PSXPrev.Common
 
         public override string ToString()
         {
-            var name = EntityName ?? GetType().Name;
+            var name = Name ?? GetType().Name;
             var page = IsTextured ? TexturePage.ToString() : "null";
             return $"{name} Triangles={TrianglesCount} TexturePage={page}";
         }

--- a/Common/Parsers/FileOffsetScanner.cs
+++ b/Common/Parsers/FileOffsetScanner.cs
@@ -92,7 +92,7 @@ namespace PSXPrev.Common.Parsers
                                 continue;
                             }
                             passed = true;
-                            entity.EntityName = name;
+                            entity.Name = name;
                             entity.FormatName = CombineFormatName(FormatName, entity.FormatName);
                             entity.FileOffset = _offset;
                             entity.ResultIndex = resultIndex++;
@@ -114,7 +114,7 @@ namespace PSXPrev.Common.Parsers
                                 continue;
                             }
                             passed = true;
-                            texture.TextureName = name;
+                            texture.Name = name;
                             texture.FormatName = CombineFormatName(FormatName, texture.FormatName);
                             texture.FileOffset = _offset;
                             texture.ResultIndex = resultIndex++;
@@ -142,7 +142,7 @@ namespace PSXPrev.Common.Parsers
                                 continue;
                             }
                             passed = true;
-                            animation.AnimationName = name;
+                            animation.Name = name;
                             animation.FormatName = CombineFormatName(FormatName, animation.FormatName);
                             animation.FileOffset = _offset;
                             animation.ResultIndex = resultIndex++;

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -209,20 +209,18 @@ namespace PSXPrev.Common.Parsers
             var m21 = reader.ReadInt16() / 4096f;
             var m22 = reader.ReadInt16() / 4096f;
 
-            var x = reader.ReadInt32() / 65536f;
-            var y = reader.ReadInt32() / 65536f;
-            var z = reader.ReadInt32() / 65536f;
-            translation = new Vector3(x, y, z);
+            var pad = reader.ReadUInt16();
 
-            var matrix = new Matrix4(
-                new Vector4(m00, m10, m20, 0f),
-                new Vector4(m01, m11, m21, 0f),
-                new Vector4(m02, m12, m22, 0f),
-                new Vector4(x, y, z, 1f)
-            );
-            // It's strange that padding comes after the int32s. Would have expected the int32s to get aligned instead.
-            var pad = reader.ReadInt16();
-            return matrix;
+            var tx = reader.ReadInt32();
+            var ty = reader.ReadInt32();
+            var tz = reader.ReadInt32();
+            translation = new Vector3(tx, ty, tz);
+
+            return new Matrix4(
+                m00, m10, m20, 0f,
+                m01, m11, m21, 0f,
+                m02, m12, m22, 0f,
+                tx, ty, tz, 1f);
         }
 
         private void ProcessPrimitiveSet(BinaryReader reader, uint primitiveIndex, uint primitiveSetTop, uint primitiveHeaderTop)

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -44,12 +44,15 @@
         public static ulong MaxPMDPointers = 4000;
         public static ulong MaxPMDPackets = 4000;
 
-        public static ulong MaxPSXObjectCount = 1024;
+        public static ulong MaxPSXObjectCount = 2048;
         public static ulong MaxPSXTaggedChunks = 256;
         public static ulong MaxPSXTextureHashes = 10000;
         public static ulong MaxPSXTextures = 2048;
         public static ulong MaxPSXVertices = 20000;
         public static ulong MaxPSXFaces = 10000;
+        public static ulong MaxPSXAnimationFrames = 2048;
+        public static ulong MaxPSXAnimations = 1024;
+        public static ulong MaxPSXLODLevel = 10;
 
         public static ulong MaxSPTSprites = 1024;
 

--- a/Common/Parsers/PILParser.cs
+++ b/Common/Parsers/PILParser.cs
@@ -328,8 +328,6 @@ namespace PSXPrev.Common.Parsers
             // (Because primitives can reference vertices defined by any mesh.....)
             _psiMeshStack.Push(new Tuple<PSIMesh, uint>(null, rootMeshTop));
             uint modelIndex = 0;
-            uint vertexIndex = 0; // Offsets into each table that the mesh writes to
-            uint normalIndex = 0;
             while (_psiMeshStack.Count > 0)
             {
                 if (_psiMeshes.Count + _psiMeshStack.Count > (int)Limits.MaxBFFModels)
@@ -342,7 +340,7 @@ namespace PSXPrev.Common.Parsers
                 var meshTop = tuple.Item2;
                 reader.BaseStream.Seek(_offset2 + meshTop, SeekOrigin.Begin);
 
-                if (!ReadMesh(reader, skinned, d2m, totalVertexCount, parent, modelIndex, ref vertexIndex, ref normalIndex))
+                if (!ReadMesh(reader, skinned, d2m, totalVertexCount, parent, modelIndex))
                 {
                     return false;
                 }
@@ -497,7 +495,7 @@ namespace PSXPrev.Common.Parsers
             return false;
         }
 
-        private bool ReadMesh(BinaryReader reader, bool skinned, bool d2m, uint totalVertexCount, PSIMesh parent, uint modelIndex, ref uint vertexIndex, ref uint normalIndex)
+        private bool ReadMesh(BinaryReader reader, bool skinned, bool d2m, uint totalVertexCount, PSIMesh parent, uint modelIndex)
         {
             // Mesh header length is 120 bytes
             var meshPosition = reader.BaseStream.Position;
@@ -510,6 +508,8 @@ namespace PSXPrev.Common.Parsers
             var meshVertexCount = reader.ReadUInt32();
             var meshNormalTop   = reader.ReadUInt32();
             var meshNormalCount = reader.ReadUInt32();
+            var vertexIndex = _vertexCount;
+            var normalIndex = _normalCount;
             _vertexCount += meshVertexCount;
             _normalCount += meshNormalCount;
             if (_vertexCount > totalVertexCount || _normalCount > Limits.MaxBFFVertices)
@@ -707,8 +707,6 @@ namespace PSXPrev.Common.Parsers
                 RotateKeys = rotateKeys,
             };
             _psiMeshes.Add(psiMesh);
-            vertexIndex += meshVertexCount;
-            normalIndex += meshNormalCount;
 
             // Add next first, since we parse depth-first (adding child last will mean its first out)
             if (nextTop != 0)

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Text;
 using OpenTK;
+using PSXPrev.Common.Animator;
 using PSXPrev.Common.Utils;
 
 //Translated from:
@@ -19,37 +19,46 @@ namespace PSXPrev.Common.Parsers
 
         private static readonly ushort MaskMagenta = TexturePalette.FromComponents(248, 0, 248, false);
 
-        // Multiplied by 16 for files with HIER tagged chunk so that humanoids match the map size
-        // Translation divisor is only used for reading objects
+        // Used in-place of _lodDepths when we're not including all LOD levels
+        private static readonly short[] LODMinDepthArray = new[] { short.MinValue };
+        private const short LODMaxDepth = short.MaxValue; // Max depth away from the camera, a mesh with this depth will always be included
+        private const ushort NoMeshIndex = ushort.MaxValue; // Used for LOD to state there is no lower-quality LOD mesh after this
+
+        // _scaleDivisor is multiplied by 16 for files with HIER tagged chunk so that humanoids
+        // match the map size. Translation divisor is only used for reading objects.
         private float _scaleDivisorTranslation = 1f;
         private float _scaleDivisor = 1f;
-        private bool _useModelIndexAsObjectIndex; // Actor models use the model index to get the transform of the object
-        private PSXObject[] _objects;
+        private bool _useObjectIndexAsModelIndex; // Actor models use the mesh index to get the transform of the object
+        private PSXObject[] _psxObjects;
         private Coordinate[] _coords;
+        private PSXMesh[] _psxMeshes;
         private uint _objectCount;
-        private uint _modelCount;
+        private uint _meshCount;
         private Vector3[] _vertices;
         private Vector3[] _normals;
-        private uint[] _vertexJoints;
-        private bool _modelIsJoint;
+        private uint[] _vertexJoints; // Joints for both vertices and normals, but always uses vertex index for lookup
+        private uint _vertexCount;    // Total vertex count of all meshes
+        private uint _normalCount;    // Total normal count of all meshes
+        private uint[] _tempSections; // Temporary top/count/etc. tuples used for tagged chunks
         private readonly Color[] _gouraudPalette = new Color[256];
-        private uint _gouraudPaletteSize;
+        private uint _gouraudCount; // Number of entries read into _gouraudPalette
         private uint[] _textureHashes;
         private uint _textureHashCount;
         private readonly Dictionary<uint, PSXClutData> _clutDatas = new Dictionary<uint, PSXClutData>();
-        private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
-        private readonly Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>> _groupedSprites = new Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>>();
+        private readonly HashSet<short> _lodDepths = new HashSet<short>();
         private readonly Dictionary<uint, Tuple<uint, Vector3>> _attachableVertices = new Dictionary<uint, Tuple<uint, Vector3>>();
         private readonly Dictionary<uint, PSXSpriteVertexData> _spriteVertices = new Dictionary<uint, PSXSpriteVertexData>();
+        private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
+        private readonly Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>> _groupedSprites = new Dictionary<Tuple<Vector3, RenderInfo>, List<Triangle>>();
         private readonly List<ModelEntity> _models = new List<ModelEntity>();
         // Debug:
 #if DEBUG
-        private readonly Dictionary<uint, List<string>> _modelDebugData = new Dictionary<uint, List<string>>();
+        private readonly Dictionary<uint, List<string>> _objectDebugData = new Dictionary<uint, List<string>>();
 #endif
 
 
-        public PSXParser(EntityAddedAction entityAdded, TextureAddedAction textureAdded)
-            : base(entityAdded: entityAdded, textureAdded: textureAdded)
+        public PSXParser(EntityAddedAction entityAdded, TextureAddedAction textureAdded, AnimationAddedAction animationAdded)
+            : base(entityAdded: entityAdded, textureAdded: textureAdded, animationAdded: animationAdded)
         {
         }
 
@@ -57,45 +66,42 @@ namespace PSXPrev.Common.Parsers
 
         protected override void Parse(BinaryReader reader)
         {
-            _scaleDivisor = _scaleDivisorTranslation = Settings.Instance.AdvancedPSXScaleDivisor;
-            _coords = null;
-            _modelIsJoint = false;
-            _gouraudPaletteSize = 0;
-            _textureHashCount = 0;
-            _useModelIndexAsObjectIndex = true; // Assumed true unless we encounter a blockmap tagged chunk
-            _clutDatas.Clear();
-            _groupedTriangles.Clear();
-            _groupedSprites.Clear();
-            _attachableVertices.Clear();
-            _models.Clear();
-#if DEBUG
-            _modelDebugData.Clear();
-#endif
-
-            if (!ReadPSX(reader))
+            var version = reader.ReadUInt16();
+            if (version == 0x0003 || version == 0x0004 || version == 0x0006)
             {
-                foreach (var texture in TextureResults)
+                var magic = reader.ReadUInt16();
+                if (magic == 0x0002)
                 {
-                    texture.Dispose();
+                    if (!ReadPSX(reader, version))
+                    {
+                        foreach (var texture in TextureResults)
+                        {
+                            texture.Dispose();
+                        }
+                        EntityResults.Clear();
+                        TextureResults.Clear();
+                        AnimationResults.Clear();
+                    }
                 }
-                TextureResults.Clear();
             }
         }
 
-        private bool ReadPSX(BinaryReader reader)
+        private bool ReadPSX(BinaryReader reader, ushort version)
         {
-            var version = reader.ReadUInt16();
-            var magic   = reader.ReadUInt16();
-            if (version != 0x0003 && version != 0x0004 && version != 0x0006)
-            {
-                return false;
-            }
-            if (magic != 0x0002)
-            {
-                return false;
-            }
+            // Reset state
+            _scaleDivisor = _scaleDivisorTranslation = Settings.Instance.AdvancedPSXScaleDivisor;
+            _vertexCount = 0;
+            _normalCount = 0;
+            _gouraudCount = 0;
+            _useObjectIndexAsModelIndex = true; // Assumed true unless we encounter a blockmap tagged chunk
+            _lodDepths.Clear();
+            _attachableVertices.Clear();
+#if DEBUG
+            _objectDebugData.Clear();
+#endif
 
-            // Pointer to tagged chunks, model names, textures
+
+            // Pointer to tagged chunks, mesh names, textures
             var metaTop = reader.ReadUInt32();
             // Allow zero object count in-case this is a texture library
             _objectCount = reader.ReadUInt32();
@@ -104,42 +110,53 @@ namespace PSXPrev.Common.Parsers
                 return false;
             }
 
-            if (_objects == null || _objects.Length < _objectCount)
+            // Coords are assigned during ReadObject (we need an exact-sized array to assign to each Coordinate)
+            _coords = _objectCount > 0 ? new Coordinate[_objectCount] : null;
+
+            if (_psxObjects == null || _psxObjects.Length < _objectCount)
             {
-                _objects = new PSXObject[_objectCount];
+                _psxObjects = new PSXObject[_objectCount];
             }
             for (uint i = 0; i < _objectCount; i++)
             {
-                _objects[i] = ReadObject(reader, version, i);
-                if (_objects[i].ModelIndex >= _objectCount)
+                _psxObjects[i] = ReadObject(reader, version, i);
+                if (_psxObjects[i].MeshIndex >= _objectCount)
                 {
-                    _useModelIndexAsObjectIndex = false; // Not expected, but we can't use this if we'd go out of bounds
+                    _useObjectIndexAsModelIndex = false; // Not expected, but we can't use this if we'd go out of bounds
                 }
             }
 
 
-            // Allow zero model count in-case this is a texture library
-            _modelCount = reader.ReadUInt32();
-            if ((_modelCount == 0) != (_objectCount == 0) || _modelCount > Limits.MaxPSXObjectCount)
+            // Allow zero mesh count in-case this is a texture library
+            _meshCount = reader.ReadUInt32();
+            if ((_meshCount == 0) != (_objectCount == 0) || _meshCount > Limits.MaxPSXObjectCount)
             {
-                return false; // Models or objects are zero, but not both. Or model count is too high
+                return false; // Meshes or objects are zero, but not both. Or mesh count is too high
+            }
+            if (_psxMeshes == null || _psxMeshes.Length < _meshCount)
+            {
+                _psxMeshes = new PSXMesh[_meshCount];
             }
 
-            /*var hasDiffs = _objectCount == 0;
-            var hasHigher = false;
-            for (uint i = 0; i < _objectCount; i++)
+            // Debug:
+            /*if (_objectCount > 0)
             {
-                hasDiffs |= (_objects[i].ModelIndex != i);
-                hasHigher |= (_objects[i].ModelIndex >= _objectCount);
-            }
-            if (!hasDiffs && _objectCount != 0)
-            {
-                //return false;
+                var hasDiffs = false;
+                var hasHigher = false;
+                for (uint i = 0; i < _objectCount; i++)
+                {
+                    hasDiffs |= (_psxObjects[i].MeshIndex != i);
+                    hasHigher |= (_psxObjects[i].MeshIndex >= _objectCount);
+                }
+                if (!hasDiffs)
+                {
+                    //return false;
+                }
             }*/
 
 
-            // Read gouraud palette/vertex divisor from tagged chunks, and texture hashes before reading models
-            var modelsStartPosition = reader.BaseStream.Position;
+            // Read gouraud palette/vertex divisor from tagged chunks, and texture hashes before reading meshes
+            var meshesStartPosition = reader.BaseStream.Position;
             reader.BaseStream.Seek(_offset + metaTop, SeekOrigin.Begin);
 
             if (!ReadTaggedChunks(reader, version))
@@ -147,84 +164,117 @@ namespace PSXPrev.Common.Parsers
                 return false;
             }
 
-            // Hashes of model names, not important
-            var modelHashes = Program.Debug ? new string[_modelCount] : null;
-            for (uint i = 0; i < _modelCount; i++)
+            // Hashes of mesh names, not important
+            var meshHashes = Program.Debug ? new string[_meshCount] : null;
+            for (uint i = 0; i < _meshCount; i++)
             {
-                var modelHash = reader.ReadUInt32();
-                if (modelHashes != null)
+                var meshHash = reader.ReadUInt32();
+                if (meshHashes != null)
                 {
-                    modelHashes[i] = $"0x{modelHash:x08}";
+                    meshHashes[i] = $"0x{meshHash:x08}";
                 }
             }
-            if (modelHashes != null && _modelCount > 0)
+            if (meshHashes != null && _meshCount > 0)
             {
-                Program.Logger.WriteLine("Model Hashes: " + string.Join(", ", modelHashes));
+                Program.Logger.WriteLine("Mesh Hashes: " + string.Join(", ", meshHashes));
             }
 
             if (!ReadTextures(reader, version))
             {
                 return false;
             }
-            reader.BaseStream.Seek(modelsStartPosition, SeekOrigin.Begin);
+            reader.BaseStream.Seek(meshesStartPosition, SeekOrigin.Begin);
 
 
-            // We need to go through and read each model's vertices first, since we need to know joint vertex positions ahead of time
-            var modelsPosition = reader.BaseStream.Position;
-            for (uint i = 0; i < _modelCount; i++)
+            // We need to go through and read each mesh's attachable vertices first,
+            // since we need to know joint vertex positions ahead of time
+            for (uint i = 0; i < _meshCount; i++)
             {
-                var modelTop = reader.ReadUInt32();
-                var modelPosition = reader.BaseStream.Position;
-                reader.BaseStream.Seek(_offset + modelTop, SeekOrigin.Begin);
-                if (!ReadModelJoints(reader, version, i))
+                var meshTop = reader.ReadUInt32();
+                var meshPosition = reader.BaseStream.Position;
+                reader.BaseStream.Seek(_offset + meshTop, SeekOrigin.Begin);
+                if (!ReadMesh(reader, version, i))
                 {
                     return false;
                 }
-                reader.BaseStream.Seek(modelPosition, SeekOrigin.Begin);
+                reader.BaseStream.Seek(meshPosition, SeekOrigin.Begin);
             }
 
-            // Now that we have the joint vertex positions, we can read through each model and build lists of triangles
-            reader.BaseStream.Seek(modelsPosition, SeekOrigin.Begin);
-            for (uint i = 0; i < _objectCount; i++)
+            // Now that we have the joint vertex positions, we can read through each mesh and build lists of triangles
+            // PSX format features swappable LOD meshes for each object,
+            // by default we only use the first-listed mesh for highest quality.
+            IEnumerable<short> lodDepths = LODMinDepthArray; // Single depth that won't use LOD (since no LOD can be less than this)
+            if (Settings.Instance.AdvancedPSXIncludeLODLevels && _lodDepths.Count > 1)
             {
-                var psxObject = _objects[i];
-                var modelIndex = _useModelIndexAsObjectIndex ? i : psxObject.ModelIndex;
-                reader.BaseStream.Seek(modelsPosition + modelIndex * 4, SeekOrigin.Begin);
-
-                var modelTop = reader.ReadUInt32();
-                reader.BaseStream.Seek(_offset + modelTop, SeekOrigin.Begin);
-                if (!ReadModel(reader, version, i, modelIndex))
-                {
-                    return false;
-                }
+                lodDepths = _lodDepths.OrderBy(d => d); // Order quality from highest to lowest
             }
-            /*reader.BaseStream.Seek(modelsPosition, SeekOrigin.Begin);
-            for (uint i = 0; i < _modelCount; i++)
-            {
-                var modelTop = reader.ReadUInt32();
-                var modelPosition = reader.BaseStream.Position;
-                reader.BaseStream.Seek(_offset + modelTop, SeekOrigin.Begin);
-                if (!ReadModel(reader, version, i))//, ref attachmentIndex))
-                {
-                    return false;
-                }
-                reader.BaseStream.Seek(modelPosition, SeekOrigin.Begin);
-            }*/
 
-            if (_models.Count > 0)
+            foreach (var lodDepth in lodDepths)
             {
-                var rootEntity = new RootEntity();
-                rootEntity.ChildEntities = _models.ToArray();
-                rootEntity.Coords = _coords;
-                //rootEntity.OwnedTextures.AddRange(TextureResults); // todo: need to change how owned textures are handled
-                foreach (var texture in TextureResults)
+                // Reset model state
+                _groupedTriangles.Clear();
+                _groupedSprites.Clear();
+                _models.Clear();
+
+                for (uint i = 0; i < _objectCount; i++)
                 {
-                    texture.OwnerEntity = rootEntity;
+                    var psxObject = _psxObjects[i];
+                    var modelIndex = _useObjectIndexAsModelIndex ? i : psxObject.MeshIndex;
+                    var psxMesh = _psxMeshes[modelIndex];
+
+                    // Find mesh index for the given LOD depth
+                    uint lodLevel = 0; // Used to sanity-check recursion
+                    while (modelIndex != NoMeshIndex && psxMesh.LODDepth < lodDepth)
+                    {
+                        if (++lodLevel > Limits.MaxPSXLODLevel)
+                        {
+                            return false;
+                        }
+                        modelIndex = psxMesh.LODNextMeshIndex;
+                        if (modelIndex != NoMeshIndex)
+                        {
+                            psxMesh = _psxMeshes[modelIndex];
+                        }
+                    }
+                    if (modelIndex == NoMeshIndex)
+                    {
+                        continue; // Mesh is hidden at this LOD depth
+                    }
+
+                    reader.BaseStream.Seek(_offset + psxMesh.MeshTop, SeekOrigin.Begin);
+                    if (!ReadMeshPrimitives(reader, version, i, modelIndex))
+                    {
+                        return false;
+                    }
                 }
-                // PrepareJoints must be called before ComputeBounds
-                rootEntity.PrepareJoints(_attachableVertices.Count > 0);
-                rootEntity.ComputeBounds();
-                EntityResults.Add(rootEntity);
+
+
+                //if (_models.Count > 0)
+                if (_models.Any(m => m.Triangles.Length > 0))
+                {
+                    var rootEntity = new RootEntity();
+                    rootEntity.ChildEntities = _models.ToArray();
+                    // We can use the original instance of coords for the first entity, but clone for all remaining entities.
+                    rootEntity.Coords = EntityResults.Count == 0 ? _coords : Coordinate.CloneCoordiantes(_coords);
+                    //rootEntity.OwnedTextures.AddRange(TextureResults); // todo: need to change how owned textures are handled
+                    rootEntity.OwnedAnimations.AddRange(AnimationResults);
+                    if (EntityResults.Count == 0)
+                    {
+                        // Set the owner as the highest-quality LOD model
+                        foreach (var texture in TextureResults)
+                        {
+                            texture.OwnerEntity = rootEntity;
+                        }
+                        foreach (var animation in AnimationResults)
+                        {
+                            animation.OwnerEntity = rootEntity;
+                        }
+                    }
+                    // PrepareJoints must be called before ComputeBounds
+                    rootEntity.PrepareJoints(_attachableVertices.Count > 0);
+                    rootEntity.ComputeBounds();
+                    EntityResults.Add(rootEntity);
+                }
             }
 
             return true;
@@ -247,6 +297,9 @@ namespace PSXPrev.Common.Parsers
             const uint TagBits      = 0x00000045; // "E" Medium (Used for bits.psx, aka fonts and common symbols/images/hud/etc.)
 
 
+            // Start by checking chunks for parser behavior changes, then parse the chunks for real after that
+            // This is needed since the HIER tagged chunk changes the scale divisor that's used for animations
+            var chunksStartPosition = reader.BaseStream.Position;
             uint chunkCount = 0;
             var chunkTag = reader.ReadUInt32();
             while (chunkTag != TagStop)
@@ -255,9 +308,7 @@ namespace PSXPrev.Common.Parsers
                 {
                     return false;
                 }
-
                 var chunkLength = reader.ReadUInt32();
-                var chunkPosition = reader.BaseStream.Position;
 
                 if (Program.Debug)
                 {
@@ -270,6 +321,30 @@ namespace PSXPrev.Common.Parsers
                     Program.Logger.WriteLine($"chunk[{chunkCount-1}]: \"{tagStr}\" 0x{chunkTag:x08} {chunkLength} : {_fileTitle}_{_offset:X} @ 0x{reader.BaseStream.Position:x}");
                 }
 
+                switch (chunkTag)
+                {
+                    case TagHIER:
+                        // Models with hierarchy are scaled down by x16.
+                        _scaleDivisor = _scaleDivisorTranslation * 16f;
+                        break;
+                    case TagBlockMap:
+                        // This probably isn't the correct way to detect this, but it works for all games tested against:
+                        // (Apocalypse, Spider Man 1-2, Tony Hawk's Pro Skater 1-4)
+                        _useObjectIndexAsModelIndex = false; // Not an actor model
+                        break;
+                }
+
+                reader.BaseStream.Seek(reader.BaseStream.Position + chunkLength, SeekOrigin.Begin);
+                chunkTag = reader.ReadUInt32();
+            }
+
+            reader.BaseStream.Seek(chunksStartPosition, SeekOrigin.Begin);
+            chunkTag = reader.ReadUInt32();
+            while (chunkTag != TagStop)
+            {
+                var chunkLength = reader.ReadUInt32();
+                var chunkPosition = reader.BaseStream.Position;
+
                 var result = true;
                 switch (chunkTag)
                 {
@@ -279,10 +354,11 @@ namespace PSXPrev.Common.Parsers
                     case TagHIER:
                         result = ReadTaggedChunkHIER(reader, chunkLength);
                         break;
-                    case TagBlockMap:
-                        // This probably isn't the correct way to detect this, but it works for all games tested against:
-                        // (Apocalypse, Spider Man 1-2, Tony Hawk's Pro Skater 1-4)
-                        _useModelIndexAsObjectIndex = false; // Not an actor model
+                    case TagUnknown2C:
+                        result = ReadTaggedChunk0x2C(reader, version, chunkLength);
+                        break;
+                    case TagUnknown2A:
+                        result = ReadTaggedChunk0x2A(reader, version, chunkLength);
                         break;
                 }
                 if (!result)
@@ -293,6 +369,7 @@ namespace PSXPrev.Common.Parsers
                 reader.BaseStream.Seek(chunkPosition + chunkLength, SeekOrigin.Begin);
                 chunkTag = reader.ReadUInt32();
             }
+
             return true;
         }
 
@@ -305,14 +382,14 @@ namespace PSXPrev.Common.Parsers
             // For now, the color is just being changed to gray so the face's texture is visible, but this isn't correct.
 
             // Palette size can be smaller than 256
-            _gouraudPaletteSize = chunkLength / 4;
-            if (_gouraudPaletteSize > _gouraudPalette.Length)
+            _gouraudCount = chunkLength / 4;
+            if (_gouraudCount > _gouraudPalette.Length)
             {
                 // Error out if palette size is too large, or should we ignore remaining colors...?
                 return false;
             }
             var specialStarted = false;
-            for (uint i = 0; i < _gouraudPaletteSize; i++)
+            for (uint i = 0; i < _gouraudCount; i++)
             {
                 var r = reader.ReadByte();
                 var g = reader.ReadByte();
@@ -348,59 +425,343 @@ namespace PSXPrev.Common.Parsers
 
         private bool ReadTaggedChunkHIER(BinaryReader reader, uint chunkLength)
         {
-            // We can't use Coords yet, the point of them is to handle relative position,
-            // but objects already store absolute position...
-
-            // Models with hierarchy are scaled down by x16.
-            _scaleDivisor = _scaleDivisorTranslation * 16f;
-            if (_coords != null)
-            {
-                var breakHere = 0;
-            }
-            _coords = new Coordinate[_objectCount];
-
             // Can't rely on chunk length, since it's padded to 4 bytes
-            var count = chunkLength / 2;
-            for (uint i = 0; i < _objectCount; i++)
+            var count = Math.Min(chunkLength / 2, _objectCount);
+            for (uint i = 0; i < count; i++)
             {
-                var coord = new Coordinate
+                var parentIndex = reader.ReadUInt16();
+                if (parentIndex != i)
                 {
-                    Coords = _coords,
-                    ID = i,
-                };
-                if (i < count)
-                {
-                    var parentIndex = reader.ReadUInt16();
-                    if (parentIndex != i)
-                    {
-                        coord.ParentID = parentIndex;
-                    }
+                    _coords[i].ParentID = parentIndex;
                 }
-                _coords[i] = coord;
             }
             if (Coordinate.FindCircularReferences(_coords))
             {
                 return false;
             }
-            for (uint i = 0; i < _objectCount; i++)
+            return true;
+        }
+
+#if DEBUG
+        private class SectionSizes
+        {
+            public class Range1d
             {
-                var coord = _coords[i];
-                var translation = _objects[i].Translation;
-                if (coord.HasParent)
+                public double Min = double.NaN;
+                public double Max = double.NaN;
+                public void Update(double value)
                 {
-                    // Convert absolute translation to relative translation.
-                    // We only need to do this for the first-level parent,
-                    // since that object's translation is also absolute.
-                    translation -= _objects[coord.ParentID].Translation;
+                    Min = (!double.IsNaN(Min) && Min < value) ? Min : value;
+                    Max = (!double.IsNaN(Max) && Max > value) ? Max : value;
                 }
-                coord.OriginalLocalMatrix = Matrix4.CreateTranslation(translation);
-                coord.OriginalTranslation = translation;
+                public override string ToString() => $"{Min}, {Max}";
+            }
+
+            public class Range1u
+            {
+                public uint Min = uint.MaxValue;
+                public uint Max = uint.MinValue;
+                public void Update(uint value)
+                {
+                    Min = Math.Min(Min, value);
+                    Max = Math.Max(Max, value);
+                }
+                public override string ToString() => $"{Min}, {Max}";
+            }
+
+            public Range1u Count = new Range1u();
+            public Range1u CountMesh = new Range1u();
+            public Range1u CountObject = new Range1u();
+            public Range1u Length = new Range1u();
+
+            public Range1d SizeCount = new Range1d();
+            public Range1d SizeCountXMesh = new Range1d();
+            public Range1d SizeCountXObject = new Range1d();
+            public Range1d SizeMesh = new Range1d();
+            public Range1d SizeObject = new Range1d();
+
+            public readonly HashSet<string> FileNames = new HashSet<string>();
+            public uint Occurrences = 0;
+
+            public void Update(string fileTitle, uint count, uint objectCount, uint meshCount, uint length)
+            {
+                Count.Update(count);
+                CountMesh.Update(meshCount);
+                CountObject.Update(objectCount);
+                Length.Update(length);
+
+                if (count > 0)
+                {
+                    SizeCount.Update((double)length / count);
+                }
+                if ((count * meshCount) > 0)
+                {
+                    SizeCountXMesh.Update((double)length / (count * meshCount));
+                }
+                if ((count * objectCount) > 0)
+                {
+                    SizeCountXObject.Update((double)length / (count * objectCount));
+                }
+                if (meshCount > 0)
+                {
+                    SizeMesh.Update((double)length / meshCount);
+                }
+                if (objectCount > 0)
+                {
+                    SizeObject.Update((double)length / objectCount);
+                }
+
+                FileNames.Add(fileTitle);
+                Occurrences++;
+            }
+
+            public override string ToString()
+            {
+                return $"({Occurrences}): {SizeCount.Min}, {SizeObject.Min}, {SizeCountXObject.Min}";
+            }
+        }
+
+        private static readonly Dictionary<ushort, SectionSizes> ChunkSectionSizes = new Dictionary<ushort, SectionSizes>();
+#endif
+
+        // Supposedly an animation format
+        private bool ReadTaggedChunk0x2C(BinaryReader reader, ushort version, uint chunkLength)
+        {
+            var chunkPosition = reader.BaseStream.Position;
+            var sectionCount = reader.ReadUInt32();
+            if (sectionCount > Limits.MaxPSXAnimations)
+            {
+                return false;
+            }
+            if (_tempSections == null || _tempSections.Length < sectionCount * 2)
+            {
+                _tempSections = new uint[sectionCount * 2];
+            }
+            for (uint i = 0; i < sectionCount; i++) // top/count(?) pairs
+            {
+                _tempSections[(i * 2) + 0] = reader.ReadUInt32();
+                _tempSections[(i * 2) + 1] = reader.ReadUInt32();
+            }
+            for (uint i = 0; i < sectionCount; i++)
+            {
+                var top   = _tempSections[(i * 2) + 0];
+                var count = _tempSections[(i * 2) + 1]; // This number is small, usually between 1 and 90
+                // count * _objectCount can be larger than the length of a section
+                var length = (i + 1 < sectionCount ? _tempSections[((i + 1) * 2) + 0] : chunkLength) - top;
+                if (count > Limits.MaxPSXAnimationFrames)
+                {
+                    return false;
+                }
+                if (count > ushort.MaxValue)
+                {
+                    var breakHere = 0;
+                }
+
+                reader.BaseStream.Seek(chunkPosition + top, SeekOrigin.Begin);
+#if DEBUG
+                var sectionID = (ushort)((0x2C << 8));
+                if (!ChunkSectionSizes.TryGetValue(sectionID, out var sectionSizes))
+                {
+                    sectionSizes = new SectionSizes();
+                    ChunkSectionSizes.Add(sectionID, sectionSizes);
+                }
+                sectionSizes.Update(_fileTitle, count, _objectCount, _meshCount, length);
+#endif
+
+                if (count > length)
+                {
+                    var breakHere = 0;
+                }
+                if (_objectCount > length)
+                {
+                    var breakHere = 0;
+                }
+            }
+            return true;
+        }
+
+        // Various animation formats (based on subtypes)
+        private bool ReadTaggedChunk0x2A(BinaryReader reader, ushort version, uint chunkLength)
+        {
+            var chunkPosition = reader.BaseStream.Position;
+            var sectionCount = reader.ReadUInt32();
+            if (sectionCount > Limits.MaxPSXAnimations)
+            {
+                return false;
+            }
+            if (_tempSections == null || _tempSections.Length < sectionCount * 3)
+            {
+                _tempSections = new uint[sectionCount * 3];
+            }
+            for (uint i = 0; i < sectionCount; i++) // top/count(?)/type(?) tuples
+            {
+                _tempSections[(i * 3) + 0] = reader.ReadUInt32();
+                _tempSections[(i * 3) + 1] = reader.ReadUInt16();
+                _tempSections[(i * 3) + 2] = reader.ReadUInt16();
+            }
+            for (uint i = 0; i < sectionCount; i++)
+            {
+                var top     = _tempSections[(i * 3) + 0];
+                var count   = _tempSections[(i * 3) + 1]; // Seems to be number of key frames (can be 1)
+                var subtype = _tempSections[(i * 3) + 2]; // Describes the format of the animation data
+                var length = (i + 1 < sectionCount ? _tempSections[((i + 1) * 3) + 0] : chunkLength) - top;
+                if (count > Limits.MaxPSXAnimationFrames)
+                {
+                    return false;
+                }
+
+                reader.BaseStream.Seek(chunkPosition + top, SeekOrigin.Begin);
+#if DEBUG
+                var sectionID = (ushort)((0x2A << 8) | subtype);
+                if (!ChunkSectionSizes.TryGetValue(sectionID, out var sectionSizes))
+                {
+                    sectionSizes = new SectionSizes();
+                    ChunkSectionSizes.Add(sectionID, sectionSizes);
+                }
+                sectionSizes.Update(_fileTitle, count, _objectCount, _meshCount, length);
+#endif
+
+                switch (subtype)
+                {
+                    case 0x0: // Matrix (Matrix3 + Translation) key frames
+                        // Always (count * _objectCount * 24) bytes in length
+                        if (!ReadTaggedChunk0x2ASubtype0(reader, version, count, length))
+                        {
+                            return false;
+                        }
+                        break;
+                    case 0x1:
+                        // Always at least (count * _objectCount * 12) bytes in length
+                        break; // Apocalypse
+                    case 0x2:
+                        break;
+                    case 0x3:
+                        break;
+                    case 0x4:
+                        break; // Spider Man 1 (henchman.psx)
+                    case 0x5:
+                        break; // Spider Man 1
+                    case 0x8:
+                        break; // Spider Man 2
+                    case 0x9:
+                        break; // Apocalypse (demon.psx, prisoner.psx, punk.psx)
+                    case 0xd:
+                        break; // Spider Man 2
+                    case 0x12:
+                        break; // Spider Man 2
+                    case 0x62:
+                        break; // Spider Man 1 (chopper.psx)
+                    default:
+                        break;
+                }
+            }
+            return true;
+        }
+
+        private bool ReadTaggedChunk0x2ASubtype0(BinaryReader reader, ushort version, uint count, uint length)
+        {
+            //if ((count * _objectCount * 24) > length)
+            //{
+            //    return false; // Section is too small
+            //}
+            // Stricter sanity-check
+            //if (length / (_objectCount * count) != 24 || length % (_objectCount * count) != 0)
+            //{
+            //    return false;
+            //}
+            var animation = new Animation();
+            var animationObjects = new Dictionary<uint, AnimationObject>();
+            for (uint i = 0; i < count; i++)
+            {
+                for (uint o = 0; o < _objectCount; o++)
+                {
+                    var objectId = o + 1u;
+                    if (!animationObjects.TryGetValue(objectId, out var animationObject))
+                    {
+                        animationObject = new AnimationObject
+                        {
+                            Animation = animation,
+                            ID = objectId,
+                        };
+                        animationObject.TMDID.Add(objectId);
+                        animationObjects.Add(objectId, animationObject);
+                    }
+
+                    var m00 = reader.ReadInt16() / 4096f;
+                    var m01 = reader.ReadInt16() / 4096f;
+                    var m02 = reader.ReadInt16() / 4096f;
+                    var m10 = reader.ReadInt16() / 4096f;
+                    var m11 = reader.ReadInt16() / 4096f;
+                    var m12 = reader.ReadInt16() / 4096f;
+                    var m20 = reader.ReadInt16() / 4096f;
+                    var m21 = reader.ReadInt16() / 4096f;
+                    var m22 = reader.ReadInt16() / 4096f;
+
+                    var tx = reader.ReadInt16() / _scaleDivisor;
+                    var ty = reader.ReadInt16() / _scaleDivisor;
+                    var tz = reader.ReadInt16() / _scaleDivisor;
+
+                    var matrix3 = new Matrix3(
+                        m00, m10, m20,
+                        m01, m11, m21,
+                        m02, m12, m22);
+
+                    var translation = new Vector3(tx, ty, tz);
+                    var rotation = matrix3.ExtractRotationSafe();
+                    var scale = matrix3.ExtractScale();
+
+                    if (i > 0 && animationObject.AnimationFrames.TryGetValue(i - 1u, out var lastAnimationFrame))
+                    {
+                        lastAnimationFrame.FinalTranslation = translation;
+                        lastAnimationFrame.FinalRotation = rotation;
+                        lastAnimationFrame.FinalScale = scale;
+                    }
+
+                    if (i + 1 < count || count == 1)
+                    {
+                        var frameTime = i;
+                        var animationFrame = new AnimationFrame
+                        {
+                            FrameTime = frameTime,
+                            FrameDuration = 1,
+                            AnimationObject = animationObject,
+                        };
+                        animationObject.AnimationFrames.Add(frameTime, animationFrame);
+
+                        animationFrame.TranslationType = InterpolationType.Linear;
+                        animationFrame.RotationType = InterpolationType.Linear;
+                        animationFrame.ScaleType = InterpolationType.Linear;
+                        animationFrame.Translation = translation;
+                        animationFrame.Rotation = rotation;
+                        animationFrame.Scale = scale;
+
+                        if (count == 1)
+                        {
+                            animationFrame.FinalTranslation = translation;
+                            animationFrame.FinalRotation = rotation;
+                            animationFrame.FinalScale = scale;
+                        }
+                    }
+                }
+            }
+
+            if (animationObjects.Count > 0 && count > 0)
+            {
+                // Apocalypse/Spider Man seems to use 25-30FPS,
+                // while THPS uses 1FPS (but it only has one identical animation used by all characters).
+                animation.AnimationType = AnimationType.PSI;
+                animation.FPS = 25f;
+                animation.AssignObjects(animationObjects, true, false);
+                AnimationResults.Add(animation);
             }
             return true;
         }
 
         private bool ReadTextures(BinaryReader reader, ushort version)
         {
+            // Reset textures state
+            _clutDatas.Clear();
+
             _textureHashCount = reader.ReadUInt32();
             if (_textureHashCount > Limits.MaxPSXTextureHashes)
             {
@@ -563,7 +924,7 @@ namespace PSXPrev.Common.Parsers
             {
                 color = TexturePalette.SetStp(color, true);
             }
-            // todo: What about stp bits for other colors? Is it effected by maskMode?
+            // todo: What about stp bits for other colors? Is it affected by maskMode?
             return color;
         }
 
@@ -651,12 +1012,13 @@ namespace PSXPrev.Common.Parsers
             var x = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
             var y = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
             var z = reader.ReadInt32() / (4096f * _scaleDivisorTranslation);
+            var translation = new Vector3(x, y, z);
             var unk1 = reader.ReadUInt32();
             var unk2 = reader.ReadUInt16();
-            // Index of model in the models list. If multiple objects have the same model,
-            // then multiple models are created, which theoretically can be used for
+            // Index of mesh in the meshes list. If multiple objects have the same mesh,
+            // then multiple meshes are created, which theoretically can be used for
             // having the same props in different positions.
-            var modelIndex = reader.ReadUInt16();
+            var meshIndex = reader.ReadUInt16();
             // When non-zero, observed as multiples of 2, tx and/or ty can be non-zero.
             var tx = reader.ReadInt16();
             var ty = reader.ReadInt16();
@@ -665,17 +1027,18 @@ namespace PSXPrev.Common.Parsers
             // This can also be null.
             var paletteTop = reader.ReadUInt32();
 
-            /*_coords[objectIndex] = new Coordinate
+            _coords[objectIndex] = new Coordinate
             {
-                OriginalLocalMatrix = Matrix4.CreateTranslation(x, y, z),
-                OriginalTranslation = new Vector3(x, y, z),
+                Coords = _coords,
                 ID = objectIndex,
-                //ParentID = Coordinate.NoID, // Assigned later
-                //Coords = coords, // Assigned later on success
-            };*/
+                IsAbsolute = true, // Transforms are absolute, parents don't affect WorldMatrix
+                OriginalLocalMatrix = Matrix4.CreateTranslation(translation),
+                OriginalTranslation = translation,
+            };
 
 #if DEBUG
-            _modelDebugData[modelIndex] = new List<string> {
+            _objectDebugData[objectIndex] = new List<string>
+            {
                 $"objectFlags: 0x{objectFlags:x08}",
                 $"unk1: 0x{unk1:x08}",
                 $"unk2: 0x{unk2:x04}",
@@ -686,14 +1049,16 @@ namespace PSXPrev.Common.Parsers
 #endif
             return new PSXObject
             {
-                Translation = new Vector3(x, y, z),
-                ModelIndex = modelIndex,
+                Translation = translation,
+                MeshIndex = meshIndex,
             };
         }
 
-        private bool ReadModelJoints(BinaryReader reader, ushort version, uint modelIndex)
+        private bool ReadMesh(BinaryReader reader, ushort version, uint modelIndex)
         {
-            var modelFlags  = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            var meshTop = (uint)(reader.BaseStream.Position - _offset);
+
+            var meshFlags   = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
             var vertexCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
             var normalCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
             var faceCount   = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
@@ -707,76 +1072,95 @@ namespace PSXPrev.Common.Parsers
                 return false;
             }
 
-            var radius = reader.ReadUInt32() / (4096f * _scaleDivisor);
-            var xMax = reader.ReadInt16() / _scaleDivisor;
-            var xMin = reader.ReadInt16() / _scaleDivisor;
-            var yMax = reader.ReadInt16() / _scaleDivisor;
-            var yMin = reader.ReadInt16() / _scaleDivisor;
-            var zMax = reader.ReadInt16() / _scaleDivisor;
-            var zMin = reader.ReadInt16() / _scaleDivisor;
+            // Skip radius, xyzMaxMin
+            reader.BaseStream.Seek(16, SeekOrigin.Current);
+            //reader.BaseStream.Seek(version == 0x04 ? 18 : 20, SeekOrigin.Current); // Includes faceCount in skip
+
+            var lodDepth = LODMaxDepth;
+            var lodNextMeshIndex = NoMeshIndex;
             if (version == 0x04)
             {
-                var unk2 = reader.ReadUInt32();
+                lodDepth = reader.ReadInt16();
+                lodNextMeshIndex = reader.ReadUInt16();
             }
 
+            var modelIsJoint = false;
+
+            // We need to read through vertices twice, first to load all attachables, and the second time
+            // to load vertices for the current mesh. Tests were done to compare load times of storing all
+            // vertices at once, and loading vertices per-mesh is faster by a decent amount.
             for (uint j = 0; j < vertexCount; j++)
             {
                 // Vertex coding:
-                // pad =  0: Normal vertex
-                // pad =  1: Attachable vertex, file-wide counter as the index
-                // pad =  2: Attached vertex,   Y is the index of the attachable (not vertex index)
-                //                              X and Z are zero
-                // pad =  4: Unknown            X, Y, and Z are not indexes, and may be negative
-                // pad = 16: Sprite vertex,     X is a byte offset to the sprite center vertex (always 0,8,16,24)
-                //                              Y is a byte offset to a vertex (usually 16,16,0,0, rarely 24,24,8,8)
-                //                              Z value is the width of the sprite with some awkward behavior, not fully understood
+                // It's possible that type is actually flags, since all encountered types are powers of 2.
+                // However most types wouldn't make sense to use together.
+                // type =  0: Normal vertex
+                // type =  1: Attachable vertex, file-wide counter as the index
+                // type =  2: Attached vertex,   Y is the index of the attachable (not vertex index)
+                //                               X and Z are zero
+                // type =  4: Unknown            X, Y, and Z are not indexes, and may be negative
+                // type = 16: Sprite vertex,     X is a byte offset to the sprite center vertex (always 0,8,16,24)
+                //                               Y is a byte offset to a vertex (usually 16,16,0,0, rarely 24,24,8,8)
+                //                               Z value is the width of the sprite with some awkward behavior, not fully understood
                 var x = reader.ReadInt16();
                 var y = reader.ReadInt16();
                 var z = reader.ReadInt16();
-                var pad = reader.ReadUInt16();
+                var type = reader.ReadUInt16();
 
-                if (pad == 1)
+                if (type == 1)
                 {
                     var vertex = new Vector3(x / _scaleDivisor, y / _scaleDivisor, z / _scaleDivisor);
 
                     // Note that this isn't a Joint ID, just a .PSX attachment index ID.
                     var attachmentIndex = (uint)_attachableVertices.Count;
-                    _attachableVertices.Add(attachmentIndex, new Tuple<uint, Vector3>(modelIndex + 1u, vertex));
+                    var modelJointID = modelIndex + 1u;
+                    _attachableVertices.Add(attachmentIndex, new Tuple<uint, Vector3>(modelJointID, vertex));
+                    modelIsJoint = true;
                 }
             }
+
+            _psxMeshes[modelIndex] = new PSXMesh
+            {
+                MeshTop = meshTop,
+                VertexStart = _vertexCount,
+                NormalStart = _normalCount,
+                IsJoint = modelIsJoint,
+                LODDepth = lodDepth,
+                LODNextMeshIndex = lodNextMeshIndex,
+            };
+            _vertexCount += vertexCount;
+            _normalCount += normalCount;
+            if (Settings.Instance.AdvancedPSXIncludeLODLevels)
+            {
+                _lodDepths.Add(lodDepth);
+            }
+
             return true;
         }
 
-        private bool ReadModel(BinaryReader reader, ushort version, uint objectIndex, uint modelIndex)
+        private bool ReadMeshPrimitives(BinaryReader reader, ushort version, uint objectIndex, uint modelIndex)
         {
-            // Reset model state
-            _modelIsJoint = false;
+            // Reset mesh state
             _spriteVertices.Clear();
 
 #if DEBUG
-            if (!_modelDebugData.TryGetValue(objectIndex, out var modelDebugData))
+            if (!_objectDebugData.TryGetValue(objectIndex, out var objectDebugData))
             {
-                modelDebugData = new List<string>();
-                _modelDebugData.Add(objectIndex, modelDebugData);
+                objectDebugData = new List<string>();
+                _objectDebugData.Add(objectIndex, objectDebugData);
             }
 #endif
-            var modelFlags  = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
+            var meshFlags   = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32(); // Always 0x8 or 0xa
             var vertexCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
             var normalCount = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
             var faceCount   = version == 0x04 ? reader.ReadUInt16() : reader.ReadUInt32();
 #if DEBUG
-            modelDebugData?.Add($"modelFlags: 0x{modelFlags:x08}");
+            objectDebugData?.Add($"meshFlags: 0x{meshFlags:x08}");
 #endif
 
-            if (vertexCount > Limits.MaxPSXVertices || normalCount > Limits.MaxPSXVertices)
-            {
-                return false;
-            }
-            if (faceCount > Limits.MaxPSXFaces)
-            {
-                return false;
-            }
+            // We already sanity-checked vertexCount, normalCount, and faceCount in ReadMesh
 
+            // Read bounds information
             var radius = reader.ReadUInt32() / (4096f * _scaleDivisor);
             var xMax = reader.ReadInt16() / _scaleDivisor;
             var xMin = reader.ReadInt16() / _scaleDivisor;
@@ -786,13 +1170,17 @@ namespace PSXPrev.Common.Parsers
             var zMin = reader.ReadInt16() / _scaleDivisor;
             if (version == 0x04)
             {
-                var unk2 = reader.ReadUInt32();
+                var lodDepth = reader.ReadInt16(); // Just a guess, maybe the range at which this LOD level shows
+                var lodNextMeshIndex = reader.ReadUInt16();
 #if DEBUG
-                modelDebugData?.Add($"modelUnk2: 0x{unk2:x08}");
+                var lodDebugDepth = lodDepth != LODMaxDepth ? lodDepth.ToString() : "max";
+                var lodDebugNextMeshIndex = lodNextMeshIndex != NoMeshIndex ? lodNextMeshIndex.ToString() : "none";
+                objectDebugData?.Add($"lodMesh: {lodDebugNextMeshIndex}, {lodDebugDepth}");
 #endif
             }
 
 
+            // Read mesh vertices (and lookup attached vertices, now that attachables are all loaded)
             if (_vertices == null || _vertices.Length < vertexCount)
             {
                 _vertices = new Vector3[vertexCount];
@@ -801,67 +1189,69 @@ namespace PSXPrev.Common.Parsers
             for (uint j = 0; j < vertexCount; j++)
             {
                 // Vertex coding:
-                // pad =  0: Normal vertex
-                // pad =  1: Attachable vertex, file-wide counter as the index
-                // pad =  2: Attached vertex,   Y is the index of the attachable (not vertex index)
-                //                              X and Z are zero
-                // pad =  4: Unknown            X, Y, and Z are not indexes, and may be negative
-                // pad = 16: Sprite vertex,     X is a byte offset to the sprite center vertex (always 0,8,16,24)
-                //                              Y is a byte offset to a vertex (usually 16,16,0,0, rarely 24,24,8,8)
-                //                              Z value is the width of the sprite with some awkward behavior, not fully understood
+                // It's possible that type is actually flags, since all encountered types are powers of 2.
+                // However most types wouldn't make sense to use together.
+                // type =  0: Normal vertex
+                // type =  1: Attachable vertex, file-wide counter as the index
+                // type =  2: Attached vertex,   Y is the index of the attachable (not vertex index)
+                //                               X and Z are zero
+                // type =  4: Unknown            X, Y, and Z are not indexes, and may be negative
+                // type = 16: Sprite vertex,     X is a byte offset to the sprite center vertex (always 0,8,16,24)
+                //                               Y is a byte offset to a vertex (usually 16,16,0,0, rarely 24,24,8,8)
+                //                               Z value is the width of the sprite with some awkward behavior, not fully understood
                 var x = reader.ReadInt16();
                 var y = reader.ReadInt16();
                 var z = reader.ReadInt16();
-                var pad = reader.ReadUInt16();
-                var vertex = new Vector3(x / _scaleDivisor, y / _scaleDivisor, z / _scaleDivisor);
-                var jointID = Triangle.NoJoint;
+                var type = reader.ReadUInt16();
+                _vertices[j] = new Vector3(x / _scaleDivisor, y / _scaleDivisor, z / _scaleDivisor);
+                _vertexJoints[j] = Triangle.NoJoint;
 
-                if (pad == 1)
+                if (type == 1)
                 {
-                    _modelIsJoint = true;
+                    // Already handled in ReadMesh
                 }
-                else if (pad == 2)
+                else if (type == 2)
                 {
                     // Note that this isn't a Joint ID, just a .PSX attachment index ID.
                     var attachmentIndex = (ushort)y;
                     if (_attachableVertices.TryGetValue(attachmentIndex, out var tuple))
                     {
-                        vertex = tuple.Item2;
-                        jointID = tuple.Item1;
+                        _vertices[j] = tuple.Item2;
+                        _vertexJoints[j] = tuple.Item1;
                     }
                     else
                     {
                         var breakHere = 0;
                     }
                 }
-                else if (pad == 4)
+                else if (type == 4)
                 {
                     // Observed in Apocalypse, not sure what to do with this
                     var breakHere = 0;
                 }
-                else if (pad == 16)
+                else if (type == 16)
                 {
-                    var indexB = (ushort)x / 8u;
+                    var indexB = (ushort)x / 8u; // 8 is the byte length of each vertex
                     var indexA = (ushort)y / 8u;
                     if ((ushort)x % 8u != 0 || (ushort)y % 8u != 0 || indexA >= vertexCount || indexB >= vertexCount)
                     {
                         return false;
                     }
-                    _spriteVertices[j] = new PSXSpriteVertexData
+                    _spriteVertices.Add(j, new PSXSpriteVertexData
                     {
                         IndexA = indexA,
                         IndexB = indexB,
                         Width = z / _scaleDivisor,
-                    };
+                    });
                 }
-                else if (pad != 0)
+                else if (type != 0)
                 {
                     var breakHere = 0;
                 }
-                _vertices[j] = vertex;
-                _vertexJoints[j] = jointID;
             }
 
+
+            // Read mesh normals
             if (_normals == null || _normals.Length < normalCount)
             {
                 _normals = new Vector3[normalCount];
@@ -881,8 +1271,8 @@ namespace PSXPrev.Common.Parsers
 
             // I've seen version 0x03 in Apocalypse, and there didn't seem to be fields like this before the faces.
             // Leaving in-case this exists somewhere else...
-            //uint faceFlags  = 0;
-            //uint faceLength = 0;
+            //ushort faceFlags  = 0;
+            //ushort faceLength = 0;
             //if (version == 0x03)
             //{
             //    faceFlags  = reader.ReadUInt16();
@@ -890,268 +1280,336 @@ namespace PSXPrev.Common.Parsers
             //}
             for (uint j = 0; j < faceCount; j++)
             {
-                var facePosition = reader.BaseStream.Position;
-
-                var renderFlags = RenderFlags.None;
-                var mixtureRate = MixtureRate.None;
-
-                var faceFlags  = reader.ReadUInt16();
-                var faceLength = reader.ReadUInt16();
-                var quad      = (faceFlags & 0x0010) == 0;
-                var gouraud   = (faceFlags & 0x0800) != 0;
-                var textured  = (faceFlags & 0x0003) != 0;
-                var semiTrans = (faceFlags & 0x01c0) >> 6;
-                //var subdivision = (faceFlags & 0x1000) != 0;
-
-                var i0 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
-                var i1 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
-                var i2 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
-                var i3 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
-                if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount || (quad && i3 >= vertexCount))
+                if (!ReadPrimitive(reader, version, modelIndex, vertexCount, normalCount))
                 {
-                    return false; //throw new IndexOutOfRangeException("Vertex index out of bounds");
-                }
-                var vertex0 = _vertices[i0];
-                var vertex1 = _vertices[i1];
-                var vertex2 = _vertices[i2];
-                var vertex3 = quad ? _vertices[i3] : Vector3.Zero;
-
-                Vector3? spriteCenter = null;
-                var hasSpr0 = _spriteVertices.TryGetValue(i0, out var spr0);
-                var hasSpr1 = _spriteVertices.TryGetValue(i1, out var spr1);
-                var hasSpr2 = _spriteVertices.TryGetValue(i2, out var spr2);
-                var hasSpr3 = _spriteVertices.TryGetValue(i3, out var spr3);
-                if (hasSpr0 && hasSpr1 && hasSpr2 && (!quad || hasSpr3))
-                {
-                    // Not really sure how to properly use IndexA vs. IndexB...
-                    var avertex0 = _vertices[spr0.IndexA];
-                    var bvertex0 = _vertices[spr0.IndexB];
-                    var avertex1 = _vertices[spr1.IndexA];
-                    var bvertex1 = _vertices[spr1.IndexB];
-                    var avertex2 = _vertices[spr2.IndexA];
-                    var bvertex2 = _vertices[spr2.IndexB];
-                    var avertex3 = quad ? _vertices[spr3.IndexA] : Vector3.Zero;
-                    var bvertex3 = quad ? _vertices[spr3.IndexB] : Vector3.Zero;
-                    bool Check(Vector3 va, Vector3 vb)
-                    {
-                        return va.X != 0f || va.Z != 0f || vb.X != 0f || vb.Z != 0f;
-                    }
-                    if (Check(avertex0, bvertex0) || Check(avertex1, bvertex1) || Check(avertex2, bvertex2) || (quad && Check(avertex3, bvertex3)))
-                    {
-                        var breakHere = 0;
-                    }
-
-                    spriteCenter = (avertex0 + avertex1 + avertex2 + (quad ? avertex3 : Vector3.Zero));
-                    spriteCenter /= (quad ? 4 : 3);
-
-                    var scale = 1.5f;
-                    // Remember that Y-up is negative, so height values are negated compared to what we set for UVs.
-                    // Note that these vertex coordinates also assume the default orientation of the view is (0, 0, -1).
-                    // These numbers are kind of fudged, but it's the only way I
-                    // could get the sprites working purely from the values given.
-                    vertex0 = avertex0 + new Vector3(-spr0.Width * scale, 0f, 0f);
-                    vertex1 = avertex1 + new Vector3(-spr1.Width * scale, 0f, 0f);
-                    vertex2 = avertex2 + new Vector3(spr2.Width * scale, 0f, 0f);
-                    vertex3 = avertex3 + new Vector3(spr3.Width * scale, 0f, 0f);
-
-                    // todo: Double-sided sprites until this is less jank.
-                    // I've encountered sprites that were backwards.
-                    // Known places where this fails without double-sided:
-                    // * THPS2, CD.WAD_1B36000 courtyard trees
-                    renderFlags |= RenderFlags.SpriteNoPitch | RenderFlags.DoubleSided;
-                }
-                else if (hasSpr0 || hasSpr1 || hasSpr2 || (quad && hasSpr3))
-                {
-                    var breakHere = 0;
-                }
-
-                var joint0 = _vertexJoints[i0];
-                var joint1 = _vertexJoints[i1];
-                var joint2 = _vertexJoints[i2];
-                var joint3 = quad ? _vertexJoints[i3] : Triangle.NoJoint;
-
-                Color color0, color1, color2, color3;
-                var r = reader.ReadByte();
-                var g = reader.ReadByte();
-                var b = reader.ReadByte();
-                var mode = reader.ReadByte();
-                if (!gouraud)
-                {
-                    color0 = color1 = color2 = color3 = new Color(r / 255f, g / 255f, b / 255f);
-                }
-                else if (r < _gouraudPaletteSize && g < _gouraudPaletteSize && b < _gouraudPaletteSize && (!quad || mode < _gouraudPaletteSize))
-                {
-                    // R/G/B/Mode are treated as indices into gouraud palette table
-                    color0 = _gouraudPalette[r];
-                    color1 = _gouraudPalette[g];
-                    color2 = _gouraudPalette[b];
-                    color3 = quad ? _gouraudPalette[mode] : Color.Grey;
-                }
-                else
-                {
-                    // Gouraud but no (or too small) palette table, this shouldn't happen
-                    //color0 = color1 = color2 = color3 = Color.Grey;
                     return false;
                 }
-
-                var normalIndex = reader.ReadUInt16();
-                var surfFlags = reader.ReadInt16(); // How the player can interact with this surface, not important
-                if (normalIndex >= normalCount)
-                {
-                    return false; //throw new IndexOutOfRangeException("Normal index out of bounds");
-                }
-                var normal0 = _normals[normalIndex];
-                var normal1 = _normals[normalIndex];
-                var normal2 = _normals[normalIndex];
-                var normal3 = quad ? _normals[normalIndex] : Vector3.Zero;
-
-                var invisible = false;
-                switch (semiTrans)
-                {
-                    case 0x0: // Opaque
-                        break;
-                    case 0x1:
-                        renderFlags |= RenderFlags.SemiTransparent;
-                        mixtureRate = MixtureRate.Back50_Poly50;
-                        invisible = false;
-                        break;
-                    case 0x2: // Invisible, likely for map triggers and behavioral objects
-                        invisible = true;
-                        break;
-                    case 0x3:
-                        renderFlags |= RenderFlags.SemiTransparent;
-                        mixtureRate = MixtureRate.Back100_Poly100;
-                        invisible = false;
-                        break;
-                    case 0x4: // Never observed, effect unknown
-                        break;
-                    case 0x5:
-                        renderFlags |= RenderFlags.SemiTransparent;
-                        mixtureRate = MixtureRate.Back100_PolyM100;
-                        invisible = false;
-                        break;
-                    case 0x6: // Never observed, effect unknown
-                        break;
-                    case 0x7:
-                        renderFlags |= RenderFlags.SemiTransparent;
-                        mixtureRate = MixtureRate.Back100_Poly25;
-                        invisible = false;
-                        break;
-                }
-
-                uint tPage = 0;
-                Vector2 uv0, uv1, uv2, uv3;
-                if (textured)
-                {
-                    renderFlags |= RenderFlags.Textured;
-                    var textureIndex = reader.ReadUInt32();
-                    if (textureIndex < _textureHashCount)
-                    {
-                        tPage = _textureHashes[textureIndex];
-                    }
-                    var u0 = reader.ReadByte();
-                    var v0 = reader.ReadByte();
-                    var u1 = reader.ReadByte();
-                    var v1 = reader.ReadByte();
-                    var u2 = reader.ReadByte();
-                    var v2 = reader.ReadByte();
-                    var u3 = reader.ReadByte();
-                    var v3 = reader.ReadByte();
-                    uv0 = GeomMath.ConvertUV(u0, v0);
-                    uv1 = GeomMath.ConvertUV(u1, v1);
-                    uv2 = GeomMath.ConvertUV(u2, v2);
-                    uv3 = GeomMath.ConvertUV(u3, v3);
-                }
-                else
-                {
-                    uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
-                }
-
-                if (!invisible || Settings.Instance.AdvancedPSXIncludeInvisible)
-                {
-#if DEBUG
-                    var extraLength = faceLength - (reader.BaseStream.Position - facePosition);
-                    var triangle1DebugData = new List<string>
-                    {
-                        $"faceFlags: 0x{faceFlags:x04}",
-                        $"surfFlags: 0x{surfFlags:x04}",
-                        $"extraLength: {extraLength}",
-                        $"Position: 0x{reader.BaseStream.Position:x}",
-                    };
-                    var triangle2DebugData = new List<string>(triangle1DebugData);
-#endif
-
-                    var modelJointID = modelIndex + 1u;
-
-                    var originalNormalIndices = new uint[] { normalIndex, normalIndex, normalIndex };
-                    //var joints1 = Triangle.CreateJoints(joint0, joint1, joint2, modelJointID);
-                    var triangle1 = new Triangle
-                    {
-                        Vertices = new[] { vertex0, vertex1, vertex2 },
-                        Normals = new[] { normal0, normal1, normal2 },
-                        Uv = new[] { uv0, uv1, uv2 },
-                        Colors = new[] { color0, color1, color2 },
-                        OriginalVertexIndices = new uint[] { i0, i1, i2 },
-                        OriginalNormalIndices = originalNormalIndices,
-                        // Use helper functions to avoid allocating an array if all are "no attachments"
-                        VertexJoints = Triangle.CreateJoints(joint0, joint1, joint2, modelJointID),
-                        NormalJoints = Triangle.CreateJoints(joint0, joint1, joint2, modelJointID),
-#if DEBUG
-                        DebugData = triangle1DebugData.ToArray(),
-#endif
-                    };
-                    if (textured)
-                    {
-                        triangle1.TiledUv = new TiledUV(triangle1.Uv, 0f, 0f, 1f, 1f);
-                        triangle1.Uv = (Vector2[])triangle1.Uv.Clone();
-                    }
-                    AddTriangle(triangle1, spriteCenter, tPage, renderFlags, mixtureRate);
-
-                    if (quad)
-                    {
-                        //var joints2 = Triangle.CreateJoints(joint1, joint3, joint2, modelJointID);
-                        var triangle2 = new Triangle
-                        {
-                            Vertices = new[] { vertex1, vertex3, vertex2 },
-                            Normals = new[] { normal1, normal3, normal2 },
-                            Uv = new[] { uv1, uv3, uv2 },
-                            Colors = new[] { color1, color3, color2 },
-                            OriginalVertexIndices = new uint[] { i1, i3, i2 },
-                            OriginalNormalIndices = originalNormalIndices,
-                            // Use helper functions to avoid allocating an array if all are "no attachments"
-                            VertexJoints = Triangle.CreateJoints(joint1, joint3, joint2, modelJointID),
-                            NormalJoints = Triangle.CreateJoints(joint1, joint3, joint2, modelJointID),
-#if DEBUG
-                            DebugData = triangle2DebugData.ToArray(),
-#endif
-                        };
-                        if (textured)
-                        {
-                            triangle2.TiledUv = new TiledUV(triangle2.Uv, 0f, 0f, 1f, 1f);
-                            triangle2.Uv = (Vector2[])triangle2.Uv.Clone();
-                        }
-                        AddTriangle(triangle2, spriteCenter, tPage, renderFlags, mixtureRate);
-                    }
-                }
-
-                reader.BaseStream.Seek(facePosition + faceLength, SeekOrigin.Begin);
             }
 
             FlushModels(objectIndex, modelIndex);
             return true;
         }
 
+        private bool ReadPrimitive(BinaryReader reader, ushort version, uint modelIndex, uint vertexCount, uint normalCount)
+        {
+            var facePosition = reader.BaseStream.Position;
+
+            var renderFlags = RenderFlags.None;
+            var mixtureRate = MixtureRate.None;
+            var invisible = false;
+
+            var faceFlags  = reader.ReadUInt16();
+            var faceLength = reader.ReadUInt16();
+
+            const ushort KnownFlags = 0x19d3;
+            var texCoord  = (faceFlags & 0x0001) != 0; // +12 extra bytes (textureIndex, uv0-3)
+            var texLookup = (faceFlags & 0x0002) != 0;
+            var textured  = texCoord || texLookup;
+            //var flag0004  = (faceFlags & 0x0004) != 0;
+            var flag0008  = (faceFlags & 0x0008) != 0; // +8 extra bytes (ushort[4], always set with 0x4, seems to be used for actor models)
+            var quad      = (faceFlags & 0x0010) == 0;
+            var flag0020  = (faceFlags & 0x0020) != 0; // +4 extra bytes (extra bytes are always zero... maybe a working field?)
+            var semiTrans = (faceFlags & 0x0040) != 0;
+            var transMode = (faceFlags & 0x0180) >> 7; // Effect depends on semiTrans
+            //var flag0200  = (faceFlags & 0x0200) != 0;
+            //var flag0400  = (faceFlags & 0x0400) != 0;
+            var gouraud   = (faceFlags & 0x0800) != 0;
+            //var subdiv    = (faceFlags & 0x1000) != 0;
+            //var flag2000  = (faceFlags & 0x2000) != 0;
+            //var flag4000  = (faceFlags & 0x4000) != 0;
+
+
+            uint i0 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+            uint i1 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+            uint i2 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+            uint i3 = version == 0x04 ? reader.ReadByte() : reader.ReadUInt16();
+            if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount || (quad && i3 >= vertexCount))
+            {
+                return false;
+            }
+
+            var r = reader.ReadByte();
+            var g = reader.ReadByte();
+            var b = reader.ReadByte();
+            var mode = reader.ReadByte();
+            if (gouraud && (r >= _gouraudCount || g >= _gouraudCount || b >= _gouraudCount || (quad && mode >= _gouraudCount)))
+            {
+                return false;
+            }
+
+            uint normalIndex = reader.ReadUInt16();
+            var surfFlags = reader.ReadInt16(); // How the player can interact with this surface, not important
+            if (normalIndex >= normalCount)
+            {
+                return false;
+            }
+
+            uint textureIndex = 0;
+            byte u0 = 0, v0 = 0, u1 = 0, v1 = 0, u2 = 0, v2 = 0, u3 = 0, v3 = 0;
+            if (texCoord)
+            {
+                textureIndex = reader.ReadUInt32();
+                u0 = reader.ReadByte();
+                v0 = reader.ReadByte();
+                u1 = reader.ReadByte();
+                v1 = reader.ReadByte();
+                u2 = reader.ReadByte();
+                v2 = reader.ReadByte();
+                u3 = reader.ReadByte();
+                v3 = reader.ReadByte();
+            }
+
+            ushort f8_0 = 0, f8_1 = 0, f8_2 = 0, f8_3 = 0;
+            if (flag0008)
+            {
+                // These are definitely ushorts. For example:
+                // f8_0 was observed as a non-zero non-minus-one value, while all other values were -1.
+                // Often times all of these values are zero, but otherwise they can be under a byte's max value,
+                // or over a short's max value.
+                f8_0 = reader.ReadUInt16();
+                f8_1 = reader.ReadUInt16();
+                f8_2 = reader.ReadUInt16();
+                f8_3 = reader.ReadUInt16();
+            }
+
+            uint f20 = 0;
+            if (texCoord && flag0020)
+            {
+                // Only ever observed as zero, this may be a working field added to aid in whatever this flag actually does.
+                // In Apocalyse pest_obj.psx where texCoord wasn't set, this field was skipped in faceLength.
+                f20 = reader.ReadUInt32();
+            }
+
+
+            var vertex0 = _vertices[i0];
+            var vertex1 = _vertices[i1];
+            var vertex2 = _vertices[i2];
+            var vertex3 = quad ? _vertices[i3] : Vector3.Zero;
+
+            var joint0 = _vertexJoints[i0];
+            var joint1 = _vertexJoints[i1];
+            var joint2 = _vertexJoints[i2];
+            var joint3 = quad ? _vertexJoints[i3] : Triangle.NoJoint;
+
+            Vector3? spriteCenter = null;
+            var hasSpr0 = _spriteVertices.TryGetValue(i0, out var spr0);
+            var hasSpr1 = _spriteVertices.TryGetValue(i1, out var spr1);
+            var hasSpr2 = _spriteVertices.TryGetValue(i2, out var spr2);
+            var hasSpr3 = _spriteVertices.TryGetValue(i3, out var spr3);
+            if (hasSpr0 && hasSpr1 && hasSpr2 && (!quad || hasSpr3))
+            {
+                if (!quad)
+                {
+                    var breakHere = 0;
+                }
+                // Not really sure how to properly use IndexA vs. IndexB...
+                var ia0 = spr0.IndexA;
+                var ib0 = spr0.IndexB;
+                var ia1 = spr1.IndexA;
+                var ib1 = spr1.IndexB;
+                var ia2 = spr2.IndexA;
+                var ib2 = spr2.IndexB;
+                var ia3 = spr3.IndexA;
+                var ib3 = spr3.IndexB;
+                if (ia0 >= vertexCount || ia1 >= vertexCount || ia2 >= vertexCount || (quad && ia3 >= vertexCount))
+                {
+                    return false;
+                }
+                if (ib0 >= vertexCount || ib1 >= vertexCount || ib2 >= vertexCount || (quad && ib3 >= vertexCount))
+                {
+                    return false;
+                }
+                var avertex0 = _vertices[ia0];
+                var bvertex0 = _vertices[ib0];
+                var avertex1 = _vertices[ia1];
+                var bvertex1 = _vertices[ib1];
+                var avertex2 = _vertices[ia2];
+                var bvertex2 = _vertices[ib2];
+                var avertex3 = quad ? _vertices[ia3] : Vector3.Zero;
+                var bvertex3 = quad ? _vertices[ib3] : Vector3.Zero;
+#if DEBUG
+                bool Check(Vector3 va, Vector3 vb)
+                {
+                    return va.X != 0f || va.Z != 0f || vb.X != 0f || vb.Z != 0f;
+                }
+                if (Check(avertex0, bvertex0) || Check(avertex1, bvertex1) || Check(avertex2, bvertex2) || (quad && Check(avertex3, bvertex3)))
+                {
+                    var breakHere = 0;
+                }
+#endif
+
+                spriteCenter = (avertex0 + avertex1 + avertex2 + (quad ? avertex3 : Vector3.Zero));
+                spriteCenter /= (quad ? 4 : 3);
+
+                var scale = 1.5f;
+                // Remember that Y-up is negative, so height values are negated compared to what we set for UVs.
+                // Note that these vertex coordinates also assume the default orientation of the view is (0, 0, -1).
+                // These numbers are kind of fudged, but it's the only way I
+                // could get the sprites working purely from the values given.
+                vertex0 = avertex0 + new Vector3(-spr0.Width * scale, 0f, 0f);
+                vertex1 = avertex1 + new Vector3(-spr1.Width * scale, 0f, 0f);
+                vertex2 = avertex2 + new Vector3(spr2.Width * scale, 0f, 0f);
+                vertex3 = avertex3 + new Vector3(spr3.Width * scale, 0f, 0f); // todo: What about when we're not a quad?
+
+                // todo: Double-sided sprites until this is less jank.
+                // I've encountered sprites that were backwards.
+                // Known places where this fails without double-sided:
+                // * THPS2, CD.WAD_1B36000 courtyard trees
+                renderFlags |= RenderFlags.SpriteNoPitch | RenderFlags.DoubleSided;
+            }
+            else if (hasSpr0 || hasSpr1 || hasSpr2 || (quad && hasSpr3))
+            {
+                var breakHere = 0;
+            }
+
+            var normal = _normals[normalIndex];
+
+            Color color0, color1, color2, color3;
+            if (!gouraud)
+            {
+                color0 = color1 = color2 = color3 = new Color(r / 255f, g / 255f, b / 255f);
+            }
+            else
+            {
+                // R/G/B/Mode are treated as indices into gouraud palette table
+                color0 = _gouraudPalette[r];
+                color1 = _gouraudPalette[g];
+                color2 = _gouraudPalette[b];
+                color3 = quad ? _gouraudPalette[mode] : Color.Grey;
+            }
+
+            uint tPage = 0;
+            Vector2 uv0, uv1, uv2, uv3;
+            if (textured)
+            {
+                renderFlags |= RenderFlags.Textured;
+                if (!texCoord)
+                {
+                    tPage = uint.MaxValue; // Arbitrary value that hopefully doesn't exist
+                }
+                else if (textureIndex < _textureHashCount)
+                {
+                    tPage = _textureHashes[textureIndex];
+                }
+                uv0 = GeomMath.ConvertUV(u0, v0);
+                uv1 = GeomMath.ConvertUV(u1, v1);
+                uv2 = GeomMath.ConvertUV(u2, v2);
+                uv3 = quad ? GeomMath.ConvertUV(u3, v3) : Vector2.Zero;
+            }
+            else
+            {
+                uv0 = uv1 = uv2 = uv3 = Vector2.Zero;
+            }
+
+            // semiTrans: 0-Normal, 1-Semi-transparent
+            // transMode: 0-Opaque, 1-Invisible, 2-unused(?), 3-unused(?)
+            //            0-50% back + 50% poly, 1-100% back + 100% poly, 2-100% back - 100% poly, 3-100% back + 25% poly
+            if (!semiTrans)
+            {
+                switch (transMode)
+                {
+                    case 0: break; // Opaque
+                    case 1: invisible = true; break; // Invisible
+                    case 2:
+                        break; // Probably unused
+                    case 3:
+                        break; // Probably unused
+                }
+            }
+            else
+            {
+                renderFlags |= RenderFlags.SemiTransparent;
+                switch (transMode)
+                {
+                    case 0: mixtureRate = MixtureRate.Back50_Poly50; break;
+                    case 1: mixtureRate = MixtureRate.Back100_Poly100; break;
+                    case 2: mixtureRate = MixtureRate.Back100_PolyM100; break;
+                    case 3: mixtureRate = MixtureRate.Back100_Poly25; break;
+                }
+            }
+
+
+            if (!invisible || Settings.Instance.AdvancedPSXIncludeInvisible)
+            {
+#if DEBUG
+                var extraLength = faceLength - (reader.BaseStream.Position - facePosition);
+                var triangleDebugData = new[]
+                {
+                    $"faceFlags: 0x{faceFlags:x04}",
+                    $"surfFlags: 0x{surfFlags:x04}",
+                    $"extraLength: {extraLength}",
+                    $"Position: 0x{reader.BaseStream.Position:x}",
+                };
+#endif
+
+                var modelJointID = modelIndex + 1u;
+
+                var originalNormalIndices = new[] { normalIndex, normalIndex, normalIndex };
+                var joints1 = Triangle.CreateJoints(joint0, joint1, joint2, modelJointID);
+                var triangle1 = new Triangle
+                {
+                    Vertices = new[] { vertex0, vertex1, vertex2 },
+                    Normals = new[] { normal, normal, normal },
+                    Uv = new[] { uv0, uv1, uv2 },
+                    Colors = new[] { color0, color1, color2 },
+                    OriginalVertexIndices = new[] { i0, i1, i2 },
+                    OriginalNormalIndices = originalNormalIndices,
+                    VertexJoints = joints1,
+                    NormalJoints = (uint[])joints1?.Clone(),
+#if DEBUG
+                    DebugData = triangleDebugData,
+#endif
+                };
+                if (textured)
+                {
+                    triangle1.TiledUv = new TiledUV(triangle1.Uv, 0f, 0f, 1f, 1f);
+                    triangle1.Uv = (Vector2[])triangle1.Uv.Clone();
+                }
+                AddTriangle(triangle1, spriteCenter, tPage, renderFlags, mixtureRate);
+
+                if (quad)
+                {
+                    var joints2 = Triangle.CreateJoints(joint1, joint3, joint2, modelJointID);
+                    var triangle2 = new Triangle
+                    {
+                        Vertices = new[] { vertex1, vertex3, vertex2 },
+                        Normals = new[] { normal, normal, normal },
+                        Uv = new[] { uv1, uv3, uv2 },
+                        Colors = new[] { color1, color3, color2 },
+                        OriginalVertexIndices = new[] { i1, i3, i2 },
+                        OriginalNormalIndices = originalNormalIndices,
+                        VertexJoints = joints2,
+                        NormalJoints = (uint[])joints2?.Clone(),
+#if DEBUG
+                        DebugData = triangleDebugData,
+#endif
+                    };
+                    if (textured)
+                    {
+                        triangle2.TiledUv = new TiledUV(triangle2.Uv, 0f, 0f, 1f, 1f);
+                        triangle2.Uv = (Vector2[])triangle2.Uv.Clone();
+                    }
+                    AddTriangle(triangle2, spriteCenter, tPage, renderFlags, mixtureRate);
+                }
+            }
+
+            reader.BaseStream.Seek(facePosition + faceLength, SeekOrigin.Begin);
+            return true;
+        }
+
         private void FlushModels(uint objectIndex, uint modelIndex)
         {
-            var psxObject = _objects[objectIndex];
+            var psxObject = _psxObjects[objectIndex];
+            var psxMesh = _psxMeshes[modelIndex];
+            var modelIsJoint = psxMesh.IsJoint;
 #if DEBUG
-            _modelDebugData.TryGetValue(objectIndex, out var modelDebugData);
-            modelDebugData?.Insert(0, $"objectIndex: {objectIndex}");
-            modelDebugData?.Insert(1, $"modelIndex: {psxObject.ModelIndex}");
+            _objectDebugData.TryGetValue(objectIndex, out var objectDebugData);
+            objectDebugData?.Insert(0, $"objectIndex: {objectIndex}");
+            objectDebugData?.Insert(1, $"modelIndex: {psxObject.MeshIndex}");
 #endif
-            //var coord = _coords[i];
-            //var localMatrix = coord.WorldMatrix;
-            var localMatrix = Matrix4.CreateTranslation(psxObject.Translation);
+
+            var localMatrix = _coords[objectIndex].WorldMatrix;
+            //var localMatrix = Matrix4.CreateTranslation(psxObject.Translation);
 
             foreach (var kvp in _groupedTriangles)
             {
@@ -1168,11 +1626,13 @@ namespace PSXPrev.Common.Parsers
                     JointID = modelIndex + 1u,
                     OriginalLocalMatrix = localMatrix,
 #if DEBUG
-                    DebugData = modelDebugData?.ToArray(),
+                    DebugData = objectDebugData?.ToArray(),
 #endif
                 };
                 _models.Add(model);
-                _modelIsJoint = false;
+                // We can add attachable indices onto this existing model, instead of adding a dummy model.
+                // A model is used so that it can transform the attachable vertices.
+                modelIsJoint = false;
             }
             foreach (var kvp in _groupedSprites)
             {
@@ -1190,13 +1650,14 @@ namespace PSXPrev.Common.Parsers
                     TMDID = objectIndex + 1u,
                     OriginalLocalMatrix = localMatrix,
 #if DEBUG
-                    DebugData = modelDebugData?.ToArray(),
+                    DebugData = objectDebugData?.ToArray(),
 #endif
                 };
                 _models.Add(spriteModel);
             }
-            if (_modelIsJoint)
+            if (modelIsJoint)
             {
+                // No models were added for this model index, add a dummy model to serve as the joint transform.
                 var jointModel = new ModelEntity
                 {
                     Triangles = new Triangle[0],
@@ -1206,11 +1667,11 @@ namespace PSXPrev.Common.Parsers
                     Visible = false,
                     OriginalLocalMatrix = localMatrix,
 #if DEBUG
-                    DebugData = modelDebugData?.ToArray(),
+                    DebugData = objectDebugData?.ToArray(),
 #endif
                 };
                 _models.Add(jointModel);
-                _modelIsJoint = false;
+                modelIsJoint = false;
             }
             _groupedTriangles.Clear();
             _groupedSprites.Clear();
@@ -1263,7 +1724,17 @@ namespace PSXPrev.Common.Parsers
         private struct PSXObject
         {
             public Vector3 Translation;
-            public ushort ModelIndex;
+            public ushort MeshIndex;
+        }
+
+        private class PSXMesh
+        {
+            public uint MeshTop;
+            public uint VertexStart;
+            public uint NormalStart;
+            public bool IsJoint;
+            public ushort LODNextMeshIndex;
+            public short LODDepth;
         }
 
         private struct PSXClutData

--- a/Common/Renderer/LineMeshBuilder.cs
+++ b/Common/Renderer/LineMeshBuilder.cs
@@ -103,7 +103,7 @@ namespace PSXPrev.Common.Renderer
             var modelEntity = CreateModelEntity(modelMatrix);
             var rootEntity = new RootEntity
             {
-                EntityName = rootEntityName ?? nameof(RootEntity),
+                Name = rootEntityName ?? nameof(RootEntity),
                 ChildEntities = new EntityBase[] { modelEntity },
             };
             return rootEntity;

--- a/Common/Renderer/MeshBatch.cs
+++ b/Common/Renderer/MeshBatch.cs
@@ -776,12 +776,6 @@ namespace PSXPrev.Common.Renderer
         public Mesh BindTriangleMesh(TriangleMeshBuilder triangleBuilder, out Skin skin, Matrix4? matrix = null, bool updateMeshData = true, Mesh sourceMesh = null, Skin sourceSkin = null)
         {
             skin = null;
-            if (triangleBuilder.Count == 0)
-            {
-                MeshIndex++; // Still consume the mesh index
-                return null;
-            }
-
             var mesh = GetMesh(MeshIndex++, sourceMesh);
             if (mesh == null)
             {
@@ -809,12 +803,6 @@ namespace PSXPrev.Common.Renderer
 
         public Mesh BindLineMesh(LineMeshBuilder lineBuilder, Matrix4? matrix = null, bool updateMeshData = true, Mesh sourceMesh = null)
         {
-            if (lineBuilder.Count == 0)
-            {
-                MeshIndex++; // Still consume the mesh index
-                return null;
-            }
-
             var mesh = GetMesh(MeshIndex++, sourceMesh);
             if (mesh == null)
             {

--- a/Common/Renderer/TriangleMeshBuilder.cs
+++ b/Common/Renderer/TriangleMeshBuilder.cs
@@ -135,7 +135,7 @@ namespace PSXPrev.Common.Renderer
             var modelEntity = CreateModelEntity(modelMatrix);
             var rootEntity = new RootEntity
             {
-                EntityName = rootEntityName ?? nameof(RootEntity),
+                Name = rootEntityName ?? nameof(RootEntity),
                 ChildEntities = new EntityBase[] { modelEntity },
             };
             return rootEntity;

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -81,7 +81,7 @@ namespace PSXPrev.Common.Renderer
                     // X coordinates [0,256) store texture data.
                     // X coordinates [256,512) store semi-transparency information for textures.
                     _vramPages[i] = new Texture(PageSize * 2, PageSize, 0, 0, 32, i, 0, null, null, true); // Is VRAM page
-                    _vramPages[i].TextureName = $"VRAM[{i}]";
+                    _vramPages[i].Name = $"VRAM[{i}]";
                     ClearPage(i, suppressUpdate);
                 }
             }

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -50,7 +50,7 @@ namespace PSXPrev.Common
             Y = fromTexture.Y;
             TexturePage = fromTexture.TexturePage;
             IsVRAMPage = fromTexture.IsVRAMPage;
-            TextureName = fromTexture.TextureName;
+            Name = fromTexture.Name;
             FormatName = fromTexture.FormatName;
             FileOffset = fromTexture.FileOffset;
             ResultIndex = fromTexture.ResultIndex;
@@ -91,7 +91,7 @@ namespace PSXPrev.Common
         }
 
         [DisplayName("Name")]
-        public string TextureName { get; set; }
+        public string Name { get; set; }
 
         [DisplayName("Format"), ReadOnly(true)]
         public string FormatName { get; set; }
@@ -193,7 +193,7 @@ namespace PSXPrev.Common
 
         public override string ToString()
         {
-            var name = TextureName ?? nameof(Texture);
+            var name = Name ?? nameof(Texture);
             return $"{name} {Width}x{Height} {Bpp}bpp";
         }
 

--- a/Forms/Dialogs/SelectRootEntityDialog.cs
+++ b/Forms/Dialogs/SelectRootEntityDialog.cs
@@ -16,7 +16,7 @@ namespace PSXPrev.Forms.Dialogs
                 entitiesListBox.Items.Clear();
                 foreach (var entity in _rootEntities)
                 {
-                    entitiesListBox.Items.Add(entity.EntityName ?? nameof(RootEntity));
+                    entitiesListBox.Items.Add(entity.Name ?? nameof(RootEntity));
                 }
             }
         }

--- a/Forms/ExportModelsForm.cs
+++ b/Forms/ExportModelsForm.cs
@@ -38,7 +38,7 @@ namespace PSXPrev.Forms
                 {
                     foreach (var animation in _animations)
                     {
-                        checkedAnimationsListBox.Items.Add(animation.AnimationName);
+                        checkedAnimationsListBox.Items.Add(animation.Name);
                     }
                 }
                 else

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -152,6 +152,12 @@ namespace PSXPrev.Forms
             _animationBatch = new AnimationBatch(_scene);
             _texturesListViewAdaptor = new TexturesListViewItemAdaptor(this);
             Toolkit.Init();
+            // todo: It's observed in GLControl's source that this is called with PreferNative in the control's constructor.
+            // Maybe we should be using it here too, since our init will prevent GLControl's init from choosing its preferred backend.
+            //Toolkit.Init(new ToolkitOptions
+            //{
+            //    Backend = PlatformBackend.PreferNative,
+            //});
             InitializeComponent();
             SetupControls();
         }
@@ -1595,7 +1601,7 @@ namespace PSXPrev.Forms
         private TreeNode CreateRootEntityNode(RootEntity rootEntity, int rootIndex)
         {
             var loaded = rootEntity.ChildEntities.Length == 0;
-            var rootEntityNode = new TreeNode(rootEntity.EntityName)
+            var rootEntityNode = new TreeNode(rootEntity.Name)
             {
                 Tag = new EntitiesTreeViewTagInfo
                 {
@@ -1613,7 +1619,7 @@ namespace PSXPrev.Forms
 
         private TreeNode CreateModelEntityNode(EntityBase modelEntity, int rootIndex, int childIndex)
         {
-            var modelNode = new TreeNode(modelEntity.EntityName)
+            var modelNode = new TreeNode(modelEntity.Name)
             {
                 Tag = new EntitiesTreeViewTagInfo
                 {
@@ -1677,7 +1683,7 @@ namespace PSXPrev.Forms
             var textureItem = new ImageListViewItem(key)
             {
                 //Text = index.ToString(), //debug
-                Text = texture.TextureName,
+                Text = texture.Name,
                 Tag = new TexturesListViewTagInfo
                 {
                     //Texture = texture,
@@ -1715,7 +1721,7 @@ namespace PSXPrev.Forms
         private TreeNode CreateAnimationNode(Animation animation, int rootIndex)
         {
             var loaded = animation.RootAnimationObject.Children.Count == 0;
-            var animationNode = new TreeNode(animation.AnimationName)
+            var animationNode = new TreeNode(animation.Name)
             {
                 Tag = new AnimationsTreeViewTagInfo
                 {
@@ -3126,7 +3132,7 @@ namespace PSXPrev.Forms
             var selectedEntityBase = GetSelectedEntityBase();
             if (selectedEntityBase != null)
             {
-                selectedNode.Text = selectedEntityBase.EntityName;
+                selectedNode.Text = selectedEntityBase.Name;
                 selectedEntityBase.Translation = SnapToGrid(selectedEntityBase.Translation);
             }
             UpdateSelectedEntity(false);
@@ -4207,8 +4213,8 @@ namespace PSXPrev.Forms
             texture.X = VRAM.ClampTextureX(texture.X);
             texture.Y = VRAM.ClampTextureY(texture.Y);
             texture.TexturePage = VRAM.ClampTexturePage(texture.TexturePage);
-            // Update changes to TextureName property in ListViewItem.
-            selectedItem.Text = texture.TextureName;
+            // Update changes to Name property in ListViewItem.
+            selectedItem.Text = texture.Name;
         }
 
         private void drawSelectedToVRAM_Click(object sender, EventArgs e)

--- a/Program.cs
+++ b/Program.cs
@@ -772,9 +772,20 @@ namespace PSXPrev
                 var hours = (int)watch.Elapsed.TotalHours;
                 var minutes = watch.Elapsed.Minutes;
                 var seconds = watch.Elapsed.Seconds;
+                var milliseconds = watch.Elapsed.Milliseconds;
                 //Program.Logger.WriteLine();
                 Program.Logger.WriteLine("Scan end {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
-                Program.Logger.WriteLine("Scan took {0} hours {1} minutes {2} seconds", hours, minutes, seconds);
+                var millisecondsStr = string.Empty;
+#if DEBUG
+                // Always print time taken to console for debug builds, and include milliseconds
+                var oldLogToConsole = Program.Logger.LogToConsole;
+                Program.Logger.LogToConsole = true;
+                millisecondsStr = $" {milliseconds} milliseconds";
+#endif
+                Program.Logger.WriteLine("Scan took {0} hours {1} minutes {2} seconds{3}", hours, minutes, seconds, millisecondsStr);
+#if DEBUG
+                Program.Logger.LogToConsole = oldLogToConsole;
+#endif
                 Program.Logger.WritePositiveLine("Found {0} Models", _scannedEntityCount);
                 Program.Logger.WritePositiveLine("Found {0} Textures", _scannedTextureCount);
                 Program.Logger.WritePositiveLine("Found {0} Animations", _scannedAnimationCount);
@@ -1005,6 +1016,7 @@ namespace PSXPrev
         {
             var parsers = new List<Func<FileOffsetScanner>>();
 
+            // todo: AN produces too many false positives to be enabled by default
             if (_options.CheckAll || _options.CheckAN)
             {
                 parsers.Add(() => new ANParser(AddAnimation));
@@ -1032,7 +1044,7 @@ namespace PSXPrev
             }
             if (_options.CheckAll || _options.CheckPSX)
             {
-                parsers.Add(() => new PSXParser(AddEntity, AddTexture));
+                parsers.Add(() => new PSXParser(AddEntity, AddTexture, AddAnimation));
             }
             // SPT produces too many false positives to be enabled by default
             if (/*_options.CheckAll ||*/ _options.CheckSPT)
@@ -1051,6 +1063,7 @@ namespace PSXPrev
             {
                 parsers.Add(() => new TODParser(AddAnimation));
             }
+            // todo: VDF produces too many false positives
             if (_options.CheckAll || _options.CheckVDF)
             {
                 parsers.Add(() => new VDFParser(AddAnimation));

--- a/Settings.cs
+++ b/Settings.cs
@@ -232,6 +232,9 @@ namespace PSXPrev
         [JsonProperty("advancedPSXScaleDivisor")]
         public float AdvancedPSXScaleDivisor { get; set; } = 2.25f;
 
+        [JsonProperty("advancedPSXIncludeLODLevels")]
+        public bool AdvancedPSXIncludeLODLevels { get; set; } = false;
+
         [JsonProperty("advancedPSXIncludeInvisible")]
         public bool AdvancedPSXIncludeInvisible { get; set; } = false;
 


### PR DESCRIPTION
* Fixed object sanity limit for Neversoft PSX being too low, meaning about 4-5 world maps from THPS 1-4 would not load.
* Fixed HMD reading matrix translation 2 bytes too early (originally I was dividing by 0x10000 to account for this, but it turns out I was dumb, and the padding really was before the translation, it's just that the translation wasn't divided by anything).
* Fixed visuals (like gizmos) not updating correctly because of a faulty check for zero-count mesh builders.
* Renamed EntityName, TextureName, and AnimationName all to just Name.
* Added Coordinate.IsAbsolute, when true, WorldMatrix will only use the coordinate's local matrix. This is needed for PSX, where transforms have no heirarchy, but hierarchy still exists and should be viewable.
* Added ExtractRotationSafe extension method for Matrix3.
* Time taken for a scan will now always be logged to the console for debug builds.
* A lot of refactoring in PSXParser. Renamed instances of PSXModel to PSXMesh, to keep consistency with other parsers.
* Added support for Neversoft PSX LOD levels. In settings.json, changing "advancedPSXIncludeLODLevels" to true will include all different LOD versions of a given model. For THPS, this is mostly a few differences in levels. For Spider Man, many mob characters have 1-2 low-poly variants.
* Added support FOR JUST ONE SUBTYPE of Neversoft PSX animation. This is a matrix/translation frame-type animation, and is used infrequently for mostly mob characters and basic props.
* Added Total Key Frames property to Animation.