### PR TITLE
Store Texture dimensions locally and remove Render_ dimensions

### DIFF
--- a/Common/Exporters/ModelPreparerExporter.cs
+++ b/Common/Exporters/ModelPreparerExporter.cs
@@ -717,8 +717,8 @@ namespace PSXPrev.Common.Exporters
                             // Keep float casts in-case we replace uvScalar with VRAM.PageSize.
                             OffsetX = ((float)texture.X / uvScalar + column) / _countX,
                             OffsetY = ((float)texture.Y / uvScalar + row)    / _countY,
-                            ScalarX = ((float)texture.RenderWidth  / uvScalar) / _countX,
-                            ScalarY = ((float)texture.RenderHeight / uvScalar) / _countY,
+                            ScalarX = ((float)texture.Width  / uvScalar) / _countX,
+                            ScalarY = ((float)texture.Height / uvScalar) / _countY,
                         };
                         _packedTextureInfos.Add(texture, packedInfo);
                     }

--- a/Common/Texture.cs
+++ b/Common/Texture.cs
@@ -26,6 +26,8 @@ namespace PSXPrev.Common
         public Texture(Bitmap bitmap, int x, int y, int bpp, int texturePage, int clutIndex, ushort[][] palettes, bool? hasSemiTransparency, bool isVRAMPage = false)
         {
             Bitmap = bitmap;
+            Width  = bitmap.Width;
+            Height = bitmap.Height;
             X = x;
             Y = y;
             Bpp = bpp;
@@ -51,6 +53,8 @@ namespace PSXPrev.Common
         {
             X = fromTexture.X;
             Y = fromTexture.Y;
+            Width = fromTexture.Width;
+            Height = fromTexture.Height;
             TexturePage = fromTexture.TexturePage;
             IsVRAMPage = fromTexture.IsVRAMPage;
             Name = fromTexture.Name;
@@ -134,21 +138,16 @@ namespace PSXPrev.Common
         [DisplayName("BPP"), ReadOnly(true)]
         public int Bpp { get; set; }
 
+        // Prefer not using Bitmap's properties for Width and Height because they call native methods.
+        // Storing dimensions locally will be faster, especially for packed texture UV conversion.
         [DisplayName("Width"), ReadOnly(true)]
-        public int Width => Bitmap.Width;
+        public int Width { get; set; }
 
         [DisplayName("Height"), ReadOnly(true)]
-        public int Height => Bitmap.Height;
+        public int Height { get; set; }
 
         [DisplayName("Texture ID")]
         public uint? LookupID { get; set; }
-
-        // Usable area of the texture (only different from Width/Height when IsVRAMPage is true).
-        [Browsable(false)]
-        public int RenderWidth => Width;// IsVRAMPage ? VRAM.PageSize : Width;
-
-        [Browsable(false)]
-        public int RenderHeight => Height;// IsVRAMPage ? VRAM.PageSize : Height;
 
         [Browsable(false)]
         public ushort[][] Palettes { get; set; }

--- a/Forms/Controls/TexturePreviewer.cs
+++ b/Forms/Controls/TexturePreviewer.cs
@@ -557,8 +557,8 @@ namespace PSXPrev.Forms.Controls
             }
             else
             {
-                width  = _texture?.RenderWidth  ?? 0;
-                height = _texture?.RenderHeight ?? 0;
+                width  = _texture?.Width  ?? 0;
+                height = _texture?.Height ?? 0;
             }
             if (scaled)
             {
@@ -633,7 +633,7 @@ namespace PSXPrev.Forms.Controls
                 }
                 else
                 {
-                    if (x >= 0 && y >= 0 && x < _texture.RenderWidth && y < _texture.RenderHeight)
+                    if (x >= 0 && y >= 0 && x < _texture.Width && y < _texture.Height)
                     {
                         position = new Point(x, y);
                         color = _texture.GetPixel(x, y, out stp, out transparent, out paletteIndex);
@@ -772,7 +772,7 @@ namespace PSXPrev.Forms.Controls
         {
             GetPreviewSize(true, out var width, out var height);
             var dstRect = new Rectangle(0, 0, width, height);
-            var srcRect = new Rectangle(0, 0, _texture.RenderWidth, _texture.RenderHeight);
+            var srcRect = new Rectangle(0, 0, _texture.Width, _texture.Height);
 
             // Despite what it sounds like, we want Half. Otherwise we end up drawing half a pixel back.
             graphics.PixelOffsetMode = PixelOffsetMode.Half;
@@ -800,8 +800,8 @@ namespace PSXPrev.Forms.Controls
 
         private Bitmap UpdateSemiTransparencyCache(RectangleF? clipBounds = null)
         {
-            var imageWidth  = _texture.RenderWidth;
-            var imageHeight = _texture.RenderHeight;
+            var imageWidth  = _texture.Width;
+            var imageHeight = _texture.Height;
             if (!GetClipRect(clipBounds, previewPanel, imageWidth, imageHeight, _scale, out var clipRect, out var viewRect))
             {
                 return null; // Nothing to draw
@@ -883,7 +883,7 @@ namespace PSXPrev.Forms.Controls
             Pen pen = null;
             try
             {
-                var clipRect = optionalClipRect ?? new Rectangle(0, 0, _texture.RenderWidth, _texture.RenderHeight);
+                var clipRect = optionalClipRect ?? new Rectangle(0, 0, _texture.Width, _texture.Height);
 
                 for (var y = clipRect.Top; y < clipRect.Bottom; y++)
                 {
@@ -967,8 +967,8 @@ namespace PSXPrev.Forms.Controls
             // To optimize drawing all UV lines in one go, we limit the size of the overlay bitmap to the size of a VRAM page.
             // If the texture is larger than this, then we clip everything past that, since it holds no meaning.
             // Additionally, if the texture position causes the texture size to end outside the VRAM page, we clip that too.
-            var endX = Math.Min(VRAM.PageSize, (_texture.X + _texture.RenderWidth));
-            var endY = Math.Min(VRAM.PageSize, (_texture.Y + _texture.RenderHeight));
+            var endX = Math.Min(VRAM.PageSize, (_texture.X + _texture.Width));
+            var endY = Math.Min(VRAM.PageSize, (_texture.Y + _texture.Height));
             var vramWidth  = (endX - _texture.X);
             var vramHeight = (endY - _texture.Y);
             // No need to check clip rect, since we always cache the entire set of UV lines at once.


### PR DESCRIPTION
* Texture now stores Width and Height locally instead of getting those properties from Bitmap. This is because Bitmap's dimension properties call native methods to retrieve the size each time, and so it will be slower than just fetching a local variable.
* Phased out Texture RenderWidth and RenderHeight, since they were no different from the Width and Height properties.