### PR TITLE
Settings catch-up and remove Old UV Alignment

### DIFF
--- a/Common/Exporters/DAEExporter.cs
+++ b/Common/Exporters/DAEExporter.cs
@@ -18,7 +18,7 @@ namespace PSXPrev.Common.Exporters
         private ExportModelOptions _options;
         private string _baseName;
 
-        public void Export(ExportModelOptions options, RootEntity[] entities)
+        public int Export(ExportModelOptions options, RootEntity[] entities)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -48,6 +48,8 @@ namespace PSXPrev.Common.Exporters
             _exportedTextures = null;
             _modelPreparer.Dispose();
             _modelPreparer = null;
+
+            return groups.Length;
         }
 
         private void ExportEntities(int index, Tuple<int, long> group, RootEntity[] entities, List<ModelEntity> models)

--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -710,21 +710,15 @@ namespace PSXPrev.Common.Exporters
                     var row    = cellIndex / _countX;
                     foreach (var texture in cellTextures)
                     {
-                        // We can't just use this, since we still need to support disabling the UV alignment fix.
-                        //var uvScalar = (float)VRAM.PageSize;
-                        //var width  = texture.RenderWidth;
-                        //var height = texture.RenderHeight;
                         var uvScalar = GeomMath.UVScalar;
-                        var width  = !texture.IsVRAMPage ? texture.Width  : (int)uvScalar; //VRAM.PageSize;
-                        var height = !texture.IsVRAMPage ? texture.Height : (int)uvScalar; //VRAM.PageSize;
                         var packedInfo = new PackedTextureInfo
                         {
                             //Texture = texture,
                             // Keep float casts in-case we replace uvScalar with VRAM.PageSize.
                             OffsetX = ((float)texture.X / uvScalar + column) / _countX,
                             OffsetY = ((float)texture.Y / uvScalar + row)    / _countY,
-                            ScalarX = (width  > 0 ? ((float)width  / (uvScalar * _countX)) : (1f / _countX)),
-                            ScalarY = (height > 0 ? ((float)height / (uvScalar * _countY)) : (1f / _countY)),
+                            ScalarX = ((float)texture.RenderWidth  / uvScalar) / _countX,
+                            ScalarY = ((float)texture.RenderHeight / uvScalar) / _countY,
                         };
                         _packedTextureInfos.Add(texture, packedInfo);
                     }
@@ -852,7 +846,7 @@ namespace PSXPrev.Common.Exporters
 
             public int TexturePage => OriginalTexture.TexturePage;
 
-            public bool IsTiled => Width != 0f && Height != 0f;
+            public bool IsTiled => Width != 0f || Height != 0f;
 
             public TiledTextureInfo(Texture originalTexture, Vector4 tiledArea)
             {

--- a/Common/Exporters/OBJExporter.cs
+++ b/Common/Exporters/OBJExporter.cs
@@ -19,7 +19,7 @@ namespace PSXPrev.Common.Exporters
         private ExportModelOptions _options;
         private string _baseName;
 
-        public void Export(ExportModelOptions options, RootEntity[] entities)
+        public int Export(ExportModelOptions options, RootEntity[] entities)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -46,6 +46,8 @@ namespace PSXPrev.Common.Exporters
             _mtlDictionary = null;
             _modelPreparer.Dispose();
             _modelPreparer = null;
+
+            return groups.Length;
         }
 
         private void ExportEntities(int index, Tuple<int, long> group, RootEntity[] entities, List<ModelEntity> models)

--- a/Common/Exporters/PLYExporter.cs
+++ b/Common/Exporters/PLYExporter.cs
@@ -15,7 +15,7 @@ namespace PSXPrev.Common.Exporters
         private ExportModelOptions _options;
         private string _baseName;
 
-        public void Export(ExportModelOptions options, RootEntity[] entities)
+        public int Export(ExportModelOptions options, RootEntity[] entities)
         {
             _options = options?.Clone() ?? new ExportModelOptions();
             // Force any required options for this format here, before calling Validate.
@@ -45,6 +45,8 @@ namespace PSXPrev.Common.Exporters
             _exportedTextures = null;
             _modelPreparer.Dispose();
             _modelPreparer = null;
+
+            return groups.Length;
         }
 
         private void ExportEntities(int index, Tuple<int, long> group, RootEntity[] entities, List<ModelEntity> models)

--- a/Common/GeomMath.cs
+++ b/Common/GeomMath.cs
@@ -19,22 +19,8 @@ namespace PSXPrev.Common
 
         public const float Fixed12Scalar = 4096f;
         public const float Fixed16Scalar = 65536f;
+        public const float UVScalar = (float)Renderer.VRAM.PageSize;
 
-        public static float UVScalar => Program.FixUVAlignment ? 256f : 255f;
-
-        // Use Vector3.Unit(XYZ) fields instead.
-        //public static Vector3 XVector = new Vector3(1f, 0f, 0f);
-        //public static Vector3 YVector = new Vector3(0f, 1f, 0f);
-        //public static Vector3 ZVector = new Vector3(0f, 0f, 1f);
-
-        // Use Vector3.Distance instead.
-        //public static float VecDistance(Vector3 a, Vector3 b)
-        //{
-        //    var x = a.X - b.X;
-        //    var y = a.Y - b.Y;
-        //    var z = a.Z - b.Z;
-        //    return (float)Math.Sqrt((x * x) + (y * y) + (z * z));
-        //}
 
         public static Vector3 ToVector3(this Color color)
         {
@@ -873,12 +859,18 @@ namespace PSXPrev.Common
 
         public static float ConvertFixed16(int value) => value / Fixed16Scalar;
 
+        public static float ConvertNormal(int xyzComponent) => xyzComponent / Fixed12Scalar;
+
+        public static Vector3 ConvertNormal(int x, int y, int z)
+        {
+            return new Vector3(x / Fixed12Scalar, y / Fixed12Scalar, z / Fixed12Scalar);
+        }
+
         public static float ConvertUV(uint uvComponent) => uvComponent / UVScalar;
 
         public static Vector2 ConvertUV(uint u, uint v)
         {
-            var scalar = UVScalar;
-            return new Vector2(u / scalar, v / scalar);
+            return new Vector2(u / UVScalar, v / UVScalar);
         }
 
         public static float InterpolateValue(float src, float dst, float delta)

--- a/Common/ModelEntity.cs
+++ b/Common/ModelEntity.cs
@@ -66,11 +66,11 @@ namespace PSXPrev.Common
         }
 
 
-        private Vector2 UVTextureOffset => new Vector2((float)Texture.X / Renderer.VRAM.PageSize,
-                                                       (float)Texture.Y / Renderer.VRAM.PageSize);
+        private Vector2 UVTextureOffset => new Vector2((float)Texture.X / GeomMath.UVScalar,
+                                                       (float)Texture.Y / GeomMath.UVScalar);
 
-        private Vector2 UVTextureSize   => new Vector2((float)Texture.Width  / Renderer.VRAM.PageSize,
-                                                       (float)Texture.Height / Renderer.VRAM.PageSize);
+        private Vector2 UVTextureSize   => new Vector2((float)Texture.Width  / GeomMath.UVScalar,
+                                                       (float)Texture.Height / GeomMath.UVScalar);
 
         public Vector2 ConvertUV(Vector2 uv, bool tiled)
         {

--- a/Common/Parsers/ANParser.cs
+++ b/Common/Parsers/ANParser.cs
@@ -8,12 +8,14 @@ namespace PSXPrev.Common.Parsers
 {
     public class ANParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "AN";
+
         public ANParser(AnimationAddedAction animationAdded)
             : base(animationAdded: animationAdded)
         {
         }
 
-        public override string FormatName => "AN";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/BFFParser.cs
+++ b/Common/Parsers/BFFParser.cs
@@ -10,6 +10,8 @@ namespace PSXPrev.Common.Parsers
     // We extend PILParser so that we can share the ReadPSI function (without having to construct a separate instance).
     public class BFFParser : PILParser
     {
+        public const string FormatNameConst = "BFF";
+
         // UVs are in texture space, and are stored in units of 2, so that 128
         // can be used to reach the last row/column of the texture.
         private const float UVConst = 2f; // UV multiplier for FMM models
@@ -34,7 +36,7 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "BFF";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/CLTParser.cs
+++ b/Common/Parsers/CLTParser.cs
@@ -5,12 +5,14 @@ namespace PSXPrev.Common.Parsers
     // Not supported yet, since we have no way to store loose palettes.
     public class CLTParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "CLT";
+
         public CLTParser(TextureAddedAction textureAdded)
             : base(textureAdded: textureAdded)
         {
         }
 
-        public override string FormatName => "CLT";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/FileOffsetScanner.cs
+++ b/Common/Parsers/FileOffsetScanner.cs
@@ -7,8 +7,8 @@ namespace PSXPrev.Common.Parsers
 {
     // Return false if the result is ignored, in which case it will be disposed of
     public delegate bool EntityAddedAction(FileOffsetScanner scanner, RootEntity rootEntity, long offset);
-    public delegate bool AnimationAddedAction(FileOffsetScanner scanner, Animation animation, long offset);
     public delegate bool TextureAddedAction(FileOffsetScanner scanner, Texture texture, long offset);
+    public delegate bool AnimationAddedAction(FileOffsetScanner scanner, Animation animation, long offset);
     public delegate void ScannerProgressAction(FileOffsetScanner scanner, long offset);
 
     public abstract class FileOffsetScanner : IDisposable

--- a/Common/Parsers/HMDParser.cs
+++ b/Common/Parsers/HMDParser.cs
@@ -11,6 +11,8 @@ namespace PSXPrev.Common.Parsers
 {
     public class HMDParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "HMD";
+
         private uint _blockCount;
         private bool _modelIsJoint;
         private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
@@ -23,7 +25,7 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "HMD";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/Limits.cs
+++ b/Common/Parsers/Limits.cs
@@ -4,6 +4,7 @@
     {
         // Strictness settings
         public static bool IgnoreHMDVersion;
+        public static bool IgnorePMDVersion;
         public static bool IgnoreTIMVersion;
         public static bool IgnoreTMDVersion;
 

--- a/Common/Parsers/MODParser.cs
+++ b/Common/Parsers/MODParser.cs
@@ -8,6 +8,8 @@ namespace PSXPrev.Common.Parsers
     // Argonaut's Blazing Render engine: .MOD model format
     public class MODParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "MOD";
+
         private float _scaleDivisor = 1f;
         //private readonly Vector3[] _boundingBox = new Vector3[9];
         private Vector3[] _vertices;
@@ -20,7 +22,7 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "MOD";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/PILParser.cs
+++ b/Common/Parsers/PILParser.cs
@@ -12,6 +12,8 @@ namespace PSXPrev.Common.Parsers
     // Blitz Games: .PIL model library format
     public class PILParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "PIL";
+
         private const float UVConst = 1f; // UV multiplier for PSI models
 
         private const uint SortIndex = 0; // 0-7
@@ -55,7 +57,7 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "PIL";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/PMDParser.cs
+++ b/Common/Parsers/PMDParser.cs
@@ -7,6 +7,8 @@ namespace PSXPrev.Common.Parsers
 {
     public class PMDParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "PMD";
+
         private readonly Dictionary<RenderInfo, List<Triangle>> _groupedTriangles = new Dictionary<RenderInfo, List<Triangle>>();
         private readonly List<ModelEntity> _models = new List<ModelEntity>();
 
@@ -15,12 +17,12 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "PMD";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {
             var version = reader.ReadUInt32();
-            if (version == 0x00000042)
+            if (Limits.IgnorePMDVersion || version == 0x00000042)
             {
                 ParsePMD(reader);
             }

--- a/Common/Parsers/PXLParser.cs
+++ b/Common/Parsers/PXLParser.cs
@@ -5,12 +5,14 @@ namespace PSXPrev.Common.Parsers
     // Not supported yet, since we have no way to assign loose palettes to textures.
     public class PXLParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "PXL";
+
         public PXLParser(TextureAddedAction textureAdded)
             : base(textureAdded: textureAdded)
         {
         }
 
-        public override string FormatName => "PXL";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/TIMParser.cs
+++ b/Common/Parsers/TIMParser.cs
@@ -9,12 +9,14 @@ namespace PSXPrev.Common.Parsers
 {
     public class TIMParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "TIM";
+
         public TIMParser(TextureAddedAction textureAdded)
             : base(textureAdded: textureAdded)
         {
         }
 
-        public override string FormatName => "TIM";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/TMDHelper.cs
+++ b/Common/Parsers/TMDHelper.cs
@@ -658,16 +658,8 @@ namespace PSXPrev.Common.Parsers
                     if (tumValue != 0 || tvmValue != 0) // We're not tiled if there's no wrap size.
                     {
                         isTiled = true;
-                        if (Program.FixUVAlignment)
-                        {
-                            tuvm = GeomMath.ConvertUV(((((tumValue << 3) ^ 0xff) + 1) & 0xff),
-                                                      ((((tvmValue << 3) ^ 0xff) + 1) & 0xff));
-                        }
-                        else
-                        {
-                            tuvm = GeomMath.ConvertUV(((tumValue << 3) ^ 0xff),
-                                                      ((tvmValue << 3) ^ 0xff));
-                        }
+                        tuvm = GeomMath.ConvertUV(((((tumValue << 3) ^ 0xff) + 1) & 0xff),
+                                                  ((((tvmValue << 3) ^ 0xff) + 1) & 0xff));
                         tuva = GeomMath.ConvertUV((tuaValue << 3),
                                                   (tvaValue << 3));
                     }

--- a/Common/Parsers/TMDParser.cs
+++ b/Common/Parsers/TMDParser.cs
@@ -7,6 +7,8 @@ namespace PSXPrev.Common.Parsers
 {
     public class TMDParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "TMD";
+
         private ObjBlock[] _objBlocks;
         private Vector3[] _vertices;
         private Vector3[] _normals;
@@ -16,7 +18,7 @@ namespace PSXPrev.Common.Parsers
         {
         }
 
-        public override string FormatName => "TMD";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/TODParser.cs
+++ b/Common/Parsers/TODParser.cs
@@ -8,12 +8,14 @@ namespace PSXPrev.Common.Parsers
 {
     public class TODParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "TOD";
+
         public TODParser(AnimationAddedAction animationAdded)
             : base(animationAdded: animationAdded)
         {
         }
 
-        public override string FormatName => "TOD";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Parsers/VDFParser.cs
+++ b/Common/Parsers/VDFParser.cs
@@ -8,12 +8,14 @@ namespace PSXPrev.Common.Parsers
 {
     public class VDFParser : FileOffsetScanner
     {
+        public const string FormatNameConst = "VDF";
+
         public VDFParser(AnimationAddedAction animationAdded)
             : base(animationAdded: animationAdded)
         {
         }
 
-        public override string FormatName => "VDF";
+        public override string FormatName => FormatNameConst;
 
         protected override void Parse(BinaryReader reader)
         {

--- a/Common/Triangle.cs
+++ b/Common/Triangle.cs
@@ -223,78 +223,76 @@ namespace PSXPrev.Common
         {
             // This fix should be applied even if all 3 UVs are Vector2.Zero.
             // However, it should not be applied if this face is untextured.
-            if (Program.FixUVAlignment)
-            {
-                // This type of tearing occurs only when the UV alignment fix is in place.
-                // It happens if all of the U or V coordinates or identical, effectively turning the UV face into a 1D line.
-                // When this happens with the alignment fix, the UV line is right on the pixel boundary.
-                // Incrementing any one of the 3 U/V coordinates will fix 1D UV tearing.
 
-                var uvs = TiledUv?.BaseUv ?? Uv;
+            // This type of tearing occurs only when the UV alignment fix is in place.
+            // It happens if all of the U or V coordinates or identical, effectively turning the UV face into a 1D line.
+            // When this happens with the alignment fix, the UV line is right on the pixel boundary.
+            // Incrementing any one of the 3 U/V coordinates will fix 1D UV tearing.
+
+            var uvs = TiledUv?.BaseUv ?? Uv;
 
 #if true
-                // Current Solution B:
-                // This works by offsetting every UV coordinate slightly if its on a pixel boundary.
-                // If the offsetted UV coordinate is the max, then the offset will be subtracted,
-                // otherwise the offset will be added. If the min and max component are equal, then the
-                // coordinate will be offset to the center of the pixel.
-                // This is preferred over Solution A, because it also solves Wireframe/Vertices fighting.
-                // The downside is it will become less accurate if you export a model with a very large single texture.
-                var uvMin = uvs[0];
-                var uvMax = uvMin;
-                for (var i = 1; i < 3; i++)
-                {
-                    var uv = uvs[i];
-                    uvMin = Vector2.ComponentMin(uvMin, uv);
-                    uvMax = Vector2.ComponentMax(uvMax, uv);
-                }
-
-                var uvScalar = GeomMath.UVScalar;
-                var inc = 0.001f / uvScalar; // Offset UV coordinates by 1/1000th of a pixel
-                var half = 0.5f / uvScalar;  // Offset UV coordinates to the center of the pixel
-                for (var i = 0; i < 3; i++)
-                {
-                    var uv = uvs[i];
-                    // Check if this coordinate is on a pixel boundary
-                    if ((float)Math.Floor(uv.X * uvScalar) == (uv.X * uvScalar))
-                    {
-                        uv.X += (uvMin.X == uvMax.X) ? half : ((uv.X < uvMax.X) ? inc : -inc);
-                        //uv.X += (uv.X < uvMax.X || uvMin.X == uvMax.X) ? inc : -inc;
-                        //uv.X += (uv.X < 1f) ? inc : -inc;
-                    }
-                    if ((float)Math.Floor(uv.Y * uvScalar) == (uv.Y * uvScalar))
-                    {
-                        uv.Y += (uvMin.Y == uvMax.Y) ? half : ((uv.Y < uvMax.Y) ? inc : -inc);
-                        //uv.Y += (uv.Y < uvMax.Y || uvMin.Y == uvMax.Y) ? inc : -inc;
-                        //uv.Y += (uv.Y < 1f) ? inc : -inc;
-                    }
-                    uvs[i] = uv;
-                }
-#else
-                // Old Solution A:
-                // This works well, until you try to use textures with Wireframe/Vertices draw mode.
-
-                // The reason it's safe to increment by one, is because the area covered by the UV will still only be one pixel.
-                // Before:
-                // |
-                // |_
-                // After:
-                // |\
-                // |_\
-
-                var uvs = TiledUv?.BaseUv ?? Uv;
-
-                // index 2 is arbitrarily chosen.
-                if (uvs[0].X == uvs[1].X && uvs[0].X == uvs[2].X)
-                {
-                    uvs[2].X += 1f / GeomMath.UVScalar;
-                }
-                if (uvs[0].Y == uvs[1].Y && uvs[0].Y == uvs[2].Y)
-                {
-                    uvs[2].Y += 1f / GeomMath.UVScalar;
-                }
-#endif
+            // Current Solution B:
+            // This works by offsetting every UV coordinate slightly if its on a pixel boundary.
+            // If the offsetted UV coordinate is the max, then the offset will be subtracted,
+            // otherwise the offset will be added. If the min and max component are equal, then the
+            // coordinate will be offset to the center of the pixel.
+            // This is preferred over Solution A, because it also solves Wireframe/Vertices fighting.
+            // The downside is it will become less accurate if you export a model with a very large single texture.
+            var uvMin = uvs[0];
+            var uvMax = uvMin;
+            for (var i = 1; i < 3; i++)
+            {
+                var uv = uvs[i];
+                uvMin = Vector2.ComponentMin(uvMin, uv);
+                uvMax = Vector2.ComponentMax(uvMax, uv);
             }
+
+            var uvScalar = GeomMath.UVScalar;
+            var inc = 0.001f / uvScalar; // Offset UV coordinates by 1/1000th of a pixel
+            var half = 0.5f / uvScalar;  // Offset UV coordinates to the center of the pixel
+            for (var i = 0; i < 3; i++)
+            {
+                var uv = uvs[i];
+                // Check if this coordinate is on a pixel boundary
+                if ((float)Math.Floor(uv.X * uvScalar) == (uv.X * uvScalar))
+                {
+                    uv.X += (uvMin.X == uvMax.X) ? half : ((uv.X < uvMax.X) ? inc : -inc);
+                    //uv.X += (uv.X < uvMax.X || uvMin.X == uvMax.X) ? inc : -inc;
+                    //uv.X += (uv.X < 1f) ? inc : -inc;
+                }
+                if ((float)Math.Floor(uv.Y * uvScalar) == (uv.Y * uvScalar))
+                {
+                    uv.Y += (uvMin.Y == uvMax.Y) ? half : ((uv.Y < uvMax.Y) ? inc : -inc);
+                    //uv.Y += (uv.Y < uvMax.Y || uvMin.Y == uvMax.Y) ? inc : -inc;
+                    //uv.Y += (uv.Y < 1f) ? inc : -inc;
+                }
+                uvs[i] = uv;
+            }
+#else
+            // Old Solution A:
+            // This works well, until you try to use textures with Wireframe/Vertices draw mode.
+
+            // The reason it's safe to increment by one, is because the area covered by the UV will still only be one pixel.
+            // Before:
+            // |
+            // |_
+            // After:
+            // |\
+            // |_\
+
+            var uvs = TiledUv?.BaseUv ?? Uv;
+
+            // index 2 is arbitrarily chosen.
+            if (uvs[0].X == uvs[1].X && uvs[0].X == uvs[2].X)
+            {
+                uvs[2].X += 1f / GeomMath.UVScalar;
+            }
+            if (uvs[0].Y == uvs[1].Y && uvs[0].Y == uvs[2].Y)
+            {
+                uvs[2].Y += 1f / GeomMath.UVScalar;
+            }
+#endif
             return this;
         }
 

--- a/Common/Utils/Logger.cs
+++ b/Common/Utils/Logger.cs
@@ -32,11 +32,38 @@ namespace PSXPrev.Common.Utils
         public ConsoleColor ErrorColor { get; set; }
         public ConsoleColor ExceptionPrefixColor { get; set; }
 
-        public Logger(bool logToFile = false, bool logToConsole = true, bool useConsoleColor = true)
+        public Logger(bool logToFile = false, bool logToConsole = true)
         {
             LogToFile = logToFile;
             LogToConsole = logToConsole;
-            UseConsoleColor = useConsoleColor;
+            ReadSettings(Settings.Defaults);
+        }
+
+        ~Logger()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+            }
+            Close();
+        }
+
+        public void Flush()
+        {
+            if (_logToFile && _writer != null)
+            {
+                _writer.Flush();
+            }
         }
 
         public void ReadSettings(Settings settings)
@@ -46,6 +73,7 @@ namespace PSXPrev.Common.Utils
             WarningColor = settings.LogWarningColor;
             ErrorColor = settings.LogErrorColor;
             ExceptionPrefixColor = settings.LogExceptionPrefixColor;
+            UseConsoleColor = settings.LogUseConsoleColor;
         }
 
         public void WriteSettings(Settings settings)
@@ -55,6 +83,7 @@ namespace PSXPrev.Common.Utils
             settings.LogWarningColor = WarningColor;
             settings.LogErrorColor = ErrorColor;
             settings.LogExceptionPrefixColor = ExceptionPrefixColor;
+            settings.LogUseConsoleColor = UseConsoleColor;
         }
 
         private void Open()
@@ -70,15 +99,17 @@ namespace PSXPrev.Common.Utils
         {
             if (_writer != null)
             {
-                _writer.Dispose();
-                _writer = null;
-                _logToFile = false;
+                try
+                {
+                    _writer.Flush();
+                }
+                finally
+                {
+                    _writer.Dispose();
+                    _writer = null;
+                    _logToFile = false;
+                }
             }
-        }
-
-        public void Dispose()
-        {
-            Close();
         }
 
 

--- a/Forms/ExportModelsForm.Designer.cs
+++ b/Forms/ExportModelsForm.Designer.cs
@@ -35,6 +35,7 @@
             this.selectFolderButton = new System.Windows.Forms.Button();
             this.filePathTextBox = new System.Windows.Forms.TextBox();
             this.formatGroupBox = new System.Windows.Forms.GroupBox();
+            this.formatDAERadioButton = new System.Windows.Forms.RadioButton();
             this.formatGLTF2RadioButton = new System.Windows.Forms.RadioButton();
             this.formatPLYRadioButton = new System.Windows.Forms.RadioButton();
             this.formatOBJRadioButton = new System.Windows.Forms.RadioButton();
@@ -46,10 +47,12 @@
             this.texturesIndividualRadioButton = new System.Windows.Forms.RadioButton();
             this.texturesOffRadioButton = new System.Windows.Forms.RadioButton();
             this.optionsGroupBox = new System.Windows.Forms.GroupBox();
+            this.optionStrictFloatsCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionHumanReadableCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionVertexIndexReuseCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionModelGroupingComboBox = new System.Windows.Forms.ComboBox();
             this.optionAttachLimbsCheckBox = new System.Windows.Forms.CheckBox();
             this.optionExperimentalVertexColorCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionMergeModelsCheckBox = new System.Windows.Forms.CheckBox();
-            this.exportButton = new System.Windows.Forms.Button();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
             this.animationsGroupBox = new System.Windows.Forms.GroupBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -57,12 +60,15 @@
             this.checkedAnimationsListBox = new System.Windows.Forms.ListBox();
             this.animationsOnRadioButton = new System.Windows.Forms.RadioButton();
             this.animationsOffRadioButton = new System.Windows.Forms.RadioButton();
-            this.formatDAERadioButton = new System.Windows.Forms.RadioButton();
+            this.scanCancelMarginFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.exportButton = new System.Windows.Forms.Button();
             this.filePathGroupBox.SuspendLayout();
             this.formatGroupBox.SuspendLayout();
             this.texturesGroupBox.SuspendLayout();
             this.optionsGroupBox.SuspendLayout();
             this.animationsGroupBox.SuspendLayout();
+            this.scanCancelMarginFlowLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // filePathGroupBox
@@ -120,6 +126,19 @@
             this.formatGroupBox.TabIndex = 1;
             this.formatGroupBox.TabStop = false;
             this.formatGroupBox.Text = "Format";
+            // 
+            // formatDAERadioButton
+            // 
+            this.formatDAERadioButton.AutoSize = true;
+            this.formatDAERadioButton.Location = new System.Drawing.Point(192, 19);
+            this.formatDAERadioButton.Name = "formatDAERadioButton";
+            this.formatDAERadioButton.Size = new System.Drawing.Size(47, 17);
+            this.formatDAERadioButton.TabIndex = 3;
+            this.formatDAERadioButton.Tag = "DAE";
+            this.formatDAERadioButton.Text = "DAE";
+            this.toolTip.SetToolTip(this.formatDAERadioButton, "COLLADA Digital Asset Exchange Format");
+            this.formatDAERadioButton.UseVisualStyleBackColor = true;
+            this.formatDAERadioButton.CheckedChanged += new System.EventHandler(this.formatRadioButtons_CheckedChanged);
             // 
             // formatGLTF2RadioButton
             // 
@@ -200,6 +219,7 @@
             this.optionShareTexturesCheckBox.Size = new System.Drawing.Size(136, 17);
             this.optionShareTexturesCheckBox.TabIndex = 4;
             this.optionShareTexturesCheckBox.Text = "Share Between Models";
+            this.toolTip.SetToolTip(this.optionShareTexturesCheckBox, "All exported models will reference the same\r\nexported texture files");
             this.optionShareTexturesCheckBox.UseVisualStyleBackColor = true;
             // 
             // optionRedrawTexturesCheckBox
@@ -210,6 +230,8 @@
             this.optionRedrawTexturesCheckBox.Size = new System.Drawing.Size(109, 17);
             this.optionRedrawTexturesCheckBox.TabIndex = 3;
             this.optionRedrawTexturesCheckBox.Text = "Redraw to VRAM";
+            this.toolTip.SetToolTip(this.optionRedrawTexturesCheckBox, "Models with associated textures will draw these\r\ntextures to the VRAM pages befor" +
+        "e exporting");
             this.optionRedrawTexturesCheckBox.UseVisualStyleBackColor = true;
             // 
             // texturesSingleRadioButton
@@ -220,6 +242,8 @@
             this.texturesSingleRadioButton.Size = new System.Drawing.Size(93, 17);
             this.texturesSingleRadioButton.TabIndex = 2;
             this.texturesSingleRadioButton.Text = "Single Texture";
+            this.toolTip.SetToolTip(this.texturesSingleRadioButton, "Required textures pages (and optionally tiled textures)\r\nwill be combined into a " +
+        "single file");
             this.texturesSingleRadioButton.UseVisualStyleBackColor = true;
             this.texturesSingleRadioButton.CheckedChanged += new System.EventHandler(this.texturesRadioButtons_CheckedChanged);
             // 
@@ -233,6 +257,8 @@
             this.texturesIndividualRadioButton.TabIndex = 1;
             this.texturesIndividualRadioButton.TabStop = true;
             this.texturesIndividualRadioButton.Text = "Individual Textures";
+            this.toolTip.SetToolTip(this.texturesIndividualRadioButton, "Required texture pages (and optionally tiled textures)\r\nwill be exported as indiv" +
+        "idual files");
             this.texturesIndividualRadioButton.UseVisualStyleBackColor = true;
             this.texturesIndividualRadioButton.CheckedChanged += new System.EventHandler(this.texturesRadioButtons_CheckedChanged);
             // 
@@ -249,23 +275,77 @@
             // 
             // optionsGroupBox
             // 
+            this.optionsGroupBox.Controls.Add(this.optionStrictFloatsCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionHumanReadableCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionVertexIndexReuseCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionModelGroupingComboBox);
             this.optionsGroupBox.Controls.Add(this.optionAttachLimbsCheckBox);
             this.optionsGroupBox.Controls.Add(this.optionExperimentalVertexColorCheckBox);
-            this.optionsGroupBox.Controls.Add(this.optionMergeModelsCheckBox);
             this.optionsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.optionsGroupBox.Location = new System.Drawing.Point(0, 204);
             this.optionsGroupBox.Name = "optionsGroupBox";
-            this.optionsGroupBox.Size = new System.Drawing.Size(394, 46);
+            this.optionsGroupBox.Size = new System.Drawing.Size(394, 75);
             this.optionsGroupBox.TabIndex = 3;
             this.optionsGroupBox.TabStop = false;
             this.optionsGroupBox.Text = "Options";
+            // 
+            // optionStrictFloatsCheckBox
+            // 
+            this.optionStrictFloatsCheckBox.AutoSize = true;
+            this.optionStrictFloatsCheckBox.Location = new System.Drawing.Point(269, 48);
+            this.optionStrictFloatsCheckBox.Name = "optionStrictFloatsCheckBox";
+            this.optionStrictFloatsCheckBox.Size = new System.Drawing.Size(81, 17);
+            this.optionStrictFloatsCheckBox.TabIndex = 6;
+            this.optionStrictFloatsCheckBox.Text = "Strict Floats";
+            this.toolTip.SetToolTip(this.optionStrictFloatsCheckBox, "Increases file size and reduces precision of vertices. However,\r\nmany format read" +
+        "ers only handle very specific formats for text\r\nnumbers, so disabling this may c" +
+        "ause problems.");
+            this.optionStrictFloatsCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // optionHumanReadableCheckBox
+            // 
+            this.optionHumanReadableCheckBox.AutoSize = true;
+            this.optionHumanReadableCheckBox.Location = new System.Drawing.Point(143, 48);
+            this.optionHumanReadableCheckBox.Name = "optionHumanReadableCheckBox";
+            this.optionHumanReadableCheckBox.Size = new System.Drawing.Size(109, 17);
+            this.optionHumanReadableCheckBox.TabIndex = 5;
+            this.optionHumanReadableCheckBox.Text = "Human Readable";
+            this.toolTip.SetToolTip(this.optionHumanReadableCheckBox, "Increases file size, but outputs text based formats in human-readable\r\nform (with" +
+        " indentation and line breaks).");
+            this.optionHumanReadableCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // optionVertexIndexReuseCheckBox
+            // 
+            this.optionVertexIndexReuseCheckBox.AutoSize = true;
+            this.optionVertexIndexReuseCheckBox.Location = new System.Drawing.Point(12, 48);
+            this.optionVertexIndexReuseCheckBox.Name = "optionVertexIndexReuseCheckBox";
+            this.optionVertexIndexReuseCheckBox.Size = new System.Drawing.Size(119, 17);
+            this.optionVertexIndexReuseCheckBox.TabIndex = 4;
+            this.optionVertexIndexReuseCheckBox.Text = "Vertex Index Reuse";
+            this.toolTip.SetToolTip(this.optionVertexIndexReuseCheckBox, "Reduces file size by attempting to reuse vertices with\r\nidentical attributes. May" +
+        " increase export time.");
+            this.optionVertexIndexReuseCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // optionModelGroupingComboBox
+            // 
+            this.optionModelGroupingComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.optionModelGroupingComboBox.FormattingEnabled = true;
+            this.optionModelGroupingComboBox.Items.AddRange(new object[] {
+            "Group by Model",
+            "Split by TMD ID",
+            "Group All"});
+            this.optionModelGroupingComboBox.Location = new System.Drawing.Point(12, 19);
+            this.optionModelGroupingComboBox.Name = "optionModelGroupingComboBox";
+            this.optionModelGroupingComboBox.Size = new System.Drawing.Size(115, 21);
+            this.optionModelGroupingComboBox.TabIndex = 3;
+            this.toolTip.SetToolTip(this.optionModelGroupingComboBox, "Choose how models are split up or grouped together.");
             // 
             // optionAttachLimbsCheckBox
             // 
             this.optionAttachLimbsCheckBox.AutoSize = true;
             this.optionAttachLimbsCheckBox.Checked = true;
             this.optionAttachLimbsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.optionAttachLimbsCheckBox.Location = new System.Drawing.Point(111, 19);
+            this.optionAttachLimbsCheckBox.Location = new System.Drawing.Point(143, 21);
             this.optionAttachLimbsCheckBox.Name = "optionAttachLimbsCheckBox";
             this.optionAttachLimbsCheckBox.Size = new System.Drawing.Size(87, 17);
             this.optionAttachLimbsCheckBox.TabIndex = 1;
@@ -277,34 +357,13 @@
             this.optionExperimentalVertexColorCheckBox.AutoSize = true;
             this.optionExperimentalVertexColorCheckBox.Checked = true;
             this.optionExperimentalVertexColorCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.optionExperimentalVertexColorCheckBox.Location = new System.Drawing.Point(204, 19);
+            this.optionExperimentalVertexColorCheckBox.Location = new System.Drawing.Point(269, 21);
             this.optionExperimentalVertexColorCheckBox.Name = "optionExperimentalVertexColorCheckBox";
-            this.optionExperimentalVertexColorCheckBox.Size = new System.Drawing.Size(172, 17);
+            this.optionExperimentalVertexColorCheckBox.Size = new System.Drawing.Size(106, 17);
             this.optionExperimentalVertexColorCheckBox.TabIndex = 2;
-            this.optionExperimentalVertexColorCheckBox.Text = "Experimental .OBJ Vertex Color";
+            this.optionExperimentalVertexColorCheckBox.Text = "OBJ Vertex Color";
+            this.toolTip.SetToolTip(this.optionExperimentalVertexColorCheckBox, "Experimental feature supported by certain OBJ readers.");
             this.optionExperimentalVertexColorCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // optionMergeModelsCheckBox
-            // 
-            this.optionMergeModelsCheckBox.AutoSize = true;
-            this.optionMergeModelsCheckBox.Location = new System.Drawing.Point(12, 19);
-            this.optionMergeModelsCheckBox.Name = "optionMergeModelsCheckBox";
-            this.optionMergeModelsCheckBox.Size = new System.Drawing.Size(93, 17);
-            this.optionMergeModelsCheckBox.TabIndex = 0;
-            this.optionMergeModelsCheckBox.Text = "Merge Models";
-            this.optionMergeModelsCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // exportButton
-            // 
-            this.exportButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.exportButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.exportButton.Enabled = false;
-            this.exportButton.Location = new System.Drawing.Point(307, 443);
-            this.exportButton.Name = "exportButton";
-            this.exportButton.Size = new System.Drawing.Size(75, 23);
-            this.exportButton.TabIndex = 6;
-            this.exportButton.Text = "Export";
-            this.exportButton.UseVisualStyleBackColor = true;
             // 
             // toolTip
             // 
@@ -320,7 +379,7 @@
             this.animationsGroupBox.Controls.Add(this.animationsOnRadioButton);
             this.animationsGroupBox.Controls.Add(this.animationsOffRadioButton);
             this.animationsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.animationsGroupBox.Location = new System.Drawing.Point(0, 250);
+            this.animationsGroupBox.Location = new System.Drawing.Point(0, 279);
             this.animationsGroupBox.Name = "animationsGroupBox";
             this.animationsGroupBox.Size = new System.Drawing.Size(394, 186);
             this.animationsGroupBox.TabIndex = 4;
@@ -379,27 +438,53 @@
             this.animationsOffRadioButton.UseVisualStyleBackColor = true;
             this.animationsOffRadioButton.CheckedChanged += new System.EventHandler(this.animationsRadioButtons_CheckedChanged);
             // 
-            // formatDAERadioButton
+            // scanCancelMarginFlowLayoutPanel
             // 
-            this.formatDAERadioButton.AutoSize = true;
-            this.formatDAERadioButton.Location = new System.Drawing.Point(192, 19);
-            this.formatDAERadioButton.Name = "formatDAERadioButton";
-            this.formatDAERadioButton.Size = new System.Drawing.Size(47, 17);
-            this.formatDAERadioButton.TabIndex = 3;
-            this.formatDAERadioButton.Tag = "DAE";
-            this.formatDAERadioButton.Text = "DAE";
-            this.toolTip.SetToolTip(this.formatDAERadioButton, "COLLADA Digital Asset Exchange Format");
-            this.formatDAERadioButton.UseVisualStyleBackColor = true;
-            this.formatDAERadioButton.CheckedChanged += new System.EventHandler(this.formatRadioButtons_CheckedChanged);
+            this.scanCancelMarginFlowLayoutPanel.Controls.Add(this.cancelButton);
+            this.scanCancelMarginFlowLayoutPanel.Controls.Add(this.exportButton);
+            this.scanCancelMarginFlowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.scanCancelMarginFlowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.scanCancelMarginFlowLayoutPanel.Location = new System.Drawing.Point(0, 465);
+            this.scanCancelMarginFlowLayoutPanel.Name = "scanCancelMarginFlowLayoutPanel";
+            this.scanCancelMarginFlowLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 11, 7);
+            this.scanCancelMarginFlowLayoutPanel.Size = new System.Drawing.Size(394, 36);
+            this.scanCancelMarginFlowLayoutPanel.TabIndex = 7;
+            this.scanCancelMarginFlowLayoutPanel.WrapContents = false;
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(308, 6);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(0);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 1;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            // 
+            // exportButton
+            // 
+            this.exportButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.exportButton.Enabled = false;
+            this.exportButton.Location = new System.Drawing.Point(227, 6);
+            this.exportButton.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
+            this.exportButton.Name = "exportButton";
+            this.exportButton.Size = new System.Drawing.Size(75, 23);
+            this.exportButton.TabIndex = 0;
+            this.exportButton.Text = "Export";
+            this.exportButton.UseVisualStyleBackColor = true;
             // 
             // ExportModelsForm
             // 
             this.AcceptButton = this.exportButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(394, 473);
+            this.AutoSize = true;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(394, 511);
+            this.Controls.Add(this.scanCancelMarginFlowLayoutPanel);
             this.Controls.Add(this.animationsGroupBox);
-            this.Controls.Add(this.exportButton);
             this.Controls.Add(this.optionsGroupBox);
             this.Controls.Add(this.texturesGroupBox);
             this.Controls.Add(this.formatGroupBox);
@@ -408,6 +493,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(410, 39);
             this.Name = "ExportModelsForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "PSXPrev Export Models";
@@ -423,6 +509,7 @@
             this.optionsGroupBox.PerformLayout();
             this.animationsGroupBox.ResumeLayout(false);
             this.animationsGroupBox.PerformLayout();
+            this.scanCancelMarginFlowLayoutPanel.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -442,8 +529,6 @@
         private System.Windows.Forms.GroupBox optionsGroupBox;
         private System.Windows.Forms.CheckBox optionRedrawTexturesCheckBox;
         private System.Windows.Forms.CheckBox optionExperimentalVertexColorCheckBox;
-        private System.Windows.Forms.CheckBox optionMergeModelsCheckBox;
-        private System.Windows.Forms.Button exportButton;
         private System.Windows.Forms.CheckBox optionAttachLimbsCheckBox;
         private System.Windows.Forms.Label exportingModelsLabel;
         private System.Windows.Forms.CheckBox optionShareTexturesCheckBox;
@@ -457,5 +542,12 @@
         private System.Windows.Forms.RadioButton animationsOffRadioButton;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.RadioButton formatDAERadioButton;
+        private System.Windows.Forms.ComboBox optionModelGroupingComboBox;
+        private System.Windows.Forms.CheckBox optionHumanReadableCheckBox;
+        private System.Windows.Forms.CheckBox optionVertexIndexReuseCheckBox;
+        private System.Windows.Forms.FlowLayoutPanel scanCancelMarginFlowLayoutPanel;
+        private System.Windows.Forms.Button cancelButton;
+        private System.Windows.Forms.Button exportButton;
+        private System.Windows.Forms.CheckBox optionStrictFloatsCheckBox;
     }
 }

--- a/Forms/PreviewForm.cs
+++ b/Forms/PreviewForm.cs
@@ -2821,12 +2821,20 @@ namespace PSXPrev.Forms
             // Get all models, checked models, or selected model if nothing is checked.
             var entities = all ? _rootEntities.ToArray() : GetCheckedEntities(true);
 
+#if DEBUG
+            // Allow testing of export models form without needing to scan
+            if (entities == null)
+            {
+                entities = new RootEntity[0];
+            }
+#else
             if (entities == null || entities.Length == 0)
             {
                 var message = all ? "No models to export" : "No models checked or selected to export";
                 ShowMessageBox(message, "PSXPrev", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
+#endif
 
             var animations = GetCheckedAnimations(true);
 
@@ -2836,8 +2844,8 @@ namespace PSXPrev.Forms
                 var options = ExportModelsForm.Show(this, entities, animations);
                 if (options != null)
                 {
-                    ExportModelsForm.Export(options, entities, animations);
-                    ShowMessageBox($"{entities.Length} models exported", "PSXPrev", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    var exportedCount = ExportModelsForm.Export(options, entities, animations);
+                    ShowMessageBox($"{exportedCount} models exported", "PSXPrev", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }
             finally

--- a/Forms/ScannerForm.Designer.cs
+++ b/Forms/ScannerForm.Designer.cs
@@ -31,6 +31,8 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ScannerForm));
             this.fileGroupBox = new System.Windows.Forms.GroupBox();
+            this.historyBookmarkButton = new System.Windows.Forms.Button();
+            this.historyRemoveButton = new System.Windows.Forms.Button();
             this.historyLabel = new System.Windows.Forms.Label();
             this.historyComboBox = new System.Windows.Forms.ComboBox();
             this.filterUseRegexCheckBox = new System.Windows.Forms.CheckBox();
@@ -42,14 +44,11 @@
             this.filePathTextBox = new System.Windows.Forms.TextBox();
             this.filterTextBox = new System.Windows.Forms.TextBox();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.checkBFFCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkPSXCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkMODCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkHMDCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionOldUVAlignmentCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatBFFCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatPSXCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatMODCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatHMDCheckBox = new System.Windows.Forms.CheckBox();
             this.optionAsyncScanCheckBox = new System.Windows.Forms.CheckBox();
-            this.binContentsCheckBox = new System.Windows.Forms.CheckBox();
-            this.isoContentsCheckBox = new System.Windows.Forms.CheckBox();
             this.offsetNextCheckBox = new System.Windows.Forms.CheckBox();
             this.offsetAlignUpDown = new System.Windows.Forms.NumericUpDown();
             this.offsetStartOnlyCheckBox = new System.Windows.Forms.CheckBox();
@@ -57,28 +56,33 @@
             this.offsetStopCheckBox = new System.Windows.Forms.CheckBox();
             this.optionDrawAllToVRAMCheckBox = new System.Windows.Forms.CheckBox();
             this.binSectorCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkSPTCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkPMDCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkTODCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkTIMCheckBox = new System.Windows.Forms.CheckBox();
-            this.checkTMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatSPTCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatPMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatTODCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatTIMCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatTMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatPILCheckBox = new System.Windows.Forms.CheckBox();
+            this.binScanComboBox = new System.Windows.Forms.ComboBox();
+            this.formatVDFCheckBox = new System.Windows.Forms.CheckBox();
+            this.isoScanComboBox = new System.Windows.Forms.ComboBox();
+            this.unstrictTMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.unstrictHMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.unstrictPMDCheckBox = new System.Windows.Forms.CheckBox();
+            this.unstrictTIMCheckBox = new System.Windows.Forms.CheckBox();
             this.formatsGroupBox = new System.Windows.Forms.GroupBox();
-            this.checkANCheckBox = new System.Windows.Forms.CheckBox();
+            this.formatANCheckBox = new System.Windows.Forms.CheckBox();
             this.animationsLabel = new System.Windows.Forms.Label();
             this.texturesLabel = new System.Windows.Forms.Label();
             this.modelsLabel = new System.Windows.Forms.Label();
-            this.checkVDFCheckBox = new System.Windows.Forms.CheckBox();
             this.optionsGroupBox = new System.Windows.Forms.GroupBox();
-            this.optionShowErrorsCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionDebugCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionNoVerboseCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionErrorLoggingCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionDebugLoggingCheckBox = new System.Windows.Forms.CheckBox();
+            this.optionLogToConsoleCheckBox = new System.Windows.Forms.CheckBox();
             this.optionLogToFileCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionIgnoreTIMVersionCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionIgnoreHMDVersionCheckBox = new System.Windows.Forms.CheckBox();
-            this.optionIgnoreTMDVersionCheckBox = new System.Windows.Forms.CheckBox();
             this.showAdvancedMarginPanel = new System.Windows.Forms.Panel();
             this.showAdvancedButton = new System.Windows.Forms.Button();
             this.advancedOptionsGroupBox = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
             this.binSectorInvalidLabel = new System.Windows.Forms.Label();
             this.binSectorSizeUpDown = new System.Windows.Forms.NumericUpDown();
             this.binSectorStartUpDown = new System.Windows.Forms.NumericUpDown();
@@ -89,8 +93,6 @@
             this.scanButton = new System.Windows.Forms.Button();
             this.cancelButton = new System.Windows.Forms.Button();
             this.scanCancelMarginFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
-            this.historyRemoveButton = new System.Windows.Forms.Button();
-            this.historyBookmarkButton = new System.Windows.Forms.Button();
             this.fileGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.offsetAlignUpDown)).BeginInit();
             this.formatsGroupBox.SuspendLayout();
@@ -122,10 +124,36 @@
             this.fileGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.fileGroupBox.Location = new System.Drawing.Point(0, 0);
             this.fileGroupBox.Name = "fileGroupBox";
-            this.fileGroupBox.Size = new System.Drawing.Size(394, 133);
+            this.fileGroupBox.Size = new System.Drawing.Size(444, 133);
             this.fileGroupBox.TabIndex = 0;
             this.fileGroupBox.TabStop = false;
             this.fileGroupBox.Text = "Files";
+            // 
+            // historyBookmarkButton
+            // 
+            this.historyBookmarkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.historyBookmarkButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.historyBookmarkButton.Location = new System.Drawing.Point(379, 18);
+            this.historyBookmarkButton.Name = "historyBookmarkButton";
+            this.historyBookmarkButton.Size = new System.Drawing.Size(24, 23);
+            this.historyBookmarkButton.TabIndex = 1;
+            this.historyBookmarkButton.Text = "+";
+            this.toolTip.SetToolTip(this.historyBookmarkButton, "Bookmark history");
+            this.historyBookmarkButton.UseVisualStyleBackColor = true;
+            this.historyBookmarkButton.Click += new System.EventHandler(this.historyBookmarkButton_Click);
+            // 
+            // historyRemoveButton
+            // 
+            this.historyRemoveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.historyRemoveButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.historyRemoveButton.Location = new System.Drawing.Point(409, 18);
+            this.historyRemoveButton.Name = "historyRemoveButton";
+            this.historyRemoveButton.Size = new System.Drawing.Size(24, 23);
+            this.historyRemoveButton.TabIndex = 2;
+            this.historyRemoveButton.Text = "−";
+            this.toolTip.SetToolTip(this.historyRemoveButton, "Remove history");
+            this.historyRemoveButton.UseVisualStyleBackColor = true;
+            this.historyRemoveButton.Click += new System.EventHandler(this.historyRemoveButton_Click);
             // 
             // historyLabel
             // 
@@ -148,7 +176,7 @@
             this.historyComboBox.Location = new System.Drawing.Point(54, 19);
             this.historyComboBox.MaxDropDownItems = 21;
             this.historyComboBox.Name = "historyComboBox";
-            this.historyComboBox.Size = new System.Drawing.Size(269, 21);
+            this.historyComboBox.Size = new System.Drawing.Size(319, 21);
             this.historyComboBox.TabIndex = 0;
             this.historyComboBox.Tag = "NOTSETTING";
             this.toolTip.SetToolTip(this.historyComboBox, "Choose a previous scan from history");
@@ -157,7 +185,7 @@
             // filterUseRegexCheckBox
             // 
             this.filterUseRegexCheckBox.AutoSize = true;
-            this.filterUseRegexCheckBox.Location = new System.Drawing.Point(204, 105);
+            this.filterUseRegexCheckBox.Location = new System.Drawing.Point(234, 105);
             this.filterUseRegexCheckBox.Name = "filterUseRegexCheckBox";
             this.filterUseRegexCheckBox.Size = new System.Drawing.Size(139, 17);
             this.filterUseRegexCheckBox.TabIndex = 9;
@@ -221,7 +249,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.filePathTextBox.Location = new System.Drawing.Point(12, 47);
             this.filePathTextBox.Name = "filePathTextBox";
-            this.filePathTextBox.Size = new System.Drawing.Size(370, 20);
+            this.filePathTextBox.Size = new System.Drawing.Size(420, 20);
             this.filePathTextBox.TabIndex = 3;
             this.filePathTextBox.TextChanged += new System.EventHandler(this.filePathTextBox_TextChanged);
             // 
@@ -229,7 +257,7 @@
             // 
             this.filterTextBox.Location = new System.Drawing.Point(44, 103);
             this.filterTextBox.Name = "filterTextBox";
-            this.filterTextBox.Size = new System.Drawing.Size(150, 20);
+            this.filterTextBox.Size = new System.Drawing.Size(180, 20);
             this.filterTextBox.TabIndex = 8;
             this.filterTextBox.Text = "*.*";
             this.toolTip.SetToolTip(this.filterTextBox, "Wildcard or Regex pattern to match files.");
@@ -242,96 +270,66 @@
             this.toolTip.InitialDelay = 500;
             this.toolTip.ReshowDelay = 100;
             // 
-            // checkBFFCheckBox
+            // formatBFFCheckBox
             // 
-            this.checkBFFCheckBox.AutoSize = true;
-            this.checkBFFCheckBox.Location = new System.Drawing.Point(341, 19);
-            this.checkBFFCheckBox.Name = "checkBFFCheckBox";
-            this.checkBFFCheckBox.Size = new System.Drawing.Size(45, 17);
-            this.checkBFFCheckBox.TabIndex = 5;
-            this.checkBFFCheckBox.Text = "BFF";
-            this.toolTip.SetToolTip(this.checkBFFCheckBox, "Blitz Games Model Format\r\nFrogger 2 / Chicken Run (Uses SPT textures)");
-            this.checkBFFCheckBox.UseVisualStyleBackColor = true;
+            this.formatBFFCheckBox.AutoSize = true;
+            this.formatBFFCheckBox.Location = new System.Drawing.Point(341, 19);
+            this.formatBFFCheckBox.Name = "formatBFFCheckBox";
+            this.formatBFFCheckBox.Size = new System.Drawing.Size(45, 17);
+            this.formatBFFCheckBox.TabIndex = 5;
+            this.formatBFFCheckBox.Tag = "format:BFF";
+            this.formatBFFCheckBox.Text = "BFF";
+            this.toolTip.SetToolTip(this.formatBFFCheckBox, "Blitz Games Models and Animations Format\r\nIncludes subformats: FMW, FMM, PSI\r\nFro" +
+        "gger 2 / Chicken Run (Uses SPT textures)");
+            this.formatBFFCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkPSXCheckBox
+            // formatPSXCheckBox
             // 
-            this.checkPSXCheckBox.AutoSize = true;
-            this.checkPSXCheckBox.Location = new System.Drawing.Point(287, 19);
-            this.checkPSXCheckBox.Name = "checkPSXCheckBox";
-            this.checkPSXCheckBox.Size = new System.Drawing.Size(47, 17);
-            this.checkPSXCheckBox.TabIndex = 4;
-            this.checkPSXCheckBox.Text = "PSX";
-            this.toolTip.SetToolTip(this.checkPSXCheckBox, "Neversoft Model and Textures Format\r\nTony Hawk\'s Pro Skater / Apocalypse / Spider" +
+            this.formatPSXCheckBox.AutoSize = true;
+            this.formatPSXCheckBox.Location = new System.Drawing.Point(287, 19);
+            this.formatPSXCheckBox.Name = "formatPSXCheckBox";
+            this.formatPSXCheckBox.Size = new System.Drawing.Size(47, 17);
+            this.formatPSXCheckBox.TabIndex = 4;
+            this.formatPSXCheckBox.Tag = "format:PSX";
+            this.formatPSXCheckBox.Text = "PSX";
+            this.toolTip.SetToolTip(this.formatPSXCheckBox, "Neversoft Model and Textures Format\r\nTony Hawk\'s Pro Skater / Apocalypse / Spider" +
         "man");
-            this.checkPSXCheckBox.UseVisualStyleBackColor = true;
+            this.formatPSXCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkMODCheckBox
+            // formatMODCheckBox
             // 
-            this.checkMODCheckBox.AutoSize = true;
-            this.checkMODCheckBox.Location = new System.Drawing.Point(233, 19);
-            this.checkMODCheckBox.Name = "checkMODCheckBox";
-            this.checkMODCheckBox.Size = new System.Drawing.Size(51, 17);
-            this.checkMODCheckBox.TabIndex = 3;
-            this.checkMODCheckBox.Text = "MOD";
-            this.toolTip.SetToolTip(this.checkMODCheckBox, "Croc Model Format");
-            this.checkMODCheckBox.UseVisualStyleBackColor = true;
+            this.formatMODCheckBox.AutoSize = true;
+            this.formatMODCheckBox.Location = new System.Drawing.Point(233, 19);
+            this.formatMODCheckBox.Name = "formatMODCheckBox";
+            this.formatMODCheckBox.Size = new System.Drawing.Size(51, 17);
+            this.formatMODCheckBox.TabIndex = 3;
+            this.formatMODCheckBox.Tag = "format:MOD";
+            this.formatMODCheckBox.Text = "MOD";
+            this.toolTip.SetToolTip(this.formatMODCheckBox, "Croc Model Format");
+            this.formatMODCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkHMDCheckBox
+            // formatHMDCheckBox
             // 
-            this.checkHMDCheckBox.AutoSize = true;
-            this.checkHMDCheckBox.Location = new System.Drawing.Point(125, 19);
-            this.checkHMDCheckBox.Name = "checkHMDCheckBox";
-            this.checkHMDCheckBox.Size = new System.Drawing.Size(51, 17);
-            this.checkHMDCheckBox.TabIndex = 1;
-            this.checkHMDCheckBox.Text = "HMD";
-            this.toolTip.SetToolTip(this.checkHMDCheckBox, "Standard Model, Textures, and Animations Format");
-            this.checkHMDCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // optionOldUVAlignmentCheckBox
-            // 
-            this.optionOldUVAlignmentCheckBox.AutoSize = true;
-            this.optionOldUVAlignmentCheckBox.Location = new System.Drawing.Point(135, 42);
-            this.optionOldUVAlignmentCheckBox.Name = "optionOldUVAlignmentCheckBox";
-            this.optionOldUVAlignmentCheckBox.Size = new System.Drawing.Size(109, 17);
-            this.optionOldUVAlignmentCheckBox.TabIndex = 4;
-            this.optionOldUVAlignmentCheckBox.Text = "Old UV Alignment";
-            this.toolTip.SetToolTip(this.optionOldUVAlignmentCheckBox, "PSXPrev originally used UV alignment that\r\nranged from 0-256, however this was in" +
-        "correct,\r\nand 0-255 is now used by default.");
-            this.optionOldUVAlignmentCheckBox.UseVisualStyleBackColor = true;
+            this.formatHMDCheckBox.AutoSize = true;
+            this.formatHMDCheckBox.Location = new System.Drawing.Point(125, 19);
+            this.formatHMDCheckBox.Name = "formatHMDCheckBox";
+            this.formatHMDCheckBox.Size = new System.Drawing.Size(51, 17);
+            this.formatHMDCheckBox.TabIndex = 1;
+            this.formatHMDCheckBox.Tag = "format:HMD";
+            this.formatHMDCheckBox.Text = "HMD";
+            this.toolTip.SetToolTip(this.formatHMDCheckBox, "Standard Model, Textures, and Animations Format");
+            this.formatHMDCheckBox.UseVisualStyleBackColor = true;
             // 
             // optionAsyncScanCheckBox
             // 
             this.optionAsyncScanCheckBox.AutoSize = true;
-            this.optionAsyncScanCheckBox.Location = new System.Drawing.Point(258, 42);
+            this.optionAsyncScanCheckBox.Location = new System.Drawing.Point(278, 44);
             this.optionAsyncScanCheckBox.Name = "optionAsyncScanCheckBox";
             this.optionAsyncScanCheckBox.Size = new System.Drawing.Size(83, 17);
             this.optionAsyncScanCheckBox.TabIndex = 5;
             this.optionAsyncScanCheckBox.Text = "Async Scan";
             this.toolTip.SetToolTip(this.optionAsyncScanCheckBox, "All formats for the current file will scan at the same time.");
             this.optionAsyncScanCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // binContentsCheckBox
-            // 
-            this.binContentsCheckBox.AutoSize = true;
-            this.binContentsCheckBox.Location = new System.Drawing.Point(12, 42);
-            this.binContentsCheckBox.Name = "binContentsCheckBox";
-            this.binContentsCheckBox.Size = new System.Drawing.Size(117, 17);
-            this.binContentsCheckBox.TabIndex = 3;
-            this.binContentsCheckBox.Text = "Scan BIN Contents";
-            this.toolTip.SetToolTip(this.binContentsCheckBox, "Scan raw PS1 .BIN files without needing\r\nto reformat them. (experimental)");
-            this.binContentsCheckBox.UseVisualStyleBackColor = true;
-            this.binContentsCheckBox.CheckedChanged += new System.EventHandler(this.binContentsCheckBox_CheckedChanged);
-            // 
-            // isoContentsCheckBox
-            // 
-            this.isoContentsCheckBox.AutoSize = true;
-            this.isoContentsCheckBox.Location = new System.Drawing.Point(135, 42);
-            this.isoContentsCheckBox.Name = "isoContentsCheckBox";
-            this.isoContentsCheckBox.Size = new System.Drawing.Size(117, 17);
-            this.isoContentsCheckBox.TabIndex = 4;
-            this.isoContentsCheckBox.Text = "Scan ISO Contents";
-            this.toolTip.SetToolTip(this.isoContentsCheckBox, "Scan the contents of .ISO files.");
-            this.isoContentsCheckBox.UseVisualStyleBackColor = true;
             // 
             // offsetNextCheckBox
             // 
@@ -410,10 +408,10 @@
             // optionDrawAllToVRAMCheckBox
             // 
             this.optionDrawAllToVRAMCheckBox.AutoSize = true;
-            this.optionDrawAllToVRAMCheckBox.Location = new System.Drawing.Point(12, 42);
+            this.optionDrawAllToVRAMCheckBox.Location = new System.Drawing.Point(258, 19);
             this.optionDrawAllToVRAMCheckBox.Name = "optionDrawAllToVRAMCheckBox";
             this.optionDrawAllToVRAMCheckBox.Size = new System.Drawing.Size(111, 17);
-            this.optionDrawAllToVRAMCheckBox.TabIndex = 3;
+            this.optionDrawAllToVRAMCheckBox.TabIndex = 5;
             this.optionDrawAllToVRAMCheckBox.Text = "Draw All to VRAM";
             this.toolTip.SetToolTip(this.optionDrawAllToVRAMCheckBox, "All loaded textures will be drawn \r\nto VRAM after the scan finishes.");
             this.optionDrawAllToVRAMCheckBox.UseVisualStyleBackColor = true;
@@ -422,7 +420,7 @@
             // 
             this.binSectorCheckBox.AutoSize = true;
             this.binSectorCheckBox.Enabled = false;
-            this.binSectorCheckBox.Location = new System.Drawing.Point(12, 69);
+            this.binSectorCheckBox.Location = new System.Drawing.Point(12, 73);
             this.binSectorCheckBox.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
             this.binSectorCheckBox.Name = "binSectorCheckBox";
             this.binSectorCheckBox.Size = new System.Drawing.Size(131, 17);
@@ -433,95 +431,202 @@
             this.binSectorCheckBox.UseVisualStyleBackColor = true;
             this.binSectorCheckBox.CheckedChanged += new System.EventHandler(this.binSectorCheckBox_CheckedChanged);
             // 
-            // checkSPTCheckBox
+            // formatSPTCheckBox
             // 
-            this.checkSPTCheckBox.AutoSize = true;
-            this.checkSPTCheckBox.Location = new System.Drawing.Point(125, 42);
-            this.checkSPTCheckBox.Name = "checkSPTCheckBox";
-            this.checkSPTCheckBox.Size = new System.Drawing.Size(47, 17);
-            this.checkSPTCheckBox.TabIndex = 14;
-            this.checkSPTCheckBox.Text = "SPT";
-            this.toolTip.SetToolTip(this.checkSPTCheckBox, "Blitz Games Textures Format\r\nFrogger 2 / Chicken Run (Used by BFF models)\r\nMust b" +
-        "e explicitly checked to scan\r\nMany false positives unless you set Align to 2048");
-            this.checkSPTCheckBox.UseVisualStyleBackColor = true;
+            this.formatSPTCheckBox.AutoSize = true;
+            this.formatSPTCheckBox.Location = new System.Drawing.Point(125, 42);
+            this.formatSPTCheckBox.Name = "formatSPTCheckBox";
+            this.formatSPTCheckBox.Size = new System.Drawing.Size(47, 17);
+            this.formatSPTCheckBox.TabIndex = 8;
+            this.formatSPTCheckBox.Tag = "format:SPT";
+            this.formatSPTCheckBox.Text = "SPT";
+            this.toolTip.SetToolTip(this.formatSPTCheckBox, resources.GetString("formatSPTCheckBox.ToolTip"));
+            this.formatSPTCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkPMDCheckBox
+            // formatPMDCheckBox
             // 
-            this.checkPMDCheckBox.AutoSize = true;
-            this.checkPMDCheckBox.Location = new System.Drawing.Point(179, 19);
-            this.checkPMDCheckBox.Name = "checkPMDCheckBox";
-            this.checkPMDCheckBox.Size = new System.Drawing.Size(50, 17);
-            this.checkPMDCheckBox.TabIndex = 2;
-            this.checkPMDCheckBox.Text = "PMD";
-            this.toolTip.SetToolTip(this.checkPMDCheckBox, "Standard Model Format");
-            this.checkPMDCheckBox.UseVisualStyleBackColor = true;
+            this.formatPMDCheckBox.AutoSize = true;
+            this.formatPMDCheckBox.Location = new System.Drawing.Point(179, 19);
+            this.formatPMDCheckBox.Name = "formatPMDCheckBox";
+            this.formatPMDCheckBox.Size = new System.Drawing.Size(50, 17);
+            this.formatPMDCheckBox.TabIndex = 2;
+            this.formatPMDCheckBox.Tag = "format:PMD";
+            this.formatPMDCheckBox.Text = "PMD";
+            this.toolTip.SetToolTip(this.formatPMDCheckBox, "Standard Model Format");
+            this.formatPMDCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkTODCheckBox
+            // formatTODCheckBox
             // 
-            this.checkTODCheckBox.AutoSize = true;
-            this.checkTODCheckBox.Location = new System.Drawing.Point(125, 66);
-            this.checkTODCheckBox.Name = "checkTODCheckBox";
-            this.checkTODCheckBox.Size = new System.Drawing.Size(49, 17);
-            this.checkTODCheckBox.TabIndex = 8;
-            this.checkTODCheckBox.Text = "TOD";
-            this.toolTip.SetToolTip(this.checkTODCheckBox, "Standard Animation Format");
-            this.checkTODCheckBox.UseVisualStyleBackColor = true;
+            this.formatTODCheckBox.AutoSize = true;
+            this.formatTODCheckBox.Location = new System.Drawing.Point(125, 66);
+            this.formatTODCheckBox.Name = "formatTODCheckBox";
+            this.formatTODCheckBox.Size = new System.Drawing.Size(49, 17);
+            this.formatTODCheckBox.TabIndex = 10;
+            this.formatTODCheckBox.Tag = "format:TOD";
+            this.formatTODCheckBox.Text = "TOD";
+            this.toolTip.SetToolTip(this.formatTODCheckBox, "Standard Animation Format");
+            this.formatTODCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkTIMCheckBox
+            // formatTIMCheckBox
             // 
-            this.checkTIMCheckBox.AutoSize = true;
-            this.checkTIMCheckBox.Location = new System.Drawing.Point(71, 42);
-            this.checkTIMCheckBox.Name = "checkTIMCheckBox";
-            this.checkTIMCheckBox.Size = new System.Drawing.Size(45, 17);
-            this.checkTIMCheckBox.TabIndex = 6;
-            this.checkTIMCheckBox.Text = "TIM";
-            this.toolTip.SetToolTip(this.checkTIMCheckBox, "Standard Texture Format");
-            this.checkTIMCheckBox.UseVisualStyleBackColor = true;
+            this.formatTIMCheckBox.AutoSize = true;
+            this.formatTIMCheckBox.Location = new System.Drawing.Point(71, 42);
+            this.formatTIMCheckBox.Name = "formatTIMCheckBox";
+            this.formatTIMCheckBox.Size = new System.Drawing.Size(45, 17);
+            this.formatTIMCheckBox.TabIndex = 7;
+            this.formatTIMCheckBox.Tag = "format:TIM";
+            this.formatTIMCheckBox.Text = "TIM";
+            this.toolTip.SetToolTip(this.formatTIMCheckBox, "Standard Texture Format");
+            this.formatTIMCheckBox.UseVisualStyleBackColor = true;
             // 
-            // checkTMDCheckBox
+            // formatTMDCheckBox
             // 
-            this.checkTMDCheckBox.AutoSize = true;
-            this.checkTMDCheckBox.Location = new System.Drawing.Point(71, 19);
-            this.checkTMDCheckBox.Name = "checkTMDCheckBox";
-            this.checkTMDCheckBox.Size = new System.Drawing.Size(50, 17);
-            this.checkTMDCheckBox.TabIndex = 0;
-            this.checkTMDCheckBox.Text = "TMD";
-            this.toolTip.SetToolTip(this.checkTMDCheckBox, "Standard Model Format");
-            this.checkTMDCheckBox.UseVisualStyleBackColor = true;
+            this.formatTMDCheckBox.AutoSize = true;
+            this.formatTMDCheckBox.Location = new System.Drawing.Point(71, 19);
+            this.formatTMDCheckBox.Name = "formatTMDCheckBox";
+            this.formatTMDCheckBox.Size = new System.Drawing.Size(50, 17);
+            this.formatTMDCheckBox.TabIndex = 0;
+            this.formatTMDCheckBox.Tag = "format:TMD";
+            this.formatTMDCheckBox.Text = "TMD";
+            this.toolTip.SetToolTip(this.formatTMDCheckBox, "Standard Model Format");
+            this.formatTMDCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // formatPILCheckBox
+            // 
+            this.formatPILCheckBox.AutoSize = true;
+            this.formatPILCheckBox.Location = new System.Drawing.Point(395, 19);
+            this.formatPILCheckBox.Name = "formatPILCheckBox";
+            this.formatPILCheckBox.Size = new System.Drawing.Size(42, 17);
+            this.formatPILCheckBox.TabIndex = 6;
+            this.formatPILCheckBox.Tag = "format:PIL";
+            this.formatPILCheckBox.Text = "PIL";
+            this.toolTip.SetToolTip(this.formatPILCheckBox, "Blitz Games Models and Animations Format\r\nIncludes subformats: PSI\r\nAction Man 2 " +
+        "/ Frogger 2 / Chicken Run (Uses SPT textures)");
+            this.formatPILCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // binScanComboBox
+            // 
+            this.binScanComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.binScanComboBox.FormattingEnabled = true;
+            this.binScanComboBox.Items.AddRange(new object[] {
+            "Don\'t Scan BIN",
+            "Scan BIN Contents",
+            "Scan BIN Data"});
+            this.binScanComboBox.Location = new System.Drawing.Point(12, 42);
+            this.binScanComboBox.Name = "binScanComboBox";
+            this.binScanComboBox.Size = new System.Drawing.Size(120, 21);
+            this.binScanComboBox.TabIndex = 3;
+            this.toolTip.SetToolTip(this.binScanComboBox, resources.GetString("binScanComboBox.ToolTip"));
+            this.binScanComboBox.SelectedIndexChanged += new System.EventHandler(this.binScanComboBox_SelectedIndexChanged);
+            // 
+            // formatVDFCheckBox
+            // 
+            this.formatVDFCheckBox.AutoSize = true;
+            this.formatVDFCheckBox.Location = new System.Drawing.Point(179, 66);
+            this.formatVDFCheckBox.Name = "formatVDFCheckBox";
+            this.formatVDFCheckBox.Size = new System.Drawing.Size(47, 17);
+            this.formatVDFCheckBox.TabIndex = 11;
+            this.formatVDFCheckBox.Tag = "format:VDF";
+            this.formatVDFCheckBox.Text = "VDF";
+            this.toolTip.SetToolTip(this.formatVDFCheckBox, "Vertex Diff Animation Format");
+            this.formatVDFCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // isoScanComboBox
+            // 
+            this.isoScanComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.isoScanComboBox.FormattingEnabled = true;
+            this.isoScanComboBox.Items.AddRange(new object[] {
+            "Don\'t Scan ISO",
+            "Scan ISO Contents"});
+            this.isoScanComboBox.Location = new System.Drawing.Point(145, 42);
+            this.isoScanComboBox.Name = "isoScanComboBox";
+            this.isoScanComboBox.Size = new System.Drawing.Size(120, 21);
+            this.isoScanComboBox.TabIndex = 4;
+            this.toolTip.SetToolTip(this.isoScanComboBox, "Scan the contents of .ISO files.");
+            // 
+            // unstrictTMDCheckBox
+            // 
+            this.unstrictTMDCheckBox.AutoSize = true;
+            this.unstrictTMDCheckBox.Location = new System.Drawing.Point(88, 19);
+            this.unstrictTMDCheckBox.Name = "unstrictTMDCheckBox";
+            this.unstrictTMDCheckBox.Size = new System.Drawing.Size(50, 17);
+            this.unstrictTMDCheckBox.TabIndex = 19;
+            this.unstrictTMDCheckBox.Tag = "unstrict:TMD";
+            this.unstrictTMDCheckBox.Text = "TMD";
+            this.toolTip.SetToolTip(this.unstrictTMDCheckBox, "Support for non-standard TMD formats\r\nthat use a different version number");
+            this.unstrictTMDCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // unstrictHMDCheckBox
+            // 
+            this.unstrictHMDCheckBox.AutoSize = true;
+            this.unstrictHMDCheckBox.Location = new System.Drawing.Point(142, 19);
+            this.unstrictHMDCheckBox.Name = "unstrictHMDCheckBox";
+            this.unstrictHMDCheckBox.Size = new System.Drawing.Size(51, 17);
+            this.unstrictHMDCheckBox.TabIndex = 20;
+            this.unstrictHMDCheckBox.Tag = "unstrict:HMD";
+            this.unstrictHMDCheckBox.Text = "HMD";
+            this.toolTip.SetToolTip(this.unstrictHMDCheckBox, "Support for non-standard HMD formats\r\nthat use a different version number");
+            this.unstrictHMDCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // unstrictPMDCheckBox
+            // 
+            this.unstrictPMDCheckBox.AutoSize = true;
+            this.unstrictPMDCheckBox.Location = new System.Drawing.Point(196, 19);
+            this.unstrictPMDCheckBox.Name = "unstrictPMDCheckBox";
+            this.unstrictPMDCheckBox.Size = new System.Drawing.Size(50, 17);
+            this.unstrictPMDCheckBox.TabIndex = 21;
+            this.unstrictPMDCheckBox.Tag = "unstrict:PMD";
+            this.unstrictPMDCheckBox.Text = "PMD";
+            this.toolTip.SetToolTip(this.unstrictPMDCheckBox, "Support for non-standard PMD formats\r\nthat use a different version number");
+            this.unstrictPMDCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // unstrictTIMCheckBox
+            // 
+            this.unstrictTIMCheckBox.AutoSize = true;
+            this.unstrictTIMCheckBox.Location = new System.Drawing.Point(250, 19);
+            this.unstrictTIMCheckBox.Name = "unstrictTIMCheckBox";
+            this.unstrictTIMCheckBox.Size = new System.Drawing.Size(45, 17);
+            this.unstrictTIMCheckBox.TabIndex = 22;
+            this.unstrictTIMCheckBox.Tag = "unstrict:TIM";
+            this.unstrictTIMCheckBox.Text = "TIM";
+            this.toolTip.SetToolTip(this.unstrictTIMCheckBox, "Support for non-standard TIM formats\r\nthat use a different version number");
+            this.unstrictTIMCheckBox.UseVisualStyleBackColor = true;
             // 
             // formatsGroupBox
             // 
-            this.formatsGroupBox.Controls.Add(this.checkSPTCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkANCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatPILCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatSPTCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatANCheckBox);
             this.formatsGroupBox.Controls.Add(this.animationsLabel);
             this.formatsGroupBox.Controls.Add(this.texturesLabel);
             this.formatsGroupBox.Controls.Add(this.modelsLabel);
-            this.formatsGroupBox.Controls.Add(this.checkBFFCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkPSXCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkMODCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkPMDCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkHMDCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkTODCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkTIMCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkVDFCheckBox);
-            this.formatsGroupBox.Controls.Add(this.checkTMDCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatBFFCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatPSXCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatMODCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatPMDCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatHMDCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatTODCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatTIMCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatVDFCheckBox);
+            this.formatsGroupBox.Controls.Add(this.formatTMDCheckBox);
             this.formatsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.formatsGroupBox.Location = new System.Drawing.Point(0, 133);
             this.formatsGroupBox.Name = "formatsGroupBox";
-            this.formatsGroupBox.Size = new System.Drawing.Size(394, 93);
+            this.formatsGroupBox.Size = new System.Drawing.Size(444, 93);
             this.formatsGroupBox.TabIndex = 1;
             this.formatsGroupBox.TabStop = false;
             this.formatsGroupBox.Text = "Formats";
             // 
-            // checkANCheckBox
+            // formatANCheckBox
             // 
-            this.checkANCheckBox.AutoSize = true;
-            this.checkANCheckBox.Location = new System.Drawing.Point(71, 66);
-            this.checkANCheckBox.Name = "checkANCheckBox";
-            this.checkANCheckBox.Size = new System.Drawing.Size(41, 17);
-            this.checkANCheckBox.TabIndex = 7;
-            this.checkANCheckBox.Text = "AN";
-            this.checkANCheckBox.UseVisualStyleBackColor = true;
+            this.formatANCheckBox.AutoSize = true;
+            this.formatANCheckBox.Location = new System.Drawing.Point(71, 66);
+            this.formatANCheckBox.Name = "formatANCheckBox";
+            this.formatANCheckBox.Size = new System.Drawing.Size(41, 17);
+            this.formatANCheckBox.TabIndex = 9;
+            this.formatANCheckBox.Tag = "format:AN";
+            this.formatANCheckBox.Text = "AN";
+            this.formatANCheckBox.UseVisualStyleBackColor = true;
             // 
             // animationsLabel
             // 
@@ -550,61 +655,53 @@
             this.modelsLabel.TabIndex = 11;
             this.modelsLabel.Text = "Models:";
             // 
-            // checkVDFCheckBox
-            // 
-            this.checkVDFCheckBox.AutoSize = true;
-            this.checkVDFCheckBox.Location = new System.Drawing.Point(179, 66);
-            this.checkVDFCheckBox.Name = "checkVDFCheckBox";
-            this.checkVDFCheckBox.Size = new System.Drawing.Size(47, 17);
-            this.checkVDFCheckBox.TabIndex = 9;
-            this.checkVDFCheckBox.Text = "VDF";
-            this.checkVDFCheckBox.UseVisualStyleBackColor = true;
-            // 
             // optionsGroupBox
             // 
-            this.optionsGroupBox.Controls.Add(this.optionShowErrorsCheckBox);
-            this.optionsGroupBox.Controls.Add(this.optionOldUVAlignmentCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionErrorLoggingCheckBox);
             this.optionsGroupBox.Controls.Add(this.optionDrawAllToVRAMCheckBox);
-            this.optionsGroupBox.Controls.Add(this.optionDebugCheckBox);
-            this.optionsGroupBox.Controls.Add(this.optionNoVerboseCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionDebugLoggingCheckBox);
+            this.optionsGroupBox.Controls.Add(this.optionLogToConsoleCheckBox);
             this.optionsGroupBox.Controls.Add(this.optionLogToFileCheckBox);
             this.optionsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.optionsGroupBox.Location = new System.Drawing.Point(0, 226);
             this.optionsGroupBox.Name = "optionsGroupBox";
-            this.optionsGroupBox.Size = new System.Drawing.Size(394, 69);
+            this.optionsGroupBox.Size = new System.Drawing.Size(444, 69);
             this.optionsGroupBox.TabIndex = 2;
             this.optionsGroupBox.TabStop = false;
             this.optionsGroupBox.Text = "Options";
             // 
-            // optionShowErrorsCheckBox
+            // optionErrorLoggingCheckBox
             // 
-            this.optionShowErrorsCheckBox.AutoSize = true;
-            this.optionShowErrorsCheckBox.Location = new System.Drawing.Point(258, 19);
-            this.optionShowErrorsCheckBox.Name = "optionShowErrorsCheckBox";
-            this.optionShowErrorsCheckBox.Size = new System.Drawing.Size(89, 17);
-            this.optionShowErrorsCheckBox.TabIndex = 2;
-            this.optionShowErrorsCheckBox.Text = "Error Logging";
-            this.optionShowErrorsCheckBox.UseVisualStyleBackColor = true;
+            this.optionErrorLoggingCheckBox.AutoSize = true;
+            this.optionErrorLoggingCheckBox.Enabled = false;
+            this.optionErrorLoggingCheckBox.Location = new System.Drawing.Point(12, 42);
+            this.optionErrorLoggingCheckBox.Name = "optionErrorLoggingCheckBox";
+            this.optionErrorLoggingCheckBox.Size = new System.Drawing.Size(89, 17);
+            this.optionErrorLoggingCheckBox.TabIndex = 3;
+            this.optionErrorLoggingCheckBox.Text = "Error Logging";
+            this.optionErrorLoggingCheckBox.UseVisualStyleBackColor = true;
             // 
-            // optionDebugCheckBox
+            // optionDebugLoggingCheckBox
             // 
-            this.optionDebugCheckBox.AutoSize = true;
-            this.optionDebugCheckBox.Location = new System.Drawing.Point(258, 42);
-            this.optionDebugCheckBox.Name = "optionDebugCheckBox";
-            this.optionDebugCheckBox.Size = new System.Drawing.Size(99, 17);
-            this.optionDebugCheckBox.TabIndex = 5;
-            this.optionDebugCheckBox.Text = "Debug Logging";
-            this.optionDebugCheckBox.UseVisualStyleBackColor = true;
+            this.optionDebugLoggingCheckBox.AutoSize = true;
+            this.optionDebugLoggingCheckBox.Enabled = false;
+            this.optionDebugLoggingCheckBox.Location = new System.Drawing.Point(135, 42);
+            this.optionDebugLoggingCheckBox.Name = "optionDebugLoggingCheckBox";
+            this.optionDebugLoggingCheckBox.Size = new System.Drawing.Size(99, 17);
+            this.optionDebugLoggingCheckBox.TabIndex = 4;
+            this.optionDebugLoggingCheckBox.Text = "Debug Logging";
+            this.optionDebugLoggingCheckBox.UseVisualStyleBackColor = true;
             // 
-            // optionNoVerboseCheckBox
+            // optionLogToConsoleCheckBox
             // 
-            this.optionNoVerboseCheckBox.AutoSize = true;
-            this.optionNoVerboseCheckBox.Location = new System.Drawing.Point(135, 19);
-            this.optionNoVerboseCheckBox.Name = "optionNoVerboseCheckBox";
-            this.optionNoVerboseCheckBox.Size = new System.Drawing.Size(97, 17);
-            this.optionNoVerboseCheckBox.TabIndex = 1;
-            this.optionNoVerboseCheckBox.Text = "Log to Console";
-            this.optionNoVerboseCheckBox.UseVisualStyleBackColor = true;
+            this.optionLogToConsoleCheckBox.AutoSize = true;
+            this.optionLogToConsoleCheckBox.Location = new System.Drawing.Point(135, 19);
+            this.optionLogToConsoleCheckBox.Name = "optionLogToConsoleCheckBox";
+            this.optionLogToConsoleCheckBox.Size = new System.Drawing.Size(97, 17);
+            this.optionLogToConsoleCheckBox.TabIndex = 1;
+            this.optionLogToConsoleCheckBox.Text = "Log to Console";
+            this.optionLogToConsoleCheckBox.UseVisualStyleBackColor = true;
+            this.optionLogToConsoleCheckBox.CheckedChanged += new System.EventHandler(this.optionLogToConsoleCheckBox_CheckedChanged);
             // 
             // optionLogToFileCheckBox
             // 
@@ -615,36 +712,7 @@
             this.optionLogToFileCheckBox.TabIndex = 0;
             this.optionLogToFileCheckBox.Text = "Log to File";
             this.optionLogToFileCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // optionIgnoreTIMVersionCheckBox
-            // 
-            this.optionIgnoreTIMVersionCheckBox.AutoSize = true;
-            this.optionIgnoreTIMVersionCheckBox.Location = new System.Drawing.Point(258, 19);
-            this.optionIgnoreTIMVersionCheckBox.Name = "optionIgnoreTIMVersionCheckBox";
-            this.optionIgnoreTIMVersionCheckBox.Size = new System.Drawing.Size(107, 17);
-            this.optionIgnoreTIMVersionCheckBox.TabIndex = 2;
-            this.optionIgnoreTIMVersionCheckBox.Text = "Skip TIM Version";
-            this.optionIgnoreTIMVersionCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // optionIgnoreHMDVersionCheckBox
-            // 
-            this.optionIgnoreHMDVersionCheckBox.AutoSize = true;
-            this.optionIgnoreHMDVersionCheckBox.Location = new System.Drawing.Point(135, 19);
-            this.optionIgnoreHMDVersionCheckBox.Name = "optionIgnoreHMDVersionCheckBox";
-            this.optionIgnoreHMDVersionCheckBox.Size = new System.Drawing.Size(113, 17);
-            this.optionIgnoreHMDVersionCheckBox.TabIndex = 1;
-            this.optionIgnoreHMDVersionCheckBox.Text = "Skip HMD Version";
-            this.optionIgnoreHMDVersionCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // optionIgnoreTMDVersionCheckBox
-            // 
-            this.optionIgnoreTMDVersionCheckBox.AutoSize = true;
-            this.optionIgnoreTMDVersionCheckBox.Location = new System.Drawing.Point(12, 19);
-            this.optionIgnoreTMDVersionCheckBox.Name = "optionIgnoreTMDVersionCheckBox";
-            this.optionIgnoreTMDVersionCheckBox.Size = new System.Drawing.Size(112, 17);
-            this.optionIgnoreTMDVersionCheckBox.TabIndex = 0;
-            this.optionIgnoreTMDVersionCheckBox.Text = "Skip TMD Version";
-            this.optionIgnoreTMDVersionCheckBox.UseVisualStyleBackColor = true;
+            this.optionLogToFileCheckBox.CheckedChanged += new System.EventHandler(this.optionLogToFileCheckBox_CheckedChanged);
             // 
             // showAdvancedMarginPanel
             // 
@@ -654,7 +722,7 @@
             this.showAdvancedMarginPanel.Location = new System.Drawing.Point(0, 295);
             this.showAdvancedMarginPanel.Name = "showAdvancedMarginPanel";
             this.showAdvancedMarginPanel.Padding = new System.Windows.Forms.Padding(3);
-            this.showAdvancedMarginPanel.Size = new System.Drawing.Size(394, 29);
+            this.showAdvancedMarginPanel.Size = new System.Drawing.Size(444, 29);
             this.showAdvancedMarginPanel.TabIndex = 3;
             // 
             // showAdvancedButton
@@ -663,7 +731,7 @@
             this.showAdvancedButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.showAdvancedButton.Location = new System.Drawing.Point(3, 3);
             this.showAdvancedButton.Name = "showAdvancedButton";
-            this.showAdvancedButton.Size = new System.Drawing.Size(388, 23);
+            this.showAdvancedButton.Size = new System.Drawing.Size(438, 23);
             this.showAdvancedButton.TabIndex = 0;
             this.showAdvancedButton.Text = "Show Advanced";
             this.showAdvancedButton.UseVisualStyleBackColor = true;
@@ -671,29 +739,40 @@
             // 
             // advancedOptionsGroupBox
             // 
+            this.advancedOptionsGroupBox.Controls.Add(this.unstrictTIMCheckBox);
+            this.advancedOptionsGroupBox.Controls.Add(this.unstrictPMDCheckBox);
+            this.advancedOptionsGroupBox.Controls.Add(this.unstrictHMDCheckBox);
+            this.advancedOptionsGroupBox.Controls.Add(this.unstrictTMDCheckBox);
+            this.advancedOptionsGroupBox.Controls.Add(this.label1);
+            this.advancedOptionsGroupBox.Controls.Add(this.isoScanComboBox);
+            this.advancedOptionsGroupBox.Controls.Add(this.binScanComboBox);
             this.advancedOptionsGroupBox.Controls.Add(this.binSectorInvalidLabel);
-            this.advancedOptionsGroupBox.Controls.Add(this.optionIgnoreTIMVersionCheckBox);
             this.advancedOptionsGroupBox.Controls.Add(this.binSectorCheckBox);
-            this.advancedOptionsGroupBox.Controls.Add(this.optionIgnoreHMDVersionCheckBox);
             this.advancedOptionsGroupBox.Controls.Add(this.binSectorSizeUpDown);
             this.advancedOptionsGroupBox.Controls.Add(this.optionAsyncScanCheckBox);
             this.advancedOptionsGroupBox.Controls.Add(this.binSectorStartUpDown);
-            this.advancedOptionsGroupBox.Controls.Add(this.binContentsCheckBox);
-            this.advancedOptionsGroupBox.Controls.Add(this.optionIgnoreTMDVersionCheckBox);
-            this.advancedOptionsGroupBox.Controls.Add(this.isoContentsCheckBox);
             this.advancedOptionsGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.advancedOptionsGroupBox.Location = new System.Drawing.Point(0, 324);
             this.advancedOptionsGroupBox.Name = "advancedOptionsGroupBox";
-            this.advancedOptionsGroupBox.Size = new System.Drawing.Size(394, 98);
+            this.advancedOptionsGroupBox.Size = new System.Drawing.Size(444, 102);
             this.advancedOptionsGroupBox.TabIndex = 4;
             this.advancedOptionsGroupBox.TabStop = false;
             this.advancedOptionsGroupBox.Text = "Advanced Options";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(6, 20);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(78, 13);
+            this.label1.TabIndex = 18;
+            this.label1.Text = "Ignore Version:";
             // 
             // binSectorInvalidLabel
             // 
             this.binSectorInvalidLabel.AutoSize = true;
             this.binSectorInvalidLabel.ForeColor = System.Drawing.Color.Firebrick;
-            this.binSectorInvalidLabel.Location = new System.Drawing.Point(270, 65);
+            this.binSectorInvalidLabel.Location = new System.Drawing.Point(270, 69);
             this.binSectorInvalidLabel.Name = "binSectorInvalidLabel";
             this.binSectorInvalidLabel.Size = new System.Drawing.Size(103, 26);
             this.binSectorInvalidLabel.TabIndex = 17;
@@ -708,7 +787,7 @@
             0,
             0,
             0});
-            this.binSectorSizeUpDown.Location = new System.Drawing.Point(206, 68);
+            this.binSectorSizeUpDown.Location = new System.Drawing.Point(206, 72);
             this.binSectorSizeUpDown.Maximum = new decimal(new int[] {
             2352,
             0,
@@ -737,7 +816,7 @@
             0,
             0,
             0});
-            this.binSectorStartUpDown.Location = new System.Drawing.Point(146, 68);
+            this.binSectorStartUpDown.Location = new System.Drawing.Point(146, 72);
             this.binSectorStartUpDown.Maximum = new decimal(new int[] {
             2351,
             0,
@@ -759,9 +838,9 @@
             this.advancedOffsetGroupBox.Controls.Add(this.offsetStopUpDown);
             this.advancedOffsetGroupBox.Controls.Add(this.offsetStopCheckBox);
             this.advancedOffsetGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.advancedOffsetGroupBox.Location = new System.Drawing.Point(0, 422);
+            this.advancedOffsetGroupBox.Location = new System.Drawing.Point(0, 426);
             this.advancedOffsetGroupBox.Name = "advancedOffsetGroupBox";
-            this.advancedOffsetGroupBox.Size = new System.Drawing.Size(394, 76);
+            this.advancedOffsetGroupBox.Size = new System.Drawing.Size(444, 76);
             this.advancedOffsetGroupBox.TabIndex = 5;
             this.advancedOffsetGroupBox.TabStop = false;
             this.advancedOffsetGroupBox.Text = "Advanced File Offset";
@@ -819,7 +898,7 @@
             // 
             this.scanButton.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.scanButton.Enabled = false;
-            this.scanButton.Location = new System.Drawing.Point(227, 6);
+            this.scanButton.Location = new System.Drawing.Point(277, 6);
             this.scanButton.Margin = new System.Windows.Forms.Padding(0, 0, 6, 0);
             this.scanButton.Name = "scanButton";
             this.scanButton.Size = new System.Drawing.Size(75, 23);
@@ -830,7 +909,7 @@
             // cancelButton
             // 
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(308, 6);
+            this.cancelButton.Location = new System.Drawing.Point(358, 6);
             this.cancelButton.Margin = new System.Windows.Forms.Padding(0);
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
@@ -844,38 +923,12 @@
             this.scanCancelMarginFlowLayoutPanel.Controls.Add(this.scanButton);
             this.scanCancelMarginFlowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.scanCancelMarginFlowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.scanCancelMarginFlowLayoutPanel.Location = new System.Drawing.Point(0, 498);
+            this.scanCancelMarginFlowLayoutPanel.Location = new System.Drawing.Point(0, 502);
             this.scanCancelMarginFlowLayoutPanel.Name = "scanCancelMarginFlowLayoutPanel";
             this.scanCancelMarginFlowLayoutPanel.Padding = new System.Windows.Forms.Padding(0, 6, 11, 7);
-            this.scanCancelMarginFlowLayoutPanel.Size = new System.Drawing.Size(394, 36);
+            this.scanCancelMarginFlowLayoutPanel.Size = new System.Drawing.Size(444, 36);
             this.scanCancelMarginFlowLayoutPanel.TabIndex = 6;
             this.scanCancelMarginFlowLayoutPanel.WrapContents = false;
-            // 
-            // historyRemoveButton
-            // 
-            this.historyRemoveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.historyRemoveButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.historyRemoveButton.Location = new System.Drawing.Point(359, 18);
-            this.historyRemoveButton.Name = "historyRemoveButton";
-            this.historyRemoveButton.Size = new System.Drawing.Size(24, 23);
-            this.historyRemoveButton.TabIndex = 2;
-            this.historyRemoveButton.Text = "−";
-            this.toolTip.SetToolTip(this.historyRemoveButton, "Remove history");
-            this.historyRemoveButton.UseVisualStyleBackColor = true;
-            this.historyRemoveButton.Click += new System.EventHandler(this.historyRemoveButton_Click);
-            // 
-            // historyBookmarkButton
-            // 
-            this.historyBookmarkButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.historyBookmarkButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.historyBookmarkButton.Location = new System.Drawing.Point(329, 18);
-            this.historyBookmarkButton.Name = "historyBookmarkButton";
-            this.historyBookmarkButton.Size = new System.Drawing.Size(24, 23);
-            this.historyBookmarkButton.TabIndex = 1;
-            this.historyBookmarkButton.Text = "+";
-            this.toolTip.SetToolTip(this.historyBookmarkButton, "Bookmark history");
-            this.historyBookmarkButton.UseVisualStyleBackColor = true;
-            this.historyBookmarkButton.Click += new System.EventHandler(this.historyBookmarkButton_Click);
             // 
             // ScannerForm
             // 
@@ -885,7 +938,7 @@
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(394, 541);
+            this.ClientSize = new System.Drawing.Size(444, 564);
             this.Controls.Add(this.scanCancelMarginFlowLayoutPanel);
             this.Controls.Add(this.advancedOffsetGroupBox);
             this.Controls.Add(this.advancedOptionsGroupBox);
@@ -897,7 +950,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
             this.MaximizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(410, 39);
+            this.MinimumSize = new System.Drawing.Size(460, 39);
             this.Name = "ScannerForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "PSXPrev Scan Files";
@@ -941,25 +994,21 @@
         private System.Windows.Forms.Label animationsLabel;
         private System.Windows.Forms.Label texturesLabel;
         private System.Windows.Forms.Label modelsLabel;
-        private System.Windows.Forms.CheckBox checkBFFCheckBox;
-        private System.Windows.Forms.CheckBox checkANCheckBox;
-        private System.Windows.Forms.CheckBox checkPSXCheckBox;
-        private System.Windows.Forms.CheckBox checkMODCheckBox;
-        private System.Windows.Forms.CheckBox checkPMDCheckBox;
-        private System.Windows.Forms.CheckBox checkHMDCheckBox;
-        private System.Windows.Forms.CheckBox checkTODCheckBox;
-        private System.Windows.Forms.CheckBox checkTIMCheckBox;
-        private System.Windows.Forms.CheckBox checkVDFCheckBox;
-        private System.Windows.Forms.CheckBox checkTMDCheckBox;
+        private System.Windows.Forms.CheckBox formatBFFCheckBox;
+        private System.Windows.Forms.CheckBox formatANCheckBox;
+        private System.Windows.Forms.CheckBox formatPSXCheckBox;
+        private System.Windows.Forms.CheckBox formatMODCheckBox;
+        private System.Windows.Forms.CheckBox formatPMDCheckBox;
+        private System.Windows.Forms.CheckBox formatHMDCheckBox;
+        private System.Windows.Forms.CheckBox formatTODCheckBox;
+        private System.Windows.Forms.CheckBox formatTIMCheckBox;
+        private System.Windows.Forms.CheckBox formatVDFCheckBox;
+        private System.Windows.Forms.CheckBox formatTMDCheckBox;
         private System.Windows.Forms.GroupBox optionsGroupBox;
-        private System.Windows.Forms.CheckBox optionIgnoreTIMVersionCheckBox;
-        private System.Windows.Forms.CheckBox optionIgnoreHMDVersionCheckBox;
-        private System.Windows.Forms.CheckBox optionShowErrorsCheckBox;
-        private System.Windows.Forms.CheckBox optionOldUVAlignmentCheckBox;
+        private System.Windows.Forms.CheckBox optionErrorLoggingCheckBox;
         private System.Windows.Forms.CheckBox optionDrawAllToVRAMCheckBox;
-        private System.Windows.Forms.CheckBox optionIgnoreTMDVersionCheckBox;
-        private System.Windows.Forms.CheckBox optionDebugCheckBox;
-        private System.Windows.Forms.CheckBox optionNoVerboseCheckBox;
+        private System.Windows.Forms.CheckBox optionDebugLoggingCheckBox;
+        private System.Windows.Forms.CheckBox optionLogToConsoleCheckBox;
         private System.Windows.Forms.CheckBox optionLogToFileCheckBox;
         private System.Windows.Forms.Panel showAdvancedMarginPanel;
         private System.Windows.Forms.Button showAdvancedButton;
@@ -968,8 +1017,6 @@
         private System.Windows.Forms.NumericUpDown binSectorSizeUpDown;
         private System.Windows.Forms.CheckBox optionAsyncScanCheckBox;
         private System.Windows.Forms.NumericUpDown binSectorStartUpDown;
-        private System.Windows.Forms.CheckBox binContentsCheckBox;
-        private System.Windows.Forms.CheckBox isoContentsCheckBox;
         private System.Windows.Forms.GroupBox advancedOffsetGroupBox;
         private System.Windows.Forms.CheckBox offsetNextCheckBox;
         private System.Windows.Forms.NumericUpDown offsetAlignUpDown;
@@ -983,10 +1030,18 @@
         private System.Windows.Forms.Button cancelButton;
         private System.Windows.Forms.FlowLayoutPanel scanCancelMarginFlowLayoutPanel;
         private System.Windows.Forms.Label binSectorInvalidLabel;
-        private System.Windows.Forms.CheckBox checkSPTCheckBox;
+        private System.Windows.Forms.CheckBox formatSPTCheckBox;
         private System.Windows.Forms.ComboBox historyComboBox;
         private System.Windows.Forms.Label historyLabel;
         private System.Windows.Forms.Button historyBookmarkButton;
         private System.Windows.Forms.Button historyRemoveButton;
+        private System.Windows.Forms.CheckBox formatPILCheckBox;
+        private System.Windows.Forms.ComboBox isoScanComboBox;
+        private System.Windows.Forms.ComboBox binScanComboBox;
+        private System.Windows.Forms.CheckBox unstrictTIMCheckBox;
+        private System.Windows.Forms.CheckBox unstrictPMDCheckBox;
+        private System.Windows.Forms.CheckBox unstrictHMDCheckBox;
+        private System.Windows.Forms.CheckBox unstrictTMDCheckBox;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/Forms/ScannerForm.resx
+++ b/Forms/ScannerForm.resx
@@ -120,6 +120,21 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="formatSPTCheckBox.ToolTip" xml:space="preserve">
+    <value>Blitz Games Textures Format
+Glover / Action Man / Frogger 2 / Chicken Run (Used by BFF/PIL models)
+Must be explicitly checked to scan
+Due to high rate of false positives, alignment is forced to a minimum of 2048</value>
+  </data>
+  <data name="binScanComboBox.ToolTip" xml:space="preserve">
+    <value>BIN files are raw PS1 CDs. These CDs may contain files (similar to ISO),
+in which case you can use Scan BIN Contents. But CDs not required to
+make those files visible, meaning you may need to use Scan BIN Data
+in order to scan the files on the CD.</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/ScanOptions.cs
+++ b/ScanOptions.cs
@@ -1,19 +1,90 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PSXPrev.Common.Parsers;
 using PSXPrev.Common.Utils;
 
 namespace PSXPrev
 {
+    public static class ScanFormats
+    {
+        public const string AN  = ANParser.FormatNameConst;
+        public const string BFF = BFFParser.FormatNameConst;
+        //public const string CLT = CLTParser.FormatNameConst;
+        public const string HMD = HMDParser.FormatNameConst;
+        public const string MOD = MODParser.FormatNameConst;
+        public const string PIL = PILParser.FormatNameConst;
+        public const string PMD = PMDParser.FormatNameConst;
+        public const string PSX = PSXParser.FormatNameConst;
+        //public const string PXL = PXLParser.FormatNameConst;
+        public const string SPT = SPTParser.FormatNameConst;
+        public const string TIM = TIMParser.FormatNameConst;
+        public const string TMD = TMDParser.FormatNameConst;
+        public const string TOD = TODParser.FormatNameConst;
+        public const string VDF = VDFParser.FormatNameConst;
+
+        // note: CLT and PXL are not supported yet
+        public static readonly string[] All =
+        {
+            AN, BFF, /*CLT,*/ HMD, MOD, PIL, PMD, PSX, /*PXL,*/ SPT, TIM, TMD, TOD, VDF,
+        };
+
+        // Formats that can only be used if explicitly selected
+        // todo: AN produces too many false positives to be enabled by default
+        public static readonly string[] Explicit =
+        {
+            SPT,
+        };
+
+        // Formats that are used when no format is selected
+        // Setup during static constructor
+        public static readonly string[] Implicit;
+
+        public static int Count => All.Length;
+
+        public static bool IsSupported(string format)
+        {
+            return Array.IndexOf(All, format) != -1;
+        }
+
+        public static bool IsExplicit(string format)
+        {
+            return Array.IndexOf(Explicit, format) != -1;
+        }
+
+        public static bool IsImplicit(string format)
+        {
+            return Array.IndexOf(Implicit, format) != -1;
+        }
+
+
+        static ScanFormats()
+        {
+            Array.Sort(All);
+            Array.Sort(Explicit);
+
+            var implicitFormats = new List<string>();
+            foreach (var format in All)
+            {
+                if (!IsExplicit(format))
+                {
+                    implicitFormats.Add(format);
+                }
+            }
+            Implicit = implicitFormats.ToArray();
+        }
+    }
+
     [JsonObject]
-    public class ScanOptions : IEquatable<ScanOptions>
+    public class ScanOptions : IEquatable<ScanOptions>, ICloneable
     {
         public static readonly ScanOptions Defaults = new ScanOptions();
 
-        public const string DefaultFilter = "*.*";
-        public const string EmptyFilter = "*";
-        public const string DefaultRegexPattern = ".*";
+        public const string DefaultFilter = "*"; //"*.*";
+        public const string DefaultRegexPattern = "^.*$";
 
         // Use a timeout to avoid user-specified runaway Regex patterns.
         private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
@@ -62,13 +133,9 @@ namespace PSXPrev
         {
             get
             {
-                if (WildcardFilter == null)
+                if (string.IsNullOrWhiteSpace(WildcardFilter))
                 {
                     return DefaultFilter;
-                }
-                else if (string.IsNullOrWhiteSpace(WildcardFilter))
-                {
-                    return EmptyFilter;
                 }
                 return WildcardFilter;
             }
@@ -89,78 +156,97 @@ namespace PSXPrev
         public bool UseRegex { get; set; } = false;
 
         // Scanner formats:
-        [JsonIgnore]
-        public bool CheckAll
+        [JsonProperty("formats")]
+        public List<string> Formats { get; set; } = new List<string>();
+
+        // Formats with reduced strictness, such as ignoring versions/magic
+        [JsonProperty("unstrictFormats")]
+        public List<string> UnstrictFormats { get; set; } = new List<string>();
+
+        public bool ContainsFormat(string format)
         {
-            get
+            return ContainsFormat(format, out _);
+        }
+
+        public bool ContainsFormat(string format, out bool isImplicit)
+        {
+            if (Formats.Count > 0)
             {
-                return !CheckAN && !CheckBFF && !CheckHMD && !CheckMOD && !CheckPMD && !CheckPSX &&
-                       !CheckSPT && !CheckTIM && !CheckTMD && !CheckTOD && !CheckVDF;
+                isImplicit = false;
+                return Formats.Contains(format);
+            }
+            else
+            {
+                isImplicit = ScanFormats.IsImplicit(format);
+                return isImplicit;
             }
         }
 
-        public List<string> GetCheckedFormats(bool groupAll)
+        public bool AddFormat(string format)
         {
-            var formats = new List<string>();
-            if (groupAll && CheckAll)
+            if (!Formats.Contains(format) && ScanFormats.IsSupported(format))
             {
-                formats.Add("Any");
-                return formats;
+                Formats.Add(format);
+                Formats.Sort();
+                return true;
             }
-            if (CheckAN)  formats.Add("AN");
-            if (CheckBFF) formats.Add("BFF");
-            if (CheckHMD) formats.Add("HMD");
-            if (CheckMOD) formats.Add("MOD");
-            if (CheckPMD) formats.Add("PMD");
-            if (CheckPSX) formats.Add("PSX");
-            if (CheckSPT) formats.Add("SPT");
-            if (CheckTIM) formats.Add("TIM");
-            if (CheckTMD) formats.Add("TMD");
-            if (CheckTOD) formats.Add("TOD");
-            if (CheckVDF) formats.Add("VDF");
-            if (groupAll && formats.Count == 11)
-            {
-                formats.Clear();
-                formats.Add("All");
-            }
-            return formats;
+            return false;
         }
 
-        [JsonProperty("formatAN")]
-        public bool CheckAN { get; set; }
-        [JsonProperty("formatBFF")]
-        public bool CheckBFF { get; set; }
-        [JsonProperty("formatHMD")]
-        public bool CheckHMD { get; set; }
-        [JsonProperty("formatMOD")]
-        public bool CheckMOD { get; set; } // Previously called Croc
-        [JsonProperty("formatPMD")]
-        public bool CheckPMD { get; set; }
-        [JsonProperty("formatPSX")]
-        public bool CheckPSX { get; set; }
-        [JsonProperty("formatSPT")]
-        public bool CheckSPT { get; set; }
-        [JsonProperty("formatTIM")]
-        public bool CheckTIM { get; set; }
-        [JsonProperty("formatTMD")]
-        public bool CheckTMD { get; set; }
-        [JsonProperty("formatTOD")]
-        public bool CheckTOD { get; set; }
-        [JsonProperty("formatVDF")]
-        public bool CheckVDF { get; set; }
+        public bool RemoveFormat(string format)
+        {
+            return Formats.Remove(format);
+        }
+
+        public bool ContainsUnstrict(string format)
+        {
+            return UnstrictFormats.Contains(format);
+        }
+
+        public bool AddUnstrict(string format)
+        {
+            if (!UnstrictFormats.Contains(format) && ScanFormats.IsSupported(format))
+            {
+                UnstrictFormats.Add(format);
+                UnstrictFormats.Sort();
+                return true;
+            }
+            return false;
+        }
+
+        public bool RemoveUnstrict(string format)
+        {
+            return UnstrictFormats.Remove(format);
+        }
+
+        public string[] GetCheckedFormats(bool groupAll)
+        {
+            if (Formats.Count == ScanFormats.Count && groupAll)
+            {
+                return new string[] { "All" };
+            }
+            else if (Formats.Count == 0)
+            {
+                if (groupAll)
+                {
+                    return new string[] { "Defaults" };
+                }
+                else
+                {
+                    return (string[])ScanFormats.Implicit.Clone();
+                }
+            }
+            else
+            {
+                return Formats.ToArray();
+            }
+        }
 
         // Scanner options:
-        [JsonProperty("ignoreHMDVersion")]
-        public bool IgnoreHMDVersion { get; set; } = false;
-        [JsonProperty("ignoreTIMVersion")]
-        public bool IgnoreTIMVersion { get; set; } = false;
-        [JsonProperty("ignoreTMDVersion")]
-        public bool IgnoreTMDVersion { get; set; } = false;
-
         [JsonProperty("fileOffsetAlign")]
         public long Alignment { get; set; } = 1;
 
-        // We want nullables, but we also want to preserve the last-used values the UI when null.
+        // We want nullables, but we also want to preserve the last-used values in the UI when null.
         [JsonProperty("fileOffsetHasStart")]
         public bool StartOffsetHasValue { get; set; } = false;
         [JsonProperty("fileOffsetHasStop")]
@@ -188,27 +274,27 @@ namespace PSXPrev
         [JsonProperty("fileSearchBINContents")]
         public bool ReadBINContents { get; set; } = false; // Read indexed files instead of data of BIN file.
         [JsonProperty("fileSearchBINSectorData")]
-        public bool ReadBINSectorData { get; set; } = false;
+        public bool ReadBINSectorData { get; set; } = false; // Read BIN file as one large data file.
 
         // We want nullables, but we also want to preserve the last-used values in the UI when null.
+        // These may be removed in the future because it turns out sector sizes are always the same.
+        // The reason I thought it was different is because Star Ocean 2 uses an archive format that cuts out more of the user size.
         [JsonProperty("binSectorHasStartSize")]
         public bool BINSectorUserStartSizeHasValue { get; set; } = false;
         [JsonProperty("binSectorStart")]
-        public int BINSectorUserStartValue { get; set; } = Common.Parsers.BinCDStream.SectorUserStart;
+        public int BINSectorUserStartValue { get; set; } = BinCDStream.SectorUserStart;
         [JsonProperty("binSectorSize")]
-        public int BINSectorUserSizeValue { get; set; } = Common.Parsers.BinCDStream.SectorUserSize;
+        public int BINSectorUserSizeValue { get; set; } = BinCDStream.SectorUserSize;
         [JsonIgnore]
-        public int BINSectorUserStart => BINSectorUserStartSizeHasValue ? BINSectorUserStartValue : Common.Parsers.BinCDStream.SectorUserStart;
+        public int BINSectorUserStart => BINSectorUserStartSizeHasValue ? BINSectorUserStartValue : BinCDStream.SectorUserStart;
         [JsonIgnore]
-        public int BINSectorUserSize  => BINSectorUserStartSizeHasValue ? BINSectorUserSizeValue  : Common.Parsers.BinCDStream.SectorUserSize;
+        public int BINSectorUserSize  => BINSectorUserStartSizeHasValue ? BINSectorUserSizeValue  : BinCDStream.SectorUserSize;
 
         // Log options:
         [JsonProperty("logToFile")]
         public bool LogToFile { get; set; } = false;
         [JsonProperty("logToConsole")]
         public bool LogToConsole { get; set; } = true;
-        [JsonProperty("consoleColor")]
-        public bool UseConsoleColor { get; set; } = true;
         [JsonProperty("debugLogging")]
         public bool DebugLogging { get; set; } = false;
         [JsonProperty("errorLogging")]
@@ -217,8 +303,111 @@ namespace PSXPrev
         // Program options:
         [JsonProperty("drawAllToVRAM")]
         public bool DrawAllToVRAM { get; set; } = false;
-        [JsonProperty("fixUVAlignment")]
-        public bool FixUVAlignment { get; set; } = true;
+
+
+        // Used for version upgrades to read properties that are no longer present in the current class
+        [JsonExtensionData(ReadData = true, WriteData = false)]
+        private Dictionary<string, JToken> _unknownData;
+
+        //[OnDeserialized]
+        //private void OnDeserializedMethod(StreamingContext context)
+        //{
+        //}
+
+        public void ValidateDeserialization(uint version)
+        {
+            Formats         = ValidateFormats(Formats);
+            UnstrictFormats = ValidateFormats(UnstrictFormats);
+
+            if (version <= 2 && _unknownData != null)
+            {
+                UpgradeFormatsToVersion3(version);
+            }
+
+            // Handle normal validation that's used outside of just deserialization
+            Validate();
+
+            _unknownData = null; // We don't need this anymore
+        }
+
+        // Remove null, unsupported, and duplicate format names, then ensure formats are sorted
+        private static List<string> ValidateFormats(List<string> formats)
+        {
+            if (formats == null)
+            {
+                formats = new List<string>();
+            }
+            else
+            {
+                var duplicates = new HashSet<string>();
+                for (var i = 0; i < formats.Count; i++)
+                {
+                    var format = formats[i];
+                    if (format == null || !ScanFormats.IsSupported(format) || !duplicates.Add(format))
+                    {
+                        formats.RemoveAt(i);
+                        i--;
+                    }
+                }
+                formats.Sort();
+            }
+            return formats;
+        }
+
+        // Previously formats were stored in individual "format___": bool properties.
+        // Handle switching to list storage.
+        private void UpgradeFormatsToVersion3(uint version)
+        {
+            void UpgradeFormat(string propertyName, string format)
+            {
+                if (_unknownData.TryGetValue(propertyName, out var token))
+                {
+                    _unknownData.Remove(propertyName); // Not unknown data anymore
+                    if (token.Type == JTokenType.Boolean && token.ToObject<bool>())
+                    {
+                        AddFormat(format);
+                        // PIL format was introduced in the middle of version 2,
+                        // and was grouped together with BFF.
+                        if (version == 2 && format == BFFParser.FormatNameConst)
+                        {
+                            AddFormat(PILParser.FormatNameConst);
+                        }
+                    }
+                }
+            }
+
+            void UpgradeUnstrict(string propertyName, string format)
+            {
+                if (_unknownData.TryGetValue(propertyName, out var token))
+                {
+                    _unknownData.Remove(propertyName); // Not unknown data anymore
+                    if (token.Type == JTokenType.Boolean && token.ToObject<bool>())
+                    {
+                        AddUnstrict(format);
+                    }
+                }
+            }
+
+            UpgradeFormat("formatAN",  ANParser.FormatNameConst);
+            UpgradeFormat("formatBFF", BFFParser.FormatNameConst);
+            UpgradeFormat("formatHMD", HMDParser.FormatNameConst);
+            UpgradeFormat("formatMOD", MODParser.FormatNameConst);
+            UpgradeFormat("formatPMD", PMDParser.FormatNameConst);
+            UpgradeFormat("formatPSX", PSXParser.FormatNameConst);
+            if (version == 2)
+            {
+                // Format introduced in version 2
+                UpgradeFormat("formatSPT", SPTParser.FormatNameConst);
+            }
+            UpgradeFormat("formatTIM", TIMParser.FormatNameConst);
+            UpgradeFormat("formatTMD", TMDParser.FormatNameConst);
+            UpgradeFormat("formatTOD", TODParser.FormatNameConst);
+            UpgradeFormat("formatVDF", VDFParser.FormatNameConst);
+
+            UpgradeUnstrict("ignoreHMDVersion", HMDParser.FormatNameConst);
+            UpgradeUnstrict("ignoreTIMVersion", TIMParser.FormatNameConst);
+            UpgradeUnstrict("ignoreTMDVersion", TMDParser.FormatNameConst);
+        }
 
 
         public Regex GetRegexFilter(bool allowErrors)
@@ -249,6 +438,11 @@ namespace PSXPrev
             if (Path == null)
             {
                 Path = string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(DisplayName))
+            {
+                DisplayName = null;
             }
 
             WildcardFilter = ValidatedWildcardFilter;
@@ -313,7 +507,7 @@ namespace PSXPrev
             string filterStr = null;
             if (!UseRegex)
             {
-                if (ValidatedWildcardFilter != EmptyFilter)
+                if (ValidatedWildcardFilter != DefaultFilter)
                 {
                     filterStr = ValidatedWildcardFilter;
                 }
@@ -328,7 +522,7 @@ namespace PSXPrev
 
             string formatsStr = null;
             var formats = GetCheckedFormats(true);
-            if (formats.Count > 0)
+            if (formats.Length > 0)
             {
                 formatsStr = string.Join(",", formats).ToLower();
             }
@@ -344,8 +538,14 @@ namespace PSXPrev
 
         public ScanOptions Clone()
         {
-            return (ScanOptions)MemberwiseClone();
+            var options = (ScanOptions)MemberwiseClone();
+            options._unknownData = null;
+            options.Formats = new List<string>(Formats);
+            options.UnstrictFormats = new List<string>(UnstrictFormats);
+            return options;
         }
+
+        object ICloneable.Clone() => Clone();
 
         // Normalize settings for equality checks
         private void Normalize()
@@ -388,13 +588,9 @@ namespace PSXPrev
                 BINSectorUserStartValue = Defaults.BINSectorUserStartValue;
                 BINSectorUserSizeValue  = Defaults.BINSectorUserSizeValue;
             }*/
-            /*if (!LogToConsole)
-            {
-                UseConsoleColor = Defaults.UseConsoleColor;
-            }*/
         }
 
-        // It's easier to manage equality by *not* having to update it every time settings are changed.
+        // It's easier to manage equality by *not* having to update the function every time settings are added.
         // This is a lazy solution, but requires near-zero maintenance.
         private string GetEqualityString(out int? hashCode)
         {


### PR DESCRIPTION
* Added settings to catch up to programmatic capabilities of PSXPrev. * Model grouping can now be split by TMD ID * PIL parsing is now a separate checkbox * BIN indexed file scanning is now possible (BIN data is still defaulted to) * Vertex index reuse export can be disabled * Human readable export can be disabled * Strict floats export can be disabled
* Added ignore version setting for PMD.
* Default wildcard filter is now "*" to match all files, this matches how things used to be before wildcards were converted to regex. It also means the user doesn't have to change their filters (or understand wildcard) to scan files without extensions.
* Recent scan history maximum no longer includes bookmarks in count (so you can have 30 scan histories and 50 bookmarked histories while the max is 30).
* Console color is no longer a scan option, but an advanced program option (under File > Advanced Settings...).
* Old UV alignment is no longer a PSXPrev option, now that it's known for sure that the fixed alignment is accurate to how the PSX did things. (Comments in source code were complaining about the missing last pixel).
* Program usage and help now always use the default console foreground color.
* Made sure logger flushes file output after a scan is finished.
* Logger now reads default settings during constructor so that default colors are initialized (and not all black).
* "Exported {0} models" message box now correctly states how many models were exported based on model grouping setting.
* For debug builds, it's now possible to open up the export models form without first running a scan.
* Scanner form format checkboxes now use tri-state. Indeterminate is used when a format is enabled in its default value. Aka, indeterminate is only used when no formats are explicitly checked, and that format is implicit (i.e. not SPT, which is too false-positive prone).
* Changed how scan formats are stored in settings.json. Formats and ignore version formats are now stored in lists. This will make it easier to add additional formats in the future by reducing the number of places we need to update for the addition.
* Default scan regex filter now includes start and end matching tokens.