### PR TITLE
VAO, Texture, and Mesh batching optimizations

### DIFF
--- a/Common/Exporters/glTF2Exporter.cs
+++ b/Common/Exporters/glTF2Exporter.cs
@@ -32,7 +32,7 @@ namespace PSXPrev.Common.Exporters
             _modelPreparer = new ModelPreparerExporter(_options, bakeConnections: false);
 
             var exportAnimations = _options.ExportAnimations && animations?.Length > 0;
-            var animationBatch = exportAnimations ? new AnimationBatch(null) : null;
+            var animationBatch = exportAnimations ? new AnimationBatch() : null;
 
             // Prepare the shared state for all models being exported (mainly setting up tiled textures).
             var groups = _modelPreparer.PrepareAll(entities);
@@ -377,7 +377,7 @@ namespace PSXPrev.Common.Exporters
                         var rotations = new Quaternion[count, totalFrames];
                         var scales = new Vector3[count, totalFrames];
                         var oldLoopMode = animationBatch.LoopMode;
-                        animationBatch.SetupAnimationBatch(animation, simulate: true);
+                        animationBatch.SetupAnimationBatch(animation);
                         animationBatch.LoopMode = AnimationLoopMode.Once;
                         var isCoordinateBased = animation.AnimationType.IsCoordinateBased();
                         var isTransformBased = animation.AnimationType.IsTransformBased();
@@ -389,7 +389,7 @@ namespace PSXPrev.Common.Exporters
                             for (var t = 0f; t < totalTime; t += timeStep, frame++)
                             {
                                 animationBatch.Time = t;
-                                if (animationBatch.SetupAnimationFrame(null, entity, null, simulate: true, force: true))
+                                if (animationBatch.SetupAnimationFrame(entity, force: true))
                                 {
                                     var transformIndex = transformStart;
                                     if ((isTransformBased || isCoordinateBased) && entity.Coords != null)

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -210,6 +210,37 @@ namespace PSXPrev.Common
             return false;
         }
 
+        public static Matrix4 CreateFromQuaternionAroundOrigin(Quaternion rotation, Vector3 origin)
+        {
+            CreateFromQuaternionAroundOrigin(ref rotation, ref origin, out var result);
+            return result;
+        }
+
+        public static void CreateFromQuaternionAroundOrigin(ref Quaternion rotation, ref Vector3 origin, out Matrix4 result)
+        {
+            Matrix4.CreateFromQuaternion(ref rotation, out var rotationMatrix);
+
+            var invOrigin = -origin;
+            Matrix4.CreateTranslation(ref invOrigin, out var invOriginMatrix);
+            Matrix4.Mult(ref invOriginMatrix, ref rotationMatrix, out result);
+
+            Matrix4.CreateTranslation(ref origin, out var originMatrix);
+            Matrix4.Mult(ref result, ref originMatrix, out result);
+        }
+
+        public static Matrix4 CreateSpriteWorldMatrix(Matrix4 worldMatrix, Vector3 origin)
+        {
+            CreateSpriteWorldMatrix(ref worldMatrix, ref origin, out var result);
+            return result;
+        }
+
+        public static void CreateSpriteWorldMatrix(ref Matrix4 worldMatrix, ref Vector3 origin, out Matrix4 result)
+        {
+            var invWorldRotation = worldMatrix.ExtractRotationSafe().Inverted();
+            CreateFromQuaternionAroundOrigin(ref invWorldRotation, ref origin, out result);
+            Matrix4.Mult(ref result, ref worldMatrix, out result);
+        }
+
         public static Vector3 UnProject(this Vector3 position, Matrix4 projection, Matrix4 view, float width, float height)
         {
             // Not entirely sure if the -1 in `height - 1f - position.Y` should be there or not.

--- a/Common/Parsers/PSXParser.cs
+++ b/Common/Parsers/PSXParser.cs
@@ -1314,7 +1314,7 @@ namespace PSXPrev.Common.Parsers
             //var flag0200  = (faceFlags & 0x0200) != 0;
             //var flag0400  = (faceFlags & 0x0400) != 0;
             var gouraud   = (faceFlags & 0x0800) != 0;
-            //var subdiv    = (faceFlags & 0x1000) != 0;
+            var subdiv    = (faceFlags & 0x1000) != 0;
             //var flag2000  = (faceFlags & 0x2000) != 0;
             //var flag4000  = (faceFlags & 0x4000) != 0;
 
@@ -1463,6 +1463,11 @@ namespace PSXPrev.Common.Parsers
             }
 
             var normal = _normals[normalIndex];
+            if (spriteCenter.HasValue)
+            {
+                // Neversoft PSX normals point in the opposite direction of how PSXPrev renders sprites, so invert the normal to match
+                normal = -normal;
+            }
 
             Color color0, color1, color2, color3;
             if (!gouraud)
@@ -1526,6 +1531,11 @@ namespace PSXPrev.Common.Parsers
                     case 2: mixtureRate = MixtureRate.Back100_PolyM100; break;
                     case 3: mixtureRate = MixtureRate.Back100_Poly25; break;
                 }
+            }
+
+            if (subdiv)
+            {
+                renderFlags |= RenderFlags.Subdivision;
             }
 
 

--- a/Common/RenderInfo.cs
+++ b/Common/RenderInfo.cs
@@ -10,11 +10,11 @@ namespace PSXPrev.Common
         DoubleSided       = (1 << 0),
         Unlit             = (1 << 1),
         SemiTransparent   = (1 << 3),
-        Fog               = (1 << 4),
+        Fog               = (1 << 4), // (Not supported)
         Textured          = (1 << 5),
         // todo: Are these even render-related?
-        Subdivision       = (1 << 6),
-        AutomaticDivision = (1 << 7),
+        Subdivision       = (1 << 6), // (Not supported)
+        AutomaticDivision = (1 << 7), // (Not supported)
 
         // Also known as VibRibbon (only use Vertex0 and Vertex1).
         Line              = (1 << 16),
@@ -45,9 +45,10 @@ namespace PSXPrev.Common
         // Use this mask when separating meshes by render info.
         public const RenderFlags SupportedFlags = RenderFlags.DoubleSided | RenderFlags.Unlit |
                                                   RenderFlags.SemiTransparent | RenderFlags.Textured |
-                                                  RenderFlags.Line | RenderFlags.Sprite | RenderFlags.SpriteNoPitch;
+                                                  RenderFlags.Line | RenderFlags.Sprite | RenderFlags.SpriteNoPitch |
+                                                  RenderFlags.NoAmbient;
 
-        public uint TexturePage { get; }
+        public uint TexturePage { get; } // May be a LookupID for packed texture types
         public RenderFlags RenderFlags { get; }
         public MixtureRate MixtureRate { get; }
         
@@ -82,6 +83,7 @@ namespace PSXPrev.Common
 
         public bool Equals(RenderInfo other)
         {
+            //return TexturePage == other.TexturePage && RenderFlags == other.RenderFlags && MixtureRate == other.MixtureRate;
             return RawValue.Equals(other.RawValue);
         }
 

--- a/Common/Renderer/Skin.cs
+++ b/Common/Renderer/Skin.cs
@@ -8,17 +8,21 @@ namespace PSXPrev.Common.Renderer
     // Represents a list of joint matrices that allow vertices to attach to other models
     public class Skin : IDisposable, IComparable<Skin>
     {
-        private readonly int _skinIndex;
         private readonly int _jointMatrixBufferId;
         private int _elementCount; // Number of elements assigned during SetData
 
+        private BufferTarget SupportedBufferTarget => Shader.SSBOSupported ? BufferTarget.ShaderStorageBuffer : BufferTarget.UniformBuffer;
+        private BufferRangeTarget SupportedBufferRangeTarget => Shader.SSBOSupported ? BufferRangeTarget.ShaderStorageBuffer : BufferRangeTarget.UniformBuffer;
+
         public int JointCount => _elementCount;
 
+        public int OrderIndex { get; set; }
+        public bool IsInitialized { get; private set; }
         public bool IsDisposed { get; private set; }
 
-        public Skin(int skinIndex)
+        public Skin(int orderIndex)
         {
-            _skinIndex = skinIndex;
+            OrderIndex = orderIndex;
             _jointMatrixBufferId = GL.GenBuffer();
         }
 
@@ -31,54 +35,80 @@ namespace PSXPrev.Common.Renderer
             }
         }
 
-        public void SetData(int elementCount, float[] jointMatrixList)
+        public int CompareTo(Skin other)
         {
-            _elementCount = elementCount;
-
-            BufferData(_jointMatrixBufferId, jointMatrixList, 32); // Matrix4[2]
-        }
-
-        // Passing null for list will fill the data with zeros.
-        private void BufferData<T>(int bufferId, T[] list, int elementSize) where T : struct
-        {
-            var length = _elementCount * elementSize;
-            if (list == null)
-            {
-                list = new T[length]; // Treat null as zeroed data.
-            }
-            else
-            {
-                Trace.Assert(list.Length >= length, "BufferData cannot use list that's smaller than expected length");
-            }
-            var size = (IntPtr)(length * 4);// sizeof(float));
-
-            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, bufferId);
-            GL.BufferData(BufferTarget.ShaderStorageBuffer, size, list, BufferUsageHint.DynamicDraw); //.StaticDraw);
+            return OrderIndex.CompareTo(other.OrderIndex);
         }
 
         public void Bind()
         {
-            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, _jointMatrixBufferId);
-            GL.BindBufferBase(BufferRangeTarget.ShaderStorageBuffer, Shader.BufferIndex_Joints, _jointMatrixBufferId);
+            GL.BindBufferBase(SupportedBufferRangeTarget, Shader.BufferIndex_JointTransforms, _jointMatrixBufferId);
         }
 
         public void Unbind()
         {
-            GL.BindBuffer(BufferTarget.ShaderStorageBuffer, 0);
-            // todo: Is this necessary?
-            GL.BindBufferBase(BufferRangeTarget.ShaderStorageBuffer, Shader.BufferIndex_Joints, 0);
+            GL.BindBufferBase(SupportedBufferRangeTarget, Shader.BufferIndex_JointTransforms, 0);
         }
 
-        public int CompareTo(Skin other)
+        // Initialize buffers, but only fill them with garbage data, intended for using SetSubData after this call.
+        public void InitData(int elementCount)
         {
-            return _skinIndex.CompareTo(other._skinIndex);
+            SetData(elementCount, null);
+        }
+
+        public void SetData(int elementCount, float[] jointMatrixList)
+        {
+            IsInitialized &= (_elementCount != elementCount); // We need to recreate buffers if the size differs
+            _elementCount = elementCount;
+
+            BufferAllData(0, elementCount, jointMatrixList);
+
+            IsInitialized = true;
+        }
+
+        // Assign partial data to the buffers, the first index in each list should be the first element assigned.
+        public void SetSubData(int elementFirst, int elementCount, float[] jointMatrixList)
+        {
+            Trace.Assert(IsInitialized, nameof(SetSubData) + " cannot be called before data is initialized");
+            Trace.Assert(elementFirst + elementCount <= _elementCount, nameof(SetSubData) + " element out of bounds");
+
+            BufferAllData(elementFirst, elementCount, jointMatrixList);
+        }
+
+        private void BufferAllData(int elementFirst, int elementCount, float[] jointMatrixList)
+        {
+            BufferData(_jointMatrixBufferId, jointMatrixList, elementFirst, elementCount, 32); // Matrix4[2]
+        }
+
+        // Passing null for list will fill the data with zeros.
+        private void BufferData<T>(int bufferId, T[] list, int elementFirst, int elementCount, int elementSize/*, int primitiveSize = 4*/) where T : struct
+        {
+            const int primitiveSize = 4;
+            var length = elementCount * elementSize;
+            if (list != null)
+            {
+                Trace.Assert(list.Length >= length, nameof(BufferData) + " cannot use list that's smaller than expected length");
+            }
+            var offset = new IntPtr(elementFirst * elementSize * primitiveSize);
+            var size = new IntPtr(length * primitiveSize);
+
+            if (!IsInitialized)
+            {
+                GL.BindBuffer(SupportedBufferTarget, bufferId);
+                GL.BufferData(SupportedBufferTarget, size, list, BufferUsageHint.DynamicDraw); //.StaticDraw);
+            }
+            else if (list != null) // No need to buffer sub data if its garbage data
+            {
+                GL.BindBuffer(SupportedBufferTarget, bufferId);
+                GL.BufferSubData(SupportedBufferTarget, offset, size, list);
+            }
         }
 
 
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static void AssignModelMatrix(float[] data, int baseIndex, ref Matrix4 matrix)
+        public static void AssignModelMatrix(float[] data, int elementIndex, ref Matrix4 matrix)
         {
-            var index = baseIndex * 32 + 0;
+            var index = elementIndex * 32 + 0;
             data[index++] = matrix.Row0.X;
             data[index++] = matrix.Row0.Y;
             data[index++] = matrix.Row0.Z;
@@ -102,9 +132,9 @@ namespace PSXPrev.Common.Renderer
 
         // This function handles transposing the normal matrix.
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        public static void AssignNormalMatrix(float[] data, int baseIndex, ref Matrix3 matrix)
+        public static void AssignNormalMatrix(float[] data, int elementIndex, ref Matrix3 matrix)
         {
-            var index = baseIndex * 32 + 16;
+            var index = elementIndex * 32 + 16;
             /*data[index++] = matrix.Row0.X;
             data[index++] = matrix.Row0.Y;
             data[index++] = matrix.Row0.Z;

--- a/Common/Renderer/TextureBinder.cs
+++ b/Common/Renderer/TextureBinder.cs
@@ -1,59 +1,197 @@
 ﻿using System;
 using System.Drawing;
+using System.Drawing.Imaging;
+using OpenTK;
 using OpenTK.Graphics.OpenGL;
+using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
+using GdiPixelFormat = System.Drawing.Imaging.PixelFormat;
 
 namespace PSXPrev.Common.Renderer
 {
     public class TextureBinder : IDisposable
     {
-        private readonly int[] _textureIds = new int[VRAM.PageCount];
+        // Constants for sharing multiple texture pages in a single texture
+        private const bool SharePages = true;
+        public const int PageColumns = SharePages ? 4 : 1;
+        public const int PageRows    = SharePages ? 8 : 1;
+        public const int PagesPerTexture = PageColumns * PageRows;
+        public const int SemiTransparencyX = PageColumns * VRAM.PageSize;
+
+
+        private int[] _textureIds;
+        private bool[] _texturesInitialized;
+        private readonly Bitmap _defaultBitmap; // Used when creating a texture for the first time
+
+        public bool IsDisposed { get; private set; }
 
         public TextureBinder()
         {
-            GL.GenTextures(VRAM.PageCount, _textureIds);
+            var width  = PageColumns * VRAM.PageSize;
+            var height = PageRows    * VRAM.PageSize;
+            _defaultBitmap = new Bitmap(width * 2, height);
+            using (var graphics = Graphics.FromImage(_defaultBitmap))
+            {
+                using (var colorBrush = new SolidBrush(VRAM.DefaultBackgroundColor))
+                {
+                    graphics.FillRectangle(colorBrush, 0, 0, width, height);
+                }
+                using (var stpBrush = new SolidBrush(Texture.NoSemiTransparentFlag))
+                {
+                    graphics.FillRectangle(stpBrush, SemiTransparencyX, 0, width, height);
+                }
+            }
         }
 
         public void Dispose()
         {
-            GL.DeleteTextures(VRAM.PageCount, _textureIds);
+            if (!IsDisposed)
+            {
+                IsDisposed = true;
+                if (_textureIds != null)
+                {
+                    GL.DeleteTextures(_textureIds.Length, _textureIds);
+                    _textureIds = null;
+                    _texturesInitialized = null;
+                }
+                _defaultBitmap.Dispose();
+            }
         }
 
-        public int GetTextureID(int index)
+        public int GetTextureID(int index) => GetTextureID((uint)index);
+
+        public int GetTextureID(uint index)
         {
-            return _textureIds[index];
+            var textureIndex = index / PagesPerTexture;
+            if (_textureIds == null || _textureIds.Length < textureIndex + 1)
+            {
+                var oldCount = _textureIds?.Length ?? 0;
+                var newCount = textureIndex + 1;
+                Array.Resize(ref _textureIds,          (int)newCount);
+                Array.Resize(ref _texturesInitialized, (int)newCount);
+                for (var i = oldCount; i < newCount; i++)
+                {
+                    _textureIds[i] = GL.GenTexture();
+                }
+            }
+            return _textureIds[textureIndex];
         }
 
-        public void UpdateTexture(Bitmap bitmap, int index)
+        public void UpdateTexture(Bitmap bitmap, int index) => UpdateTexture(bitmap, (uint)index);
+
+        public void UpdateTexture(Bitmap bitmap, uint index)
         {
-            var textureId = _textureIds[index];
+            var textureId = GetTextureID(index);
+            if (textureId == 0)
+            {
+                return;
+            }
+
+            GL.ActiveTexture(TextureUnit.Texture0 + Shader.TextureUnit_MainTexture);
             GL.BindTexture(TextureTarget.Texture2D, textureId);
 
+            // If this is the first update to this textureId, then we need to create it before we can call TexSubImage2D.
+            var textureIndex = index / PagesPerTexture;
+            if (!_texturesInitialized[textureIndex])
+            {
+                // We could just pass in IntPtr.Zero for the data,
+                // but this is only a good idea if we KNOW that all pages will be written to.
+                // And TextureBinder has been redesigned to support any number of additional textures,
+                // which may not write all pages, unlike what VRAM does for the first 32 pages.
+                var defRect = new Rectangle(0, 0, _defaultBitmap.Width, _defaultBitmap.Height);
+                var defData = _defaultBitmap.LockBits(defRect, ImageLockMode.ReadOnly, GdiPixelFormat.Format32bppArgb);
+                try
+                {
+                    // Make sure to restore PixelStore settings here, since we change them below
+                    GL.PixelStore(PixelStoreParameter.UnpackSkipPixels, 0);
+                    GL.PixelStore(PixelStoreParameter.UnpackRowLength, defData.Width);
+                    GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, defData.Width, defData.Height, 0, PixelFormat.Bgra, PixelType.UnsignedByte, defData.Scan0);
+                }
+                finally
+                {
+                    _defaultBitmap.UnlockBits(defData);
+                }
+
+                // Set parameters so that the texture looks sharp, and has no smoothing/blurring between pixels
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
+
+                _texturesInitialized[textureIndex] = true;
+            }
+
+            // Copy the VRAM page color and semi-transparency columns into their respective squares in the larger texture image.
+            var x = GetColumnX(index);
+            var y = GetRowY(index);
+            var stpX = SemiTransparencyX + x;
             var rect = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
-            var bmpData = bitmap.LockBits(rect, System.Drawing.Imaging.ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            var bmpData = bitmap.LockBits(rect, ImageLockMode.ReadOnly, GdiPixelFormat.Format32bppArgb);
             try
             {
-                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, bmpData.Width, bmpData.Height, 0, PixelFormat.Bgra, PixelType.UnsignedByte, bmpData.Scan0);
+                // Setting this is necessary so that we skip pixels from the semi-transparency/color
+                // sections when writing the opposite section.
+                GL.PixelStore(PixelStoreParameter.UnpackRowLength, bitmap.Width);
+
+                // Write color column page and skip semi-transparency column pixels
+                GL.PixelStore(PixelStoreParameter.UnpackSkipPixels, 0);
+                GL.TexSubImage2D(TextureTarget.Texture2D, 0, x, y, VRAM.PageSize, VRAM.PageSize, PixelFormat.Bgra, PixelType.UnsignedByte, bmpData.Scan0);
+
+                // Write semi-transparency column page and skip color column pixels
+                GL.PixelStore(PixelStoreParameter.UnpackSkipPixels, VRAM.PageSemiTransparencyX);
+                GL.TexSubImage2D(TextureTarget.Texture2D, 0, stpX, y, VRAM.PageSize, VRAM.PageSize, PixelFormat.Bgra, PixelType.UnsignedByte, bmpData.Scan0);
             }
             finally
             {
                 bitmap.UnlockBits(bmpData);
             }
-
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
-            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
         }
 
-        public void BindTexture(int textureId)
+        public static bool IsTexturePageShared(int indexA, int indexB) => IsTexturePageShared((uint)indexA, (uint)indexB);
+
+        public static bool IsTexturePageShared(uint indexA, uint indexB)
         {
-            GL.ActiveTexture(TextureUnit.Texture0);
-            GL.BindTexture(TextureTarget.Texture2D, textureId);
-            // Sampler uniform NEEDS to be set with uint, not int!
-            GL.Uniform1(Shader.AttributeIndex_Texture, (uint)textureId);
+            return (indexA / PagesPerTexture) == (indexB / PagesPerTexture);
         }
 
-        public void Unbind()
+        public static Vector2 ConvertUV(Vector2 uv, bool isTiled, int index) => ConvertUV(uv, isTiled, (uint)index);
+
+        public static Vector2 ConvertUV(Vector2 uv, bool isTiled, uint index)
         {
-            GL.BindTexture(TextureTarget.Texture2D, 0);
+            if (isTiled)
+            {
+                return new Vector2(uv.X / (float)PageColumns,
+                                   uv.Y / (float)PageRows);
+            }
+            else
+            {
+                index %= PagesPerTexture;
+                return new Vector2(((index % PageColumns) + uv.X) / (float)PageColumns,
+                                   ((index / PageColumns) + uv.Y) / (float)PageRows);
+            }
+            //index %= PagesPerTexture;
+            //return new Vector2(((isTiled ? 0 : index % PageColumns) + uv.X) / (float)PageColumns,
+            //                   ((isTiled ? 0 : index / PageColumns) + uv.Y) / (float)PageRows);
+        }
+
+        public static Vector4 ConvertTiledArea(Vector4 tiledArea, int index) => ConvertTiledArea(tiledArea, (uint)index);
+
+        public static Vector4 ConvertTiledArea(Vector4 tiledArea, uint index)
+        {
+            index %= PagesPerTexture;
+            return new Vector4(((index % PageColumns) + tiledArea.X) / (float)PageColumns,
+                               ((index / PageColumns) + tiledArea.Y) / (float)PageRows,
+                               tiledArea.Z / (float)PageColumns,
+                               tiledArea.W / (float)PageRows);
+        }
+
+        private static int GetColumnX(uint index)
+        {
+            //index %= TexturePagesPerTexture; // Not necessary because of the other modulus
+            return (int)(index % PageColumns) * VRAM.PageSize;
+        }
+
+        private static int GetRowY(uint index)
+        {
+            index %= PagesPerTexture;
+            return (int)(index / PageColumns) * VRAM.PageSize;
         }
     }
 }

--- a/Common/Renderer/TriangleMeshBuilder.cs
+++ b/Common/Renderer/TriangleMeshBuilder.cs
@@ -30,7 +30,7 @@ namespace PSXPrev.Common.Renderer
             new Vector3(-1f,  1f, -1f),
             new Vector3(-1f, -1f, -1f),
         };
-        private static readonly Vector3 SpriteNormal = -Vector3.UnitZ;
+        private static readonly Vector3 SpriteNormal = Vector3.UnitZ;
 
 
         public bool CalculateNormals { get; set; }
@@ -891,8 +891,8 @@ namespace PSXPrev.Common.Renderer
                 {
                     for (var w = 1; w <= h; w++)
                     {
-                        var w1 = order ? w : w - 1;
-                        var w2 = order ? w - 1 : w;
+                        var w1 = order ? w - 1 : w;
+                        var w2 = order ? w : w - 1;
 
                         var v0 = vertices[face, h - 1, w - 1];
                         var v1 = vertices[face, h, w1];

--- a/Common/Renderer/VRAM.cs
+++ b/Common/Renderer/VRAM.cs
@@ -11,7 +11,7 @@ namespace PSXPrev.Common.Renderer
         public const int PageSize = 256;
         public const int PackAlign = 8;
         public const int PackBlocks = PageSize / PackAlign;
-        private const int PageSemiTransparencyX = PageSize;
+        public const int PageSemiTransparencyX = PageSize;
 
         public static readonly System.Drawing.Color DefaultBackgroundColor = System.Drawing.Color.White;
 
@@ -28,7 +28,7 @@ namespace PSXPrev.Common.Renderer
 
         public System.Drawing.Color BackgroundColor { get; set; } = DefaultBackgroundColor;
 
-        public bool Initialized { get; private set; }
+        public bool IsInitialized { get; private set; }
 
         public VRAM(Scene scene)
         {
@@ -54,7 +54,7 @@ namespace PSXPrev.Common.Renderer
 
         public void Dispose()
         {
-            if (Initialized)
+            if (IsInitialized)
             {
                 for (var i = 0; i < PageCount; i++)
                 {
@@ -64,13 +64,13 @@ namespace PSXPrev.Common.Renderer
                     _usedPages[i] = false;
                 }
                 ClearAllPagePacking();
-                Initialized = false;
+                IsInitialized = false;
             }
         }
 
         public void Initialize(bool suppressUpdate = false)
         {
-            if (Initialized)
+            if (IsInitialized)
             {
                 return;
             }
@@ -85,7 +85,7 @@ namespace PSXPrev.Common.Renderer
                     ClearPage(i, suppressUpdate);
                 }
             }
-            Initialized = true;
+            IsInitialized = true;
         }
 
         public void AssignModelTextures(RootEntity rootEntity)

--- a/Common/Renderer/VertexArrayObject.cs
+++ b/Common/Renderer/VertexArrayObject.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Diagnostics;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
+
+namespace PSXPrev.Common.Renderer
+{
+    public class VertexArrayObject : IDisposable, IComparable<VertexArrayObject>
+    {
+        private readonly int _vertexArrayObjectId; // Vertex array object
+        private readonly int[] _bufferIds = new int[6];
+        private readonly int _positionBufferId;
+        private readonly int _normalBufferId;
+        private readonly int _colorBufferId;
+        private readonly int _uvBufferId;
+        private readonly int _tiledAreaBufferId;
+        private readonly int _jointBufferId;
+
+        private int _elementCount; // Number of elements assigned during SetData
+
+        public int VertexCount => _elementCount;
+        public int VertexArrayObjectID => _vertexArrayObjectId;
+
+        public int OrderIndex { get; set; }
+        public bool IsInitialized { get; private set; }
+        public bool IsDisposed { get; private set; }
+
+        public VertexArrayObject(int orderIndex)
+        {
+            OrderIndex = orderIndex;
+            _vertexArrayObjectId = GL.GenVertexArray();
+            GL.GenBuffers(_bufferIds.Length, _bufferIds);
+            _positionBufferId  = _bufferIds[0];
+            _normalBufferId    = _bufferIds[1];
+            _colorBufferId     = _bufferIds[2];
+            _uvBufferId        = _bufferIds[3];
+            _tiledAreaBufferId = _bufferIds[4];
+            _jointBufferId     = _bufferIds[5];
+        }
+
+        public void Dispose()
+        {
+            if (!IsDisposed)
+            {
+                IsDisposed = true;
+                GL.DeleteVertexArray(_vertexArrayObjectId);
+                GL.DeleteBuffers(_bufferIds.Length, _bufferIds);
+            }
+        }
+
+        public int CompareTo(VertexArrayObject other)
+        {
+            return OrderIndex.CompareTo(other.OrderIndex);
+        }
+
+        public void Bind()
+        {
+            GL.BindVertexArray(_vertexArrayObjectId);
+        }
+
+        public void Unbind()
+        {
+            GL.BindVertexArray(0);
+        }
+
+        // Initializes buffers, filling them with garbage data. Intended for use with SetSubData.
+        public void InitData(int elementCount)
+        {
+            SetData(elementCount, null, null, null, null, null, null);
+        }
+
+        // Initializes buffers and assigns data to them. Null lists will assign garbage data.
+        public void SetData(int elementCount, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList, uint[] jointList)
+        {
+            IsInitialized &= (_elementCount != elementCount); // We need to recreate buffers if the size differs
+            _elementCount = elementCount;
+
+            BufferAllData(0, elementCount, positionList, normalList, colorList, uvList, tiledAreaList, jointList);
+
+            if (!IsInitialized)
+            {
+                BindVertexBuffers();
+                IsInitialized = true;
+            }
+        }
+
+        // Assigns partial data to initialized buffers. Null lists will not assign any data.
+        // The first index in each list should be the first element assigned.
+        public void SetSubData(int elementFirst, int elementCount, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList, uint[] jointList)
+        {
+            Trace.Assert(IsInitialized, "SetSubData cannot be called before data is initialized");
+            Trace.Assert(elementFirst + elementCount <= _elementCount, "SetSubData element out of bounds");
+
+            BufferAllData(elementFirst, elementCount, positionList, normalList, colorList, uvList, tiledAreaList, jointList);
+        }
+
+        private void BufferAllData(int elementFirst, int elementCount, float[] positionList, float[] normalList, float[] colorList, float[] uvList, float[] tiledAreaList, uint[] jointList)
+        {
+            BufferData(_positionBufferId,  positionList,  elementFirst, elementCount, 3); // Vector3
+            BufferData(_normalBufferId,    normalList,    elementFirst, elementCount, 3); // Vector3
+            BufferData(_colorBufferId,     colorList,     elementFirst, elementCount, 3); // Vector3 (Color)
+            BufferData(_uvBufferId,        uvList,        elementFirst, elementCount, 2); // Vector2
+            BufferData(_tiledAreaBufferId, tiledAreaList, elementFirst, elementCount, 4); // Vector4
+            BufferData(_jointBufferId,     jointList,     elementFirst, elementCount, 2); // uint[2]
+        }
+
+        // Passing null for list will fill the buffer with garbage data.
+        private void BufferData<T>(int bufferId, T[] list, int elementFirst, int elementCount, int elementSize/*, int primitiveSize = 4*/) where T : struct
+        {
+            const int primitiveSize = 4;
+            var length = elementCount * elementSize;
+            if (list != null)
+            {
+                Trace.Assert(list.Length >= length, "BufferData cannot use list that's smaller than expected length");
+            }
+            var offset = new IntPtr(elementFirst * elementSize * primitiveSize);
+            var size = new IntPtr(length * primitiveSize);
+
+            if (!IsInitialized)
+            {
+                GL.BindBuffer(BufferTarget.ArrayBuffer, bufferId);
+                GL.BufferData(BufferTarget.ArrayBuffer, size, list, BufferUsageHint.StaticDraw); //.DynamicDraw);
+            }
+            else if (list != null) // No need to buffer sub data if its garbage data
+            {
+                GL.BindBuffer(BufferTarget.ArrayBuffer, bufferId);
+                GL.BufferSubData(BufferTarget.ArrayBuffer, offset, size, list);
+            }
+        }
+
+        private void BindVertexBuffers()
+        {
+            // Bind buffers
+            GL.BindVertexArray(_vertexArrayObjectId);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _positionBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_Position);
+            GL.VertexAttribPointer(Shader.AttributeIndex_Position, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _normalBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_Normal);
+            GL.VertexAttribPointer(Shader.AttributeIndex_Normal, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _colorBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_Color);
+            GL.VertexAttribPointer(Shader.AttributeIndex_Color, 3, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _uvBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_Uv);
+            GL.VertexAttribPointer(Shader.AttributeIndex_Uv, 2, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _tiledAreaBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_TiledArea);
+            GL.VertexAttribPointer(Shader.AttributeIndex_TiledArea, 4, VertexAttribPointerType.Float, false, 0, IntPtr.Zero);
+            
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _jointBufferId);
+            GL.EnableVertexAttribArray(Shader.AttributeIndex_Joint);
+            GL.VertexAttribIPointer(Shader.AttributeIndex_Joint, 2, VertexAttribIntegerType.UnsignedInt, 0, IntPtr.Zero);
+        }
+
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector2(float[] data, int elementIndex, ref Vector2 vector)
+        {
+            var index = elementIndex * 2;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector3(float[] data, int elementIndex, ref Vector3 vector)
+        {
+            var index = elementIndex * 3;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+            data[index++] = vector.Z;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignVector4(float[] data, int elementIndex, ref Vector4 vector)
+        {
+            var index = elementIndex * 4;
+            data[index++] = vector.X;
+            data[index++] = vector.Y;
+            data[index++] = vector.Z;
+            data[index++] = vector.W;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignColor(float[] data, int elementIndex, Color color)
+        {
+            var index = elementIndex * 3;
+            data[index++] = color.R;
+            data[index++] = color.G;
+            data[index++] = color.B;
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static void AssignJoint(uint[] data, int elementIndex, uint? vertexJoint, uint? normalJoint)
+        {
+            var index = elementIndex * 2;
+            data[index++] = (vertexJoint ?? Triangle.NoJoint) + 1u;
+            data[index++] = (normalJoint ?? Triangle.NoJoint) + 1u;
+        }
+    }
+}

--- a/Common/RootEntity.cs
+++ b/Common/RootEntity.cs
@@ -19,6 +19,9 @@ namespace PSXPrev.Common
         [Browsable(false)]
         public ModelEntity[] Joints { get; set; }
 
+        [Browsable(false)]
+        public bool NeedsBakedJoints => Joints != null && (!Renderer.Shader.JointsSupported || Joints.Length > Renderer.Shader.MaxJoints);
+
         // Gets world joint transform matrices
         private Matrix4[] _jointMatrices;
         [Browsable(false)]
@@ -136,6 +139,9 @@ namespace PSXPrev.Common
                 return count;
             }
         }
+
+        [DisplayName("Total Joints"), ReadOnly(true)]
+        public int JointCount => Joints?.Length ?? 0;
 
         [Browsable(false)]
         public WeakReferenceCollection<Texture> OwnedTextures { get; } = new WeakReferenceCollection<Texture>();
@@ -257,13 +263,14 @@ namespace PSXPrev.Common
             }
 #endif
             Joints = joints;
+            //NeedsBakedJoints = joints != null && (!Renderer.Shader.JointsSupported || joints.Length > Renderer.Shader.MaxJoints);
         }
 
         public override void FixConnections(bool? bake = null, Matrix4[] tempJointMatrices = null)
         {
             if (!bake.HasValue)
             {
-                bake = !Renderer.Shader.JointsSupported;
+                bake = NeedsBakedJoints;
             }
             if (!bake.Value && tempJointMatrices == null)
             {

--- a/Forms/Controls/ExtendedTreeView.cs
+++ b/Forms/Controls/ExtendedTreeView.cs
@@ -1,23 +1,79 @@
-﻿using System;
+﻿using PSXPrev.Forms.Utils;
+using System;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace PSXPrev.Forms.Controls
 {
     public class ExtendedTreeView : TreeView
     {
-        // Fix a bug where double clicking a checkbox desyncs its actual and visual checked state.
-        // Of all the WinForms moments so far, this is the worst...
-        // <https://social.msdn.microsoft.com/forums/windows/en-US/9d717ce0-ec6b-4758-a357-6bb55591f956/possible-bug-in-net-treeview-treenode-checked-state-inconsistent?forum=winforms>
+#if DEBUG
+        //private static int _wndProcCounter = 0;
+#endif
+
         protected override void WndProc(ref Message m)
         {
-            const int WM_LBUTTONDBLCLK = 0x203;
-
-            // Filter WM_LBUTTONDBLCLK when we're showing checkboxes.
-            if (m.Msg == WM_LBUTTONDBLCLK && CheckBoxes)
+#if DEBUG
+            //Program.ConsoleLogger.WriteLine($"{Name} ({_wndProcCounter++}): msg=0x{m.Msg:x04} wparam=0x{(uint)m.WParam.ToInt32():x08} lparam=0x{(uint)m.LParam.ToInt32():x08}");
+#endif
+            if (m.Msg == NativeMethods.OCM_NOTIFY)
             {
+                //struct NMHDR {
+                //    IntPtr hwndFrom;
+                //    uint   idFrom;
+                //    uint   code;
+                //}
+                //var hwndFrom = Marshal.ReadIntPtr(m.LParam);
+                //var idFrom = Marshal.ReadInt32(m.LParam + IntPtr.Size);
+                var code = Marshal.ReadInt32(m.LParam + IntPtr.Size + sizeof(int));
+                if (code == NativeMethods.NM_CUSTOMDRAW && DrawMode == TreeViewDrawMode.Normal)
+                {
+                    //struct NMCUSTOMDRAW {
+                    //    NMHDR  hdr; // IntPtr[1], int[2]
+                    //    uint   dwDrawStage;
+                    //    IntPtr hdc;
+                    //    int[4] rc;
+                    //    IntPtr dwItemSpec;
+                    //    uint   uItemState;
+                    //    IntPtr lItemlParam;
+                    //}
+                    //struct NMTVCUSTOMDRAW {
+                    //    NMCUSTOMDRAW nmcd; // IntPtr[4], int[8]
+                    //    uint   clrText;
+                    //    uint   clrTextBk;
+                    //    int    iLevel;
+                    //}
+                    //var dwDrawStage = Marshal.ReadInt32(m.LParam + IntPtr.Size + sizeof(int) * 2);
+                    
+                    // Prevent an unholy amount of NM_CUSTOMDRAW message spam by telling the TreeView to shut up and not draw anything special.
+                    // Originally the TreeView would end up handling custom draw events FOR EVERY TREE NODE IN THE HIERARCHY!
+                    // AND WE ABSOLUTELY DO NOT NEED TO BE DRAWING 1000+ TREE NODES THAT ARE NOT ON SCREEN!
+
+                    // Note, that TreeView handles custom draw for a reason during the CDDS_ITEMPREPAINT stage.
+                    // If you select a tree node, then click down on another and drag the mouse,
+                    // the clicked tree node will be highlighted until you start dragging, after which the original will be highlighted.
+                    // Instead, we solve this by just selecting the node on mouse-down instead of mouse-click.
+                    m.Result = IntPtr.Zero;
+                    return; // Disable original behavior
+                }
+            }
+            else if (m.Msg == NativeMethods.WM_TIMER)
+            {
+                // Prevent the TreeView from being a royal pain and scrolling the selection back into focus moments after the selection occurred.
+                // This issue also exists with ListViews, so we can likely solve it the same way if we ever use any (ImageListView doesn't count).
+                m.Result = IntPtr.Zero;
+                return; // Disable original behavior
+            }
+            else if (m.Msg == NativeMethods.WM_LBUTTONDBLCLK && CheckBoxes)
+            {
+                // Fix a bug where double clicking a checkbox desyncs its actual and visual checked state.
+                // Of all the WinForms moments, this is the worst (so far)...
+                // <https://social.msdn.microsoft.com/forums/windows/en-US/9d717ce0-ec6b-4758-a357-6bb55591f956/possible-bug-in-net-treeview-treenode-checked-state-inconsistent?forum=winforms>
+
+                // Filter WM_LBUTTONDBLCLK only when we're showing checkboxes.
+
                 // See if we're over the checkbox. If so then we'll handle the toggling of it ourselves.
-                var x = m.LParam.ToInt32() & 0xffff;
-                var y = (m.LParam.ToInt32() >> 16) & 0xffff;
+                NativeMethods.Int32ToSignedXY(m.LParam.ToInt32(), out var x, out var y);
                 var hitTestInfo = HitTest(x, y);
 
                 var node = hitTestInfo.Node;
@@ -32,6 +88,49 @@ namespace PSXPrev.Forms.Controls
             }
 
             base.WndProc(ref m);
+        }
+
+        protected override void DefWndProc(ref Message m)
+        {
+            if (m.Msg == NativeMethods.WM_LBUTTONDOWN)
+            {
+                // Fix the visual bug that occurs when selecting a node and then dragging a different node.
+                // This is now a problem because we eliminated custom draw.
+                // So to solve it, we just force selection on mouse-down instead of mouse-click.
+
+                // Don't put this in WndProc so that the TreeView can handle its normal mouse-down behavior first.
+                NativeMethods.Int32ToSignedXY(m.LParam.ToInt32(), out var x, out var y);
+                var hitTestInfo = HitTest(x, y);
+
+                var node = hitTestInfo.Node;
+                if (node != null && hitTestInfo.Location == TreeViewHitTestLocations.Label)
+                {
+                    if (SelectedNode != node)
+                    {
+                        SelectedNode = node;
+                    }
+                    m.Result = IntPtr.Zero;
+                    return; // Disable original behavior
+                }
+            }
+            base.DefWndProc(ref m);
+        }
+
+        protected override void OnBeforeCheck(TreeViewCancelEventArgs e)
+        {
+            // Fix issue where pressing space bar over a node that has its checkbox hidden will cause the checkbox to reappear.
+
+            // Unknown action means we're manually setting the node to checked.
+            // Don't waste time with checking if its hidden when Unknown, especially if we're mass-checking all nodes.
+            if (e.Action != TreeViewAction.Unknown)
+            {
+                if (e.Node.IsCheckBoxHidden())
+                {
+                    e.Cancel = true; // Prevent hidden checkbox from reappearing
+                    return;
+                }
+            }
+            base.OnBeforeCheck(e);
         }
     }
 }

--- a/Forms/PreviewForm.Designer.cs
+++ b/Forms/PreviewForm.Designer.cs
@@ -346,7 +346,6 @@ namespace PSXPrev.Forms
             this.entitiesTreeView.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterCheck);
             this.entitiesTreeView.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.entitiesTreeView_BeforeExpand);
             this.entitiesTreeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.entitiesTreeView_AfterSelect);
-            this.entitiesTreeView.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.entitiesTreeView_NodeMouseClick);
             // 
             // tableLayoutPanel5
             // 

--- a/Forms/Utils/NativeMethods.cs
+++ b/Forms/Utils/NativeMethods.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace PSXPrev.Forms.Utils
+{
+    internal static class NativeMethods
+    {
+        // Constants
+
+        public const int WM_TIMER         = 0x0113;
+        public const int WM_LBUTTONDOWN   = 0x0201;
+        public const int WM_LBUTTONDBLCLK = 0x0203;
+        public const int OCM_NOTIFY       = 0x204e;
+        public const int TV_FIRST         = 0x1100;
+        public const int TVM_GETITEMSTATE = TV_FIRST + 39;
+        public const int TVM_GETITEM      = TV_FIRST + 62; // (TVM_GETITEMW, TVM_GETITEMA is: TV_FIRST + 12)
+        public const int TVM_SETITEM      = TV_FIRST + 63; // (TVM_SETITEMW, TVM_SETITEMA is: TV_FIRST + 13)
+
+        public const int NM_CUSTOMDRAW    = -12;
+
+        public const int TVIF_STATE          = 0x8;
+        public const int TVIS_STATEIMAGEMASK = 0xF000;
+
+
+        // Structures
+
+        [StructLayout(LayoutKind.Sequential, Pack = 8, CharSet = CharSet.Auto)]
+        public struct TVITEM
+        {
+            public int mask;
+            public IntPtr hItem;
+            public int state;
+            public int stateMask;
+            [MarshalAs(UnmanagedType.LPTStr)]
+            public string lpszText;
+            public int cchTextMax;
+            public int iImage;
+            public int iSelectedImage;
+            public int cChildren;
+            public IntPtr lParam;
+        }
+
+
+        // P/Invoke methods
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, ref TVITEM lParam);
+
+
+        // Helper methods
+
+        public static void Int32ToSignedXY(int param, out int x, out int y)
+        {
+            x = (short)((param      ) & 0xffff);
+            y = (short)((param >> 16) & 0xffff);
+        }
+    }
+}

--- a/Forms/Utils/TreeViewExtensions.cs
+++ b/Forms/Utils/TreeViewExtensions.cs
@@ -6,42 +6,42 @@ namespace PSXPrev.Forms.Utils
 {
     public static class TreeViewExtensions
     {
-        private const int TVIF_STATE = 0x8;
-        private const int TVIS_STATEIMAGEMASK = 0xF000;
-        private const int TV_FIRST = 0x1100;
-        private const int TVM_SETITEM = TV_FIRST + 63;
-
-        [StructLayout(LayoutKind.Sequential, Pack = 8, CharSet = CharSet.Auto)]
-        private struct TVITEM
-        {
-            public int mask;
-            public IntPtr hItem;
-            public int state;
-            public int stateMask;
-            [MarshalAs(UnmanagedType.LPTStr)]
-            public string lpszText;
-            public int cchTextMax;
-            public int iImage;
-            public int iSelectedImage;
-            public int cChildren;
-            public IntPtr lParam;
-        }
-
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        private static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam,
-                                                 ref TVITEM lParam);
-
         /// <summary>
         /// Hides the checkbox for the specified node on a TreeView control.
         /// </summary>
-        public static void HideCheckBox(this TreeNode node)
+        public static bool HideCheckBox(this TreeNode node)
         {
-            TVITEM tvi = new TVITEM();
-            tvi.hItem = node.Handle;
-            tvi.mask = TVIF_STATE;
-            tvi.stateMask = TVIS_STATEIMAGEMASK;
-            tvi.state = 0;
-            SendMessage(node.TreeView.Handle, TVM_SETITEM, IntPtr.Zero, ref tvi);
+            // State image values are shifted by 12. 0 = no checkbox, 1 = unchecked, 2 = checked
+            var tvi = new NativeMethods.TVITEM
+            {
+                hItem = node.Handle,
+                mask = NativeMethods.TVIF_STATE,
+                stateMask = NativeMethods.TVIS_STATEIMAGEMASK,
+                state = 0 << 12,
+            };
+            var result = NativeMethods.SendMessage(node.TreeView.Handle, NativeMethods.TVM_SETITEM, IntPtr.Zero, ref tvi);
+            return result != IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Returns true if the checkbox is hidden for the specified node on a TreeView control.
+        /// </summary>
+        public static bool IsCheckBoxHidden(this TreeNode node)
+        {
+            // State image values are shifted by 12. 0 = no checkbox, 1 = unchecked, 2 = checked
+            var stateMask = new IntPtr(NativeMethods.TVIS_STATEIMAGEMASK);
+            var state = NativeMethods.SendMessage(node.TreeView.Handle, NativeMethods.TVM_GETITEMSTATE, node.Handle, stateMask).ToInt32();
+            var stateImage = state >> 12;
+            // Alt:
+            /*var tvi = new NativeMethods.TVITEM
+            {
+                hItem = node.Handle,
+                mask = NativeMethods.TVIF_STATE,
+                stateMask = NativeMethods.TVIS_STATEIMAGEMASK,
+            };
+            SendMessage(node.TreeView.Handle, NativeMethods.TVM_GETITEM, IntPtr.Zero, ref tvi);
+            var stateImage = tvi.state >> 12;*/
+            return stateImage == 0;
         }
     }
 }

--- a/PSXPrev.csproj
+++ b/PSXPrev.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Common\Renderer\Mesh.cs" />
     <Compile Include="Common\Renderer\MeshBatch.cs" />
     <Compile Include="Common\Renderer\MeshRenderInfo.cs" />
+    <Compile Include="Common\Renderer\VertexArrayObject.cs" />
     <Compile Include="Common\Renderer\Shader.cs" />
     <Compile Include="Common\Renderer\Skin.cs" />
     <Compile Include="Common\Renderer\TriangleMeshBuilder.cs" />
@@ -175,6 +176,7 @@
     </Compile>
     <Compile Include="Forms\Utils\ControlExtensions.cs" />
     <Compile Include="Forms\Utils\DictionaryPropertyGridAdapter.cs" />
+    <Compile Include="Forms\Utils\NativeMethods.cs" />
     <Compile Include="Forms\Utils\TreeViewExtensions.cs" />
     <Compile Include="Forms\PreviewForm.cs">
       <SubType>Form</SubType>

--- a/Shaders/Shader.frag
+++ b/Shaders/Shader.frag
@@ -1,37 +1,34 @@
 ﻿#version 150
+
 in vec2 pass_Uv;
 in vec4 pass_TiledArea;
-in vec4 pass_Ambient;
-in vec4 pass_Color;
-
+in vec3 pass_Color;
 in float pass_NormalDotLight;
 in float pass_NormalLength;
 in float pass_DiscardPixel;
 
 out vec4 out_Color;
 
-uniform mat3 normalMatrix;
-uniform mat4 modelMatrix;
-uniform mat4 mvpMatrix;
-uniform vec3 lightDirection;
-uniform vec3 maskColor;
-uniform vec3 ambientColor;
-uniform vec3 solidColor;
-uniform vec2 uvOffset;
-uniform int lightMode;
-uniform int colorMode;
-uniform int textureMode;
-uniform int semiTransparentPass;
-uniform float lightIntensity;
-uniform sampler2D mainTex;
+uniform sampler2D u_MainTexture;
+uniform vec3 u_LightDirection;
+uniform vec3 u_MaskColor;
+uniform vec3 u_AmbientColor;
+uniform vec3 u_SolidColor;
+uniform vec2 u_UvOffset;
+uniform int u_LightMode;
+uniform int u_ColorMode;
+uniform int u_TextureMode;
+uniform int u_SemiTransparentPass;
+uniform float u_LightIntensity;
 
-const vec3 BlackMask = vec3(0.0, 0.0, 0.0);
+const vec3 BlackMask = vec3(0.0);
 
-const vec4 OutOfBoundsTexture_Color1 = vec4(1.0, 0.05, 0.0, 1.0); // Red with slight Orange
-const vec4 MissingTexture_Color1     = vec4(1.0, 0.0, 1.0, 1.0); // Magenta
-const vec4 InvalidTexture_Color2     = vec4(0.0, 0.0, 0.0, 1.0); // Black
-const vec4 InvalidTexture_StpColor2  = vec4(0.5, 0.5, 0.5, 1.0); // Gray
-const float InvalidTexture_Step = 8.0 / 256.0;
+const vec3 OutOfBoundsTexture_Color1 = vec3(1.0, 0.05, 0.0); // Red with slight Orange
+const vec3 MissingTexture_Color1     = vec3(1.0, 0.0, 1.0); // Magenta
+const vec3 InvalidTexture_Color2     = vec3(0.0, 0.0, 0.0); // Black
+const vec3 InvalidTexture_StpColor2  = vec3(0.5, 0.5, 0.5); // Gray
+//const float InvalidTexture_Step = 8.0 / 256.0;
+const vec2 InvalidTexture_Step = vec2((8.0 / 256.0) / 4.0, (8.0 / 256.0) / 8.0); // Divided by number of texture page columns, rows
 
 const int LightMode_AmbientDirectional = 0;
 const int LightMode_Ambient            = 1;
@@ -52,26 +49,30 @@ const int RenderPass_Pass3SemiTransparent             = 2;
 
 vec3 calcUV(vec2 uv) {
 	// X,Y is tiled U,V offset and Z,W is tiled U,V wrap size.
-	if (pass_TiledArea.z != 0.0) {
-		uv.x = pass_TiledArea.x + mod(uv.x, pass_TiledArea.z);
-	}
-	if (pass_TiledArea.w != 0.0) {
-		uv.y = pass_TiledArea.y + mod(uv.y, pass_TiledArea.w);
-	}
-	float outOfBounds = ((uv.x < 0.0 || uv.y < 0.0 || uv.x > 1.0 || uv.y > 1.0) ? 1.0 : 0.0);
-	return vec3(uv.x, uv.y, outOfBounds);
+	// We only add the offset and wrap a component if the wrap size is non-zero.
+	uv = mix(uv, pass_TiledArea.xy + mod(uv, pass_TiledArea.zw), bvec2(pass_TiledArea.zw));
+	float outOfBounds = mix(0.0, 1.0, any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0))));
+	// Readable version of above:
+	//if (pass_TiledArea.z != 0.0) {
+	//	uv.x = pass_TiledArea.x + mod(uv.x, pass_TiledArea.z);
+	//}
+	//if (pass_TiledArea.w != 0.0) {
+	//	uv.y = pass_TiledArea.y + mod(uv.y, pass_TiledArea.w);
+	//}
+	//float outOfBounds = ((uv.x < 0.0 || uv.y < 0.0 || uv.x > 1.0 || uv.y > 1.0) ? 1.0 : 0.0);
+	return vec3(uv, outOfBounds);
 }
 
-vec4 calcInvalidTexture(vec3 uv) {
-	bool invalidX = (mod(uv.x, InvalidTexture_Step * 2) >= InvalidTexture_Step);
-	bool invalidY = (mod(uv.y, InvalidTexture_Step * 2) >= InvalidTexture_Step);
-	if (invalidX == invalidY) {
+vec3 calcInvalidTexture(vec3 uv) {
+	// Check if we're in an even or odd square
+	bvec2 evenOdd = greaterThanEqual(mod(uv.xy, InvalidTexture_Step * 2.0), InvalidTexture_Step);
+	if (evenOdd.x == evenOdd.y) {
 		// Primary color for even squares
-		return (uv.z == 0 ? MissingTexture_Color1 : OutOfBoundsTexture_Color1);
+		return (uv.z == 0.0 ? MissingTexture_Color1 : OutOfBoundsTexture_Color1);
 	} else {
 		// Secondary color for odd squares
 		// Change black squares to gray, so that they show up with semi-transparency
-		return (semiTransparentPass != 2 ? InvalidTexture_Color2 : InvalidTexture_StpColor2);
+		return (u_SemiTransparentPass != 2 ? InvalidTexture_Color2 : InvalidTexture_StpColor2);
 	}
 }
 
@@ -84,46 +85,41 @@ void main(void) {
 
 	// Process texture UVs and stp bit:
 	vec3 uv = calcUV(pass_Uv); // uv.z is non-zero when out-of-bounds
-	vec4 tex2D;
+	vec3 texColor;
 	bool stp;
-	if (textureMode == 0 && uv.z == 0.0) {
+	if (u_TextureMode == 0 && uv.z == 0.0) {
 		// Note: I read a comment stating the result of texture() can be undefined
 		// when inside an if statement. If issues arise, then try moving this outside.
-		tex2D      = texture(mainTex, vec2(uv.x * 0.5,       uv.y));
-		vec4 stp2D = texture(mainTex, vec2(uv.x * 0.5 + 0.5, uv.y));
-		stp = (stp2D.x != 0.0);
-	} else if (textureMode == 1) {
+		texColor = texture(u_MainTexture, vec2(uv.x * 0.5,       uv.y)).xyz;
+		stp      = texture(u_MainTexture, vec2(uv.x * 0.5 + 0.5, uv.y)).x != 0.0;
+	} else if (u_TextureMode == 1) {
 		// Use vertex color only
-		tex2D = vec4(1.0, 1.0, 1.0, 1.0);
+		texColor = vec3(1.0);
 		stp = true; // Untextured always treats stp bit as set.
 	} else {
 		// Use missing/out-of-bounds texture checkered pattern
-		tex2D = calcInvalidTexture(uv);
+		texColor = calcInvalidTexture(uv);
 		stp = true; // Show semi-transparency and avoid black masking
 	}
 
 	// Process semi-transparency discarding:
-	if (!stp && tex2D.xyz == maskColor) {
+	if (!stp && texColor == u_MaskColor) {
 		discard; // Black surfaces are transparent when stp bit is unset.
-	} else if (semiTransparentPass == 1) {
-		if (stp) {
-			discard; // Semi-transparent surface during no-stp bit pass.
-		}
-	} else if (semiTransparentPass == 2) {
-		if (!stp) {
-			discard; // Opaque surface during stp bit pass.
-		}
+	} else if (stp && u_SemiTransparentPass == 1) {
+		discard; // Semi-transparent surface during no-stp bit pass.
+	} else if (!stp && u_SemiTransparentPass == 2) {
+		discard; // Opaque surface during stp bit pass.
 	}
 
 	// Process lighting and final color:
-	vec4 finalColor = tex2D * pass_Color;
-	if (lightMode == 0) {
-		finalColor *= (pass_Ambient + pass_NormalDotLight);
-	} else if (lightMode == 1) {
-		finalColor *= (pass_Ambient) * 2.0;
-	} else if (lightMode == 2) {
+	vec3 finalColor = texColor * pass_Color;
+	if (u_LightMode == 0) {
+		finalColor *= (u_AmbientColor + pass_NormalDotLight);
+	} else if (u_LightMode == 1) {
+		finalColor *= (u_AmbientColor) * 2.0;
+	} else if (u_LightMode == 2) {
 		finalColor *= (pass_NormalDotLight);
 	}
 	// No extra logic for lightMode == 3
-	out_Color = finalColor;
+	out_Color = vec4(finalColor, 1.0);
 }

--- a/Shaders/Shader.vert
+++ b/Shaders/Shader.vert
@@ -1,48 +1,56 @@
 ﻿#version 430
 //FALLBACK_VERSION 150
+#define SSBO_SUPPORTED
 #define JOINTS_SUPPORTED
 
 in vec3 in_Position;
-in vec3 in_Color;
 in vec3 in_Normal;
+in vec3 in_Color;
 in vec2 in_Uv;
 in vec4 in_TiledArea;
-#ifdef JOINTS_SUPPORTED
-in uvec2 in_Joint;
-
-layout(std140, binding = 0) buffer jointBuffer
-{
-	mat4 joints[]; // vertex,normal joint pairs
-};
-#endif
+in uvec2 in_Joint; // Always defined in order to handle DiscardPixel
 
 out vec2 pass_Uv;
 out vec4 pass_TiledArea;
-out vec4 pass_Ambient;
-out vec4 pass_Color;
+out vec3 pass_Color;
 out float pass_NormalDotLight;
 out float pass_NormalLength;
-out float pass_DiscardPixel;
+out float pass_DiscardPixel; // > 0.0 when the vertex is jointed, and we want to hide it
 
-uniform mat3 normalMatrix;
-uniform mat4 modelMatrix;
-uniform mat4 mvpMatrix;
-uniform mat4 viewMatrix;
-uniform mat4 projectionMatrix;
-uniform vec3 lightDirection;
-uniform vec3 maskColor;
-uniform vec3 ambientColor;
-uniform vec3 solidColor;
-uniform vec2 uvOffset;
-uniform int jointMode;
-uniform int lightMode;
-uniform int colorMode;
-uniform int textureMode;
-uniform int semiTransparentPass;
-uniform float lightIntensity;
-uniform sampler2D mainTex;
+#ifdef JOINTS_SUPPORTED
+#ifdef SSBO_SUPPORTED
+layout(std140, binding = 0) buffer buffer_JointTransforms
+{
+	mat4 b_JointTransforms[]; // vertex,normal joint pairs
+};
+#else
+#define MAX_JOINTS 512
+layout(std140) uniform buffer_JointTransforms
+{
+	mat4 b_JointTransforms[MAX_JOINTS * 2]; // vertex,normal joint pairs
+};
+#endif
+#endif
 
-const float DISCARD_VALUE = 100000000;
+uniform sampler2D u_MainTexture;
+uniform mat3 u_NormalMatrix;
+uniform mat3 u_NormalSpriteMatrix;
+uniform mat4 u_ModelMatrix;
+uniform mat4 u_ModelSpriteMatrix;
+uniform mat4 u_ViewMatrix;
+uniform mat4 u_ProjectionMatrix;
+uniform vec3 u_LightDirection;
+uniform vec3 u_MaskColor;
+uniform vec3 u_AmbientColor;
+uniform vec3 u_SolidColor;
+uniform vec2 u_UvOffset;
+uniform int u_JointMode;
+uniform int u_LightMode;
+uniform int u_ColorMode;
+uniform int u_TextureMode;
+uniform int u_SemiTransparentPass;
+uniform float u_LightIntensity;
+
 const uint NO_JOINT = 0u;
 
 const int ColorMode_VertexColor = 0;
@@ -50,60 +58,58 @@ const int ColorMode_SolidColor  = 1;
 
 const int JointMode_Enabled  = 0;
 const int JointMode_Disabled = 1;
+const int JointMode_Hide     = 2;
+
 
 mat4 getModelMatrix() {
 	#ifdef JOINTS_SUPPORTED
-	if (jointMode == 0 && in_Joint.x != NO_JOINT) {
-		return joints[(in_Joint.x - 1) * 2];
+	if (u_JointMode == 0 && in_Joint.x != NO_JOINT) {
+		return b_JointTransforms[(in_Joint.x - 1u) * 2u];
 	}
 	#endif
-	return modelMatrix;
+	return u_ModelMatrix;
 }
 
 mat3 getNormalMatrix() {
 	#ifdef JOINTS_SUPPORTED
-	if (jointMode == 0 && in_Joint.y != NO_JOINT) {
-		return mat3(joints[(in_Joint.y - 1) * 2 + 1]);
+	if (u_JointMode == 0 && in_Joint.y != NO_JOINT) {
+		return mat3(b_JointTransforms[(in_Joint.y - 1u) * 2u + 1u]);
 	}
 	#endif
-	return normalMatrix;
+	return u_NormalMatrix;
 }
 
+
 void main(void) {
-	// Check for discarded vertices (coordinates match DISCARD_VALUE):
-	pass_DiscardPixel = step(DISCARD_VALUE, in_Position.x);
+	// Check for discarded vertices:
+	// We only discard jointed vertices for JointMode 2, normals are ignored
+	pass_DiscardPixel = mix(0.0, 1.0, u_JointMode == 2 && in_Joint.x != NO_JOINT);
 
 	// Process position:
-	#ifdef JOINTS_SUPPORTED
 	mat4 jointModelMatrix = getModelMatrix();
-	vec4 worldPosition = jointModelMatrix * vec4(in_Position, 1.0);
-	vec4 cameraPosition = viewMatrix * worldPosition;
-	gl_Position = projectionMatrix * cameraPosition;
-	#else
-	// Skip combining matrices and just use pre-defined mvpMatrix when joints aren't in use
-	gl_Position = mvpMatrix * vec4(in_Position, 1.0);
-	#endif
+	vec4 worldPosition = jointModelMatrix * (u_ModelSpriteMatrix * vec4(in_Position, 1.0));
+	vec4 cameraPosition = u_ViewMatrix * worldPosition;
+	gl_Position = u_ProjectionMatrix * cameraPosition;
 
 	// Process normal and directional lighting:
 	mat3 jointNormalMatrix = getNormalMatrix();
 	pass_NormalLength = length(in_Normal);
-	vec3 normal = jointNormalMatrix * in_Normal;
+	vec3 normal = jointNormalMatrix * (u_NormalSpriteMatrix * in_Normal);
 	if (dot(normal, normal) != 0.0) {
 		normal = normalize(normal);
 		// todo: Should we preserve original normal length?
 		//normal *= pass_NormalLength;
 	}
-	pass_NormalDotLight = clamp(dot(normal, lightDirection), 0.0, 1.0) * lightIntensity;
+	pass_NormalDotLight = clamp(dot(normal, u_LightDirection), 0.0, 1.0) * u_LightIntensity;
 
 	// Process UVs:
-	pass_Uv = in_Uv + uvOffset;
+	pass_Uv = in_Uv + u_UvOffset;
 	pass_TiledArea = in_TiledArea;
 
 	// Process color:
-	pass_Ambient = vec4(ambientColor, 1.0);
-	if (colorMode == 0) {
-		pass_Color = vec4(in_Color, 1.0);
+	if (u_ColorMode == 0) {
+		pass_Color = in_Color;
 	} else {
-		pass_Color = vec4(solidColor, 1.0);
+		pass_Color = u_SolidColor;
 	}
 }


### PR DESCRIPTION
* Fixed pressing space on tree view nodes without checkboxes causing the checkboxes to reappear.
* Fixed delayed scroll in tree view after selecting an item.
* Fixed excess lag caused by tree view due to custom draw.
* AnimationBatch no longer controls the models MeshBatch, this should now be done by the caller.
* Fixed TriangleMeshBuilder sprite normal, and OctoSphere being inverted.
* Shader now tries to support joints for GLSL 150 by using UBOs. When an entity has more joints than the UBO can fit, it will fallback to baking the connections.
* Changed main texture uniform from being bound as an attribute to a uniform (which fixes some issues with how the uniform is assigned).
* Texture uniform is now assigned via texture unit index.
* Joint attribute is now always present in the shader, and is used instead of DiscardValue to determine if a joint should be hidden.
* A lot of shader refactoring and optimizations. Uniforms now have the `u_` prefix to help distinguish them from local variables, and color is now processed in vec3, since alpha is never used.
* Fixed sprite joint matrices not correctly handling camera rotation (since they were attempting to apply it at setup time and not at render time). Now, two more matrix uniforms are used to apply sprite camera rotation.
* Fixed sprite transforms incorrectly eliminating model rotation.
* TextureBinder now combines 32 VRAM pages into a single texture, this reduces the number of texture binds, and allows for much more mesh batching.
* TextureBinder now uses TexSubImage2D after the first call.
* BufferSubData is now used instead of BufferData after the first call.
* Fixed normal for Neversoft PSX sprites being inverted.
* Meshes now get their data from the VertexArrayObject class. All root entities use a single VAO for all meshes, and meshes will use a portion of the data stored in it.
* Added mesh batching for the models mesh batch. With this, the number of draw calls can be reduced by between x4 and x8 (also thanks to the texture sharing).
* Fixed Scene.CameraYawRotation being inverted.
* Vertex attributes are no longer bound every time a mesh is drawn, but only after data is assigned. When drawing a mesh, only the vertex array is bound.
* Baked connections now take sprite rotation into account.