### PR TITLE
Switch VRAM semi-transparency storage to same as normal Textures

### DIFF
--- a/Common/Exporters/PNGExporter.cs
+++ b/Common/Exporters/PNGExporter.cs
@@ -14,18 +14,7 @@ namespace PSXPrev.Common.Exporters
 
         public void Export(Texture texture, string name, string selectedPath)
         {
-            if (texture.IsVRAMPage)
-            {
-                // Remove the semi-transparency section from the exported bitmap.
-                using (var bitmap = VRAM.ConvertTexture(texture, false))
-                {
-                    ExportBitmap(bitmap, name, selectedPath);
-                }
-            }
-            else
-            {
-                ExportBitmap(texture.Bitmap, name, selectedPath);
-            }
+            ExportBitmap(texture.Bitmap, name, selectedPath);
         }
 
         public void ExportEmpty(Color color, int textureId, string selectedPath, int width = 1, int height = 1)

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -145,10 +145,10 @@ namespace PSXPrev.Common
 
         // Usable area of the texture (only different from Width/Height when IsVRAMPage is true).
         [Browsable(false)]
-        public int RenderWidth => IsVRAMPage ? VRAM.PageSize : Width;
+        public int RenderWidth => Width;// IsVRAMPage ? VRAM.PageSize : Width;
 
         [Browsable(false)]
-        public int RenderHeight => IsVRAMPage ? VRAM.PageSize : Height;
+        public int RenderHeight => Height;// IsVRAMPage ? VRAM.PageSize : Height;
 
         [Browsable(false)]
         public ushort[][] Palettes { get; set; }
@@ -411,22 +411,14 @@ namespace PSXPrev.Common
                         var g = p[1];
                         var r = p[2];
                         var a = p[3];
-                        stp = false;
-                        if (!IsVRAMPage)
+                        if (s != null)
                         {
-                            if (s != null)
-                            {
-                                s += (x * 4); // Normal textures store stp bits in a separate image
-                                stp = *s != NoSemiTransparentFlag.B;
-                            }
+                            s += (x * 4); // Normal textures store stp bits in a separate image
+                            stp = *s != NoSemiTransparentFlag.B;
                         }
                         else
                         {
-                            if (VRAM.PageSemiTransparencyX + x < Width)
-                            {
-                                p += (VRAM.PageSemiTransparencyX * 4); // VRAM textures store stp bits directly in the same image
-                                stp = *p != NoSemiTransparentFlag.B;
-                            }
+                            stp = false;
                         }
                         transparent = a == 0 || (!stp && r == 0 && g == 0 && b == 0);
                         paletteIndex = null;

--- a/Common/TexturePalette.cs
+++ b/Common/TexturePalette.cs
@@ -19,9 +19,22 @@ namespace PSXPrev.Common
             return (a << 24) | (r << 16) | (g << 8) | b;
         }
 
+        public static ushort FromArgb(int argb, bool stp = false)
+        {
+            var r = (byte)(argb >> 16);
+            var g = (byte)(argb >>  8);
+            var b = (byte)(argb      );
+            return FromComponents(r, g, b, stp);
+        }
+
         public static Color ToColor(ushort color, bool noTransparent = false)
         {
             return Color.FromArgb(ToArgb(color, noTransparent));
+        }
+
+        public static ushort FromColor(Color color, bool stp = false)
+        {
+            return FromComponents(color.R, color.G, color.B, stp);
         }
 
 

--- a/Forms/Controls/ScenePreviewer.cs
+++ b/Forms/Controls/ScenePreviewer.cs
@@ -170,10 +170,6 @@ namespace PSXPrev.Forms.Controls
                 var bmpData = bitmap.LockBits(rect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
                 try
                 {
-                    // These values are modified by TextureBinder, so change them back to default.
-                    // (Maybe TextureBinder should restore these when done...)
-                    GL.PixelStore(PixelStoreParameter.UnpackRowLength, 0);
-                    GL.PixelStore(PixelStoreParameter.UnpackSkipPixels, 0);
                     GL.ReadPixels(0, 0, bmpData.Width, bmpData.Height, PixelFormat.Bgra, PixelType.UnsignedByte, bmpData.Scan0);
                 }
                 finally

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -803,6 +803,7 @@ namespace PSXPrev.Forms
                 _packedTextures.Clear();
                 _animations.Clear();
                 _vram.ClearAllPages();
+                vramPreviewer.InvalidateTexture(); // Invalidate to make sure we redraw.
 
                 // Reset scene batches
                 _scene.MeshBatch.Reset(0);
@@ -4402,6 +4403,7 @@ namespace PSXPrev.Forms
                     if (!texture.IsPacked)
                     {
                         texture.X = VRAM.ClampTextureX(texture.X);
+                        texturePreviewer.InvalidateUVs(); // Offset of UV lines has changed
                     }
                     else
                     {
@@ -4413,6 +4415,7 @@ namespace PSXPrev.Forms
                     if (!texture.IsPacked)
                     {
                         texture.Y = VRAM.ClampTextureY(texture.Y);
+                        texturePreviewer.InvalidateUVs(); // Offset of UV lines has changed
                     }
                     else
                     {
@@ -4424,6 +4427,7 @@ namespace PSXPrev.Forms
                     if (!texture.IsPacked)
                     {
                         texture.TexturePage = VRAM.ClampTexturePage(texture.TexturePage);
+                        texturePreviewer.InvalidateUVs(); // Set of UV lines has changed
                     }
                     else
                     {

--- a/Forms/Utils/ControlExtensions.cs
+++ b/Forms/Utils/ControlExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
 using PSXPrev.Common;
@@ -124,6 +125,15 @@ namespace PSXPrev.Forms.Utils
                 }
             }
             comboBox.DropDownWidth = width;
+        }
+
+
+        public static Rectangle GetAutoScrollRectangle(this ScrollableControl scrollableControl)
+        {
+            var scrollPos  = scrollableControl.AutoScrollPosition;
+            var scrollSize = scrollableControl.ClientSize;
+            // Negate scrollPos, since AutoScrollPosition is negative to signify positive offset
+            return new Rectangle(-scrollPos.X, -scrollPos.Y, scrollSize.Width, scrollSize.Height);
         }
 
 


### PR DESCRIPTION
* VRAM now stores semi-transparency information in the designated Texture.SemiTransparentMap, just like normal textures. With this, handling VRAM textures and normal textures no longer needs different logic.
* VRAM now caches its graphics objects when drawing to speed up mass updates to VRAM (probably). These graphics objects are disposed of during the Update functions.
* Texture.RenderWidth and RenderHeight now return the same values as Width and Height, and will be removed eventually.
* Fixed TexturePreviewer not getting invalidated during certain events like property changes or ClearScanResults.
* Fixed TexturePreviewer semi-transparency caching not working correctly with clipRect, thus making it effectively useless unless scrolling down/right. The rect that's cached is now the viewable auto scroll rectangle, while clipRect is mearly used to handle what stp lines to update.
* Added caching for TexturePreviewer UV lines. Caching is done by drawing all UV lines to a bitmap once, and then rendering that bitmap from there on. This does have a larger performance hit when first zooming in or out (when part of the texture is off the screen), but has no lag afterwards, making it cleaner to scroll around a texture.